### PR TITLE
Fix unpacking of median aggregation result

### DIFF
--- a/eland/operations.py
+++ b/eland/operations.py
@@ -480,7 +480,6 @@ class Operations:
         field_names = query_compiler.get_field_names(include_scripted_fields=False)
 
         body = Query(query_params["query"])
-
         # convert pandas aggs to ES equivalent
         es_aggs = self._map_pd_aggs_to_es_aggs(pd_aggs)
 
@@ -509,9 +508,13 @@ class Operations:
             values = list()
             for es_agg in es_aggs:
                 if isinstance(es_agg, tuple):
-                    values.append(
-                        response["aggregations"][es_agg[0] + "_" + field][es_agg[1]]
-                    )
+                    agg_value = response["aggregations"][es_agg[0] + "_" + field]
+
+                    # Pull multiple values from 'percentiles' result.
+                    if es_agg[0] == "percentiles":
+                        agg_value = agg_value["values"]
+
+                    values.append(agg_value[es_agg[1]])
                 else:
                     values.append(
                         response["aggregations"][es_agg + "_" + field]["value"]

--- a/eland/tests/dataframe/test_aggs_pytest.py
+++ b/eland/tests/dataframe/test_aggs_pytest.py
@@ -68,3 +68,22 @@ class TestDataFrameAggs(TestData):
         print(ed_sum_min_std.dtypes)
 
         assert_almost_equal(pd_sum_min_std, ed_sum_min_std, check_less_precise=True)
+
+    def test_aggs_median_var(self):
+        pd_ecommerce = self.pd_ecommerce()
+        ed_ecommerce = self.ed_ecommerce()
+
+        pd_aggs = pd_ecommerce[
+            ["taxful_total_price", "taxless_total_price", "total_quantity"]
+        ].agg(["median", "var"])
+        ed_aggs = ed_ecommerce[
+            ["taxful_total_price", "taxless_total_price", "total_quantity"]
+        ].agg(["median", "var"])
+
+        print(pd_aggs, pd_aggs.dtypes)
+        print(ed_aggs, ed_aggs.dtypes)
+
+        # Eland returns all float values for all metric aggs, pandas can return int
+        # TODO - investigate this more
+        pd_aggs = pd_aggs.astype("float64")
+        assert_almost_equal(pd_aggs, ed_aggs, check_less_precise=2)


### PR DESCRIPTION
The percentiles query result look like this: `{"percentiles_X": {"values": {"50.0": <value>}}}`, need the extra level of unpacking compared to all other tuple agg types so far.