### PR TITLE
Move to latest .ci script structure

### DIFF
--- a/.ci/run-elasticsearch.sh
+++ b/.ci/run-elasticsearch.sh
@@ -5,6 +5,10 @@
 #
 # Export the ELASTICSEARCH_VERSION variable, eg. 'elasticsearch:8.0.0-SNAPSHOT'.
 
+# Version 1.0
+# - Initial version of the run-elasticsearch.sh script
+
+
 if [[ -z "$ELASTICSEARCH_VERSION" ]]; then
   echo -e "\033[31;1mERROR:\033[0m Required environment variable [ELASTICSEARCH_VERSION] not set\033[0m"
   exit 1
@@ -178,11 +182,11 @@ if [[ "$DETACH" == "true" ]]; then
   done;
 
   # Always show logs if the container is running, this is very useful both on CI as well as while developing
-  if container_running "$NODE_NAME"; then
+  if container_running $NODE_NAME; then
     docker logs $NODE_NAME
   fi
 
-  if ! container_running "$NODE_NAME" || [[ "$(docker inspect -f "{{.State.Health.Status}}" ${NODE_NAME})" != "healthy" ]]; then
+  if ! container_running $NODE_NAME || [[ "$(docker inspect -f "{{.State.Health.Status}}" ${NODE_NAME})" != "healthy" ]]; then
     cleanup 1
     echo
     echo -e "\033[31;1mERROR:\033[0m Failed to start ${ELASTICSEARCH_VERSION} in detached mode beyond health checks\033[0m"

--- a/.ci/run-repository.sh
+++ b/.ci/run-repository.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+#
+# Called by entry point `run-test` use this script to add your repository specific test commands
+#
+# Once called Elasticsearch is up and running and the following parameters are available to this script
+
+# ELASTICSEARCH_VERSION -- version e.g Major.Minor.Patch(-Prelease)
+# ELASTICSEARCH_CONTAINER -- the docker moniker as a reference to know which docker image distribution is used
+# ELASTICSEARCH_URL -- The url at which elasticsearch is reachable
+# NETWORK_NAME -- The docker network name
+# NODE_NAME -- The docker container name also used as Elasticsearch node name
+
+# When run in CI the test-matrix is used to define additional variables
+
+# TEST_SUITE -- either `oss` or `xpack`, defaults to `oss` in `run-tests`
+#
+
+PYTHON_VERSION=${PYTHON_VERSION-3.8}
+echo -e "\033[34;1mINFO:\033[0m URL ${ELASTICSEARCH_URL}\033[0m"
+echo -e "\033[34;1mINFO:\033[0m VERSION ${ELASTICSEARCH_VERSION}\033[0m"
+echo -e "\033[34;1mINFO:\033[0m CONTAINER ${ELASTICSEARCH_CONTAINER}\033[0m"
+echo -e "\033[34;1mINFO:\033[0m TEST_SUITE ${TEST_SUITE}\033[0m"
+echo -e "\033[34;1mINFO:\033[0m PYTHON_VERSION ${PYTHON_VERSION}\033[0m"
+
+echo -e "\033[1m>>>>> Build [elastic/eland container] >>>>>>>>>>>>>>>>>>>>>>>>>>>>>\033[0m"
+
+docker build --file .ci/Dockerfile --tag elastic/eland --build-arg PYTHON_VERSION=${PYTHON_VERSION} .
+
+echo -e "\033[1m>>>>> Run [elastic/eland container] >>>>>>>>>>>>>>>>>>>>>>>>>>>>>\033[0m"
+
+docker run \
+  --network=${NETWORK_NAME} \
+  --env "ELASTICSEARCH_HOST=${ELASTICSEARCH_URL}" \
+  --env "TEST_SUITE=${TEST_SUITE}" \
+  --name eland-test-runner \
+  --rm \
+  elastic/eland \
+  ./run_build.sh

--- a/.ci/run-tests
+++ b/.ci/run-tests
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-
-echo $PYTHON_VERSION
+#
+# Version 1.0
+# - Moved to .ci folder and seperated out `run-repository.sh`
 
 if [[ -z $ELASTICSEARCH_VERSION ]]; then
   echo -e "\033[31;1mERROR:\033[0m Required environment variable [ELASTICSEARCH_VERSION] not set\033[0m"
@@ -12,8 +13,6 @@ set -euxo pipefail
 TEST_SUITE=${TEST_SUITE-oss}
 NODE_NAME=instance
 
-
-repo=$(pwd)
 
 elasticsearch_image=elasticsearch
 elasticsearch_url=https://elastic:changeme@${NODE_NAME}:9200
@@ -49,24 +48,11 @@ ELASTICSEARCH_VERSION=${elasticsearch_image}:${ELASTICSEARCH_VERSION} \
   DETACH=true \
   bash .ci/run-elasticsearch.sh
 
-echo -e "\033[1m>>>>> YOUR STEPS HERE >>>>>>>>>>>>>>>>>>>>>>>>>>>>>\033[0m"
+echo -e "\033[1m>>>>> Repository specific tests >>>>>>>>>>>>>>>>>>>>>>>>>>>>>\033[0m"
 
-## Add your steps here
-## Use ${elasticsearch_url} to talk to elasticsearch
-## declare your matrix variables here as well e.g DOTNET_VERSION=${DOTNET_VERSION-3.0.100}
+ELASTICSEARCH_CONTAINER=${elasticsearch_image}:${ELASTICSEARCH_VERSION} \
+  NETWORK_NAME=elasticsearch \
+  NODE_NAME=${NODE_NAME} \
+  ELASTICSEARCH_URL=${elasticsearch_url} \
+  bash .ci/run-repository.sh
 
-
-echo -e "\033[1m>>>>> Build [elastic/eland container] >>>>>>>>>>>>>>>>>>>>>>>>>>>>>\033[0m"
-
-docker build --file .ci/Dockerfile --tag elastic/eland --build-arg PYTHON_VERSION=${PYTHON_VERSION} .
-
-echo -e "\033[1m>>>>> Run [elastic/eland container] >>>>>>>>>>>>>>>>>>>>>>>>>>>>>\033[0m"
-
-docker run \
-  --network=elasticsearch \
-  --env "ELASTICSEARCH_HOST=${elasticsearch_url}" \
-  --env "TEST_SUITE=${TEST_SUITE}" \
-  --name eland-test-runner \
-  --rm \
-  elastic/eland \
-  ./run_build.sh


### PR DESCRIPTION
Introduces a dedicated `run-repository.sh` for the repository custom
bits.

This allows us to keep `run-elasticsearch.sh` and `run-tests` in sync
through file copying or patches easier.