### PR TITLE
Prepare release for v7.6.0a4

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,13 @@
+Changelog
+=========
+
+7.6.0a4 (2020-03-23)
+--------------------
+
+* Fixed issue in ``DataFrame.info()`` when called on an empty frame (`#135`_)
+* Fixed issues where many ``_source`` fields would generate
+  a ``too_long_frame`` error (`#135`_, `#137`_)
+* Changed requirement for ``xgboost`` from ``>=0.90`` to ``==0.90``
+
+ .. _#135: https://github.com/elastic/eland/pull/135
+ .. _#137: https://github.com/elastic/eland/pull/137

--- a/eland/_version.py
+++ b/eland/_version.py
@@ -15,6 +15,6 @@
 __title__ = 'eland'
 __description__ = 'Python elasticsearch client to analyse, explore and manipulate data that resides in elasticsearch.'
 __url__ = 'https://github.com/elastic/eland'
-__version__ = '7.6.0a3'
+__version__ = '7.6.0a4'
 __maintainer__ = 'Elasticsearch B.V.'
 __maintainer_email__ = 'steve.dodson@elastic.co'


### PR DESCRIPTION
Preparing for a release of v7.6.0a4, will build and push to PyPI after merging.