### PR TITLE
No spaces in delimiters for serialized ML model

### DIFF
--- a/eland/ml/_model_serializer.py
+++ b/eland/ml/_model_serializer.py
@@ -34,7 +34,9 @@ class ModelSerializer(ABC):
         return self._feature_names
 
     def serialize_and_compress_model(self) -> str:
-        json_string = json.dumps({"trained_model": self.to_dict()})
+        json_string = json.dumps(
+            {"trained_model": self.to_dict()}, separators=(",", ":")
+        )
         return base64.b64encode(gzip.compress(bytes(json_string, "utf-8")))
 
 


### PR DESCRIPTION
Experimentally this makes serialized ML models from the test suite ~1% smaller. Not sure how big they can get or if this matters much but this is how clients all dump JSON.