### PR TITLE
Add default dtype for empty series

### DIFF
--- a/eland/operations.py
+++ b/eland/operations.py
@@ -40,7 +40,7 @@ from eland.tasks import (
     SizeTask,
 )
 
-with warnings.catch_warnings() as w:
+with warnings.catch_warnings(record=True):
     warnings.simplefilter("ignore")
     EMPTY_SERIES_DTYPE = pd.Series().dtype
 

--- a/eland/operations.py
+++ b/eland/operations.py
@@ -40,7 +40,7 @@ from eland.tasks import (
     SizeTask,
 )
 
-with warnings.catch_warnings(record=True):
+with warnings.catch_warnings():
     warnings.simplefilter("ignore")
     EMPTY_SERIES_DTYPE = pd.Series().dtype
 

--- a/eland/operations.py
+++ b/eland/operations.py
@@ -40,6 +40,10 @@ from eland.tasks import (
     SizeTask,
 )
 
+with warnings.catch_warnings() as w:
+    warnings.simplefilter("ignore")
+    EMPTY_SERIES_DTYPE = pd.Series().dtype
+
 
 class Operations:
     """
@@ -340,7 +344,8 @@ class Operations:
         # Return single value if this is a series
         # if len(numeric_source_fields) == 1:
         #    return np.float64(results[numeric_source_fields[0]])
-        s = pd.Series(data=results, index=results.keys())
+        out_dtype = EMPTY_SERIES_DTYPE if not results else None
+        s = pd.Series(data=results, index=results.keys(), dtype=out_dtype)
 
         return s
 
@@ -390,7 +395,8 @@ class Operations:
         except IndexError:
             name = None
 
-        s = pd.Series(data=results, index=results.keys(), name=name)
+        out_dtype = EMPTY_SERIES_DTYPE if not results else None
+        s = pd.Series(data=results, index=results.keys(), name=name, dtype=out_dtype)
 
         return s
 

--- a/eland/operations.py
+++ b/eland/operations.py
@@ -45,6 +45,12 @@ with warnings.catch_warnings() as w:
     EMPTY_SERIES_DTYPE = pd.Series().dtype
 
 
+def build_series(data, dtype=None, **kwargs):
+    out_dtype = EMPTY_SERIES_DTYPE if not data else dtype
+    s = pd.Series(data=data, index=data.keys(), dtype=out_dtype, **kwargs)
+    return s
+
+
 class Operations:
     """
     A collector of the queries and selectors we apply to queries to return the appropriate results.
@@ -344,8 +350,7 @@ class Operations:
         # Return single value if this is a series
         # if len(numeric_source_fields) == 1:
         #    return np.float64(results[numeric_source_fields[0]])
-        out_dtype = EMPTY_SERIES_DTYPE if not results else None
-        s = pd.Series(data=results, index=results.keys(), dtype=out_dtype)
+        s = build_series(results)
 
         return s
 
@@ -395,8 +400,7 @@ class Operations:
         except IndexError:
             name = None
 
-        out_dtype = EMPTY_SERIES_DTYPE if not results else None
-        s = pd.Series(data=results, index=results.keys(), name=name, dtype=out_dtype)
+        s = build_series(results, name=name)
 
         return s
 

--- a/eland/tests/dataframe/test_dtypes_pytest.py
+++ b/eland/tests/dataframe/test_dtypes_pytest.py
@@ -14,6 +14,7 @@
 
 # File called _pytest for PyCharm compatability
 
+import warnings
 import numpy as np
 from pandas.testing import assert_series_equal
 
@@ -45,5 +46,7 @@ class TestDataFrameDtypes(TestData):
         )
 
     def test_emtpy_series_dtypes(self):
-        s = build_series({})
+        with warnings.catch_warnings(record=True) as w:
+            s = build_series({})
         assert s.dtype == EMPTY_SERIES_DTYPE
+        assert w == []

--- a/eland/tests/dataframe/test_dtypes_pytest.py
+++ b/eland/tests/dataframe/test_dtypes_pytest.py
@@ -17,6 +17,7 @@
 import numpy as np
 from pandas.testing import assert_series_equal
 
+from eland.operations import build_series, EMPTY_SERIES_DTYPE
 from eland.tests.common import TestData
 from eland.tests.common import assert_pandas_eland_frame_equal
 
@@ -42,3 +43,7 @@ class TestDataFrameDtypes(TestData):
             pd_flights.select_dtypes(include=np.number),
             ed_flights.select_dtypes(include=np.number),
         )
+
+    def test_emtpy_series_dtypes(self):
+        s = build_series({})
+        assert s.dtype == EMPTY_SERIES_DTYPE


### PR DESCRIPTION
In case the content of the series if empty, the code should create the series with a the matching dtype of pandas.

Closes #165 