### PR TITLE
Resolving inconsistent __repr__ test on python 3.5

### DIFF
--- a/eland/tests/dataframe/test_repr_pytest.py
+++ b/eland/tests/dataframe/test_repr_pytest.py
@@ -52,8 +52,14 @@ class TestDataFrameRepr(TestData):
         self.num_rows_to_string(100, 200, 200)
 
     def num_rows_to_string(self, rows, max_rows_eland=None, max_rows_pandas=None):
-        ed_flights = self.ed_flights()
-        pd_flights = self.pd_flights()
+        # {'lat': '-33.94609833', 'lon': '151.177002'} order is not consistent in python 3.5 (dict's not ordered)
+        # remove from test for now
+        if not PY36:
+            ed_flights = self.ed_flights().drop(columns=['OriginLocation', 'DestLocation'])
+            pd_flights = self.pd_flights().drop(columns=['OriginLocation', 'DestLocation'])
+        else:
+            ed_flights = self.ed_flights()
+            pd_flights = self.pd_flights()
 
         ed_head = ed_flights.head(rows)
         pd_head = pd_flights.head(rows)


### PR DESCRIPTION
dict structures used internally in elasticsearch-py can result in inconsistent ordering in python 3.5. For the top level of results, we reorder using an `OrderedDict`, but for nested types (e.g. `geopoint`) we don't reorder.

In general, this isn't an issue unless we specifically compare order to pandas. Therefore, this test removes the nested types for comparison in python 3.5.