### PR TITLE
Add python_requires to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -180,7 +180,7 @@ setup(
     url=about['__url__'],
     maintainer=about['__maintainer__'],
     maintainer_email=about['__maintainer_email__'],
-    license='Apache 2.0',
+    license='Apache-2.0',
     classifiers=CLASSIFIERS,
     keywords='elastic eland pandas python',
     packages=find_packages(include=["eland", "eland.*"]),
@@ -188,5 +188,6 @@ setup(
         'elasticsearch>=7.0.5',
         'pandas==0.25.3',
         'matplotlib'
-    ]
+    ],
+    python_requires=">=3.5",
 )


### PR DESCRIPTION
This metadata will ensure that the package can't be installed on unsupported Python versions.
The extra dash in the license is because this field is typically the SPDX identifier for the license.