### PR TITLE
Instantiates Column as Series with Specified dtype

### DIFF
--- a/eland/query_compiler.py
+++ b/eland/query_compiler.py
@@ -219,8 +219,7 @@ class ElandQueryCompiler:
 
         for missing in missing_columns:
             is_source_field, pd_dtype = self._mappings.source_field_pd_dtype(missing)
-            df[missing] = None
-            df[missing].astype(pd_dtype)
+            df[missing] = pd.Series(dtype=pd_dtype)
 
         # Sort columns in mapping order
         df = df[self.columns]


### PR DESCRIPTION
fixes #54.

We had originally been reconstructing the resulting dataframe by instantiating columns using `col = None` and then trying to change its dtype - however this results `TypeError`.

Now we create the column as a pandas series with the specified type.