### PR TITLE
Add type hints to base modules

### DIFF
--- a/eland/dataframe.py
+++ b/eland/dataframe.py
@@ -187,7 +187,7 @@ class DataFrame(NDFrame):
         """
         return len(self.columns) == 0 or len(self.index) == 0
 
-    def head(self, n=5):
+    def head(self, n: int = 5) -> "DataFrame":
         """
         Return the first n rows.
 
@@ -222,7 +222,7 @@ class DataFrame(NDFrame):
         """
         return DataFrame(query_compiler=self._query_compiler.head(n))
 
-    def tail(self, n=5):
+    def tail(self, n: int = 5) -> "DataFrame":
         """
         Return the last n rows.
 

--- a/eland/filter.py
+++ b/eland/filter.py
@@ -59,7 +59,7 @@ class BooleanFilter:
         return NotFilter(self)
 
     def empty(self) -> bool:
-        return bool(self._filter)
+        return not bool(self._filter)
 
     def __repr__(self) -> str:
         return str(self._filter)

--- a/eland/filter.py
+++ b/eland/filter.py
@@ -14,12 +14,14 @@
 
 # Originally based on code in MIT-licensed pandasticsearch filters
 
+from typing import Dict, Any, List, Optional, Union, cast
+
 
 class BooleanFilter:
-    def __init__(self, *args):
-        self._filter = None
+    def __init__(self) -> None:
+        self._filter: Dict[str, Any] = {}
 
-    def __and__(self, x):
+    def __and__(self, x: "BooleanFilter") -> "BooleanFilter":
         # Combine results
         if isinstance(self, AndFilter):
             if "must_not" in x.subtree:
@@ -37,7 +39,7 @@ class BooleanFilter:
             return x
         return AndFilter(self, x)
 
-    def __or__(self, x):
+    def __or__(self, x: "BooleanFilter") -> "BooleanFilter":
         # Combine results
         if isinstance(self, OrFilter):
             if "must_not" in x.subtree:
@@ -53,85 +55,79 @@ class BooleanFilter:
             return x
         return OrFilter(self, x)
 
-    def __invert__(self):
+    def __invert__(self) -> "BooleanFilter":
         return NotFilter(self)
 
-    def empty(self):
-        if self._filter is None:
-            return True
-        return False
+    def empty(self) -> bool:
+        return bool(self._filter)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return str(self._filter)
 
     @property
-    def subtree(self):
+    def subtree(self) -> Dict[str, Any]:
         if "bool" in self._filter:
-            return self._filter["bool"]
+            return cast(Dict[str, Any], self._filter["bool"])
         else:
             return self._filter
 
-    def build(self):
+    def build(self) -> Dict[str, Any]:
         return self._filter
 
 
 # Binary operator
 class AndFilter(BooleanFilter):
-    def __init__(self, *args):
-        [isinstance(x, BooleanFilter) for x in args]
+    def __init__(self, *args: BooleanFilter) -> None:
         super().__init__()
         self._filter = {"bool": {"must": [x.build() for x in args]}}
 
 
 class OrFilter(BooleanFilter):
-    def __init__(self, *args):
-        [isinstance(x, BooleanFilter) for x in args]
+    def __init__(self, *args: BooleanFilter) -> None:
         super().__init__()
         self._filter = {"bool": {"should": [x.build() for x in args]}}
 
 
 class NotFilter(BooleanFilter):
-    def __init__(self, x):
-        assert isinstance(x, BooleanFilter)
+    def __init__(self, x: BooleanFilter) -> None:
         super().__init__()
         self._filter = {"bool": {"must_not": x.build()}}
 
 
 # LeafBooleanFilter
 class GreaterEqual(BooleanFilter):
-    def __init__(self, field, value):
+    def __init__(self, field: str, value: Any) -> None:
         super().__init__()
         self._filter = {"range": {field: {"gte": value}}}
 
 
 class Greater(BooleanFilter):
-    def __init__(self, field, value):
+    def __init__(self, field: str, value: Any) -> None:
         super().__init__()
         self._filter = {"range": {field: {"gt": value}}}
 
 
 class LessEqual(BooleanFilter):
-    def __init__(self, field, value):
+    def __init__(self, field: str, value: Any) -> None:
         super().__init__()
         self._filter = {"range": {field: {"lte": value}}}
 
 
 class Less(BooleanFilter):
-    def __init__(self, field, value):
+    def __init__(self, field: str, value: Any) -> None:
         super().__init__()
         self._filter = {"range": {field: {"lt": value}}}
 
 
 class Equal(BooleanFilter):
-    def __init__(self, field, value):
+    def __init__(self, field: str, value: Any) -> None:
         super().__init__()
         self._filter = {"term": {field: value}}
 
 
 class IsIn(BooleanFilter):
-    def __init__(self, field, value):
+    def __init__(self, field: str, value: List[Any]) -> None:
         super().__init__()
-        assert isinstance(value, list)
         if field == "ids":
             self._filter = {"ids": {"values": value}}
         else:
@@ -139,39 +135,44 @@ class IsIn(BooleanFilter):
 
 
 class Like(BooleanFilter):
-    def __init__(self, field, value):
+    def __init__(self, field: str, value: str) -> None:
         super().__init__()
         self._filter = {"wildcard": {field: value}}
 
 
 class Rlike(BooleanFilter):
-    def __init__(self, field, value):
+    def __init__(self, field: str, value: str) -> None:
         super().__init__()
         self._filter = {"regexp": {field: value}}
 
 
 class Startswith(BooleanFilter):
-    def __init__(self, field, value):
+    def __init__(self, field: str, value: str) -> None:
         super().__init__()
         self._filter = {"prefix": {field: value}}
 
 
 class IsNull(BooleanFilter):
-    def __init__(self, field):
+    def __init__(self, field: str) -> None:
         super().__init__()
         self._filter = {"missing": {"field": field}}
 
 
 class NotNull(BooleanFilter):
-    def __init__(self, field):
+    def __init__(self, field: str) -> None:
         super().__init__()
         self._filter = {"exists": {"field": field}}
 
 
 class ScriptFilter(BooleanFilter):
-    def __init__(self, inline, lang=None, params=None):
+    def __init__(
+        self,
+        inline: str,
+        lang: Optional[str] = None,
+        params: Optional[Dict[str, Any]] = None,
+    ) -> None:
         super().__init__()
-        script = {"source": inline}
+        script: Dict[str, Union[str, Dict[str, Any]]] = {"source": inline}
         if lang is not None:
             script["lang"] = lang
         if params is not None:
@@ -180,6 +181,6 @@ class ScriptFilter(BooleanFilter):
 
 
 class QueryFilter(BooleanFilter):
-    def __init__(self, query):
+    def __init__(self, query: Dict[str, Any]) -> None:
         super().__init__()
         self._filter = query

--- a/eland/index.py
+++ b/eland/index.py
@@ -13,6 +13,12 @@
 # limitations under the License.
 
 
+from typing import Optional, TextIO, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .query_compiler import QueryCompiler
+
+
 class Index:
     """
     The index for an eland.DataFrame.
@@ -33,30 +39,36 @@ class Index:
     ID_INDEX_FIELD = "_id"
     ID_SORT_FIELD = "_doc"  # if index field is _id, sort by _doc
 
-    def __init__(self, query_compiler, index_field=None):
+    def __init__(
+        self, query_compiler: "QueryCompiler", index_field: Optional[str] = None
+    ):
         self._query_compiler = query_compiler
 
         # _is_source_field is set immediately within
         # index_field.setter
         self._is_source_field = False
-        self.index_field = index_field
+
+        # The type:ignore is due to mypy not being smart enough
+        # to recognize the property.setter has a different type
+        # than the property.getter.
+        self.index_field = index_field  # type: ignore
 
     @property
-    def sort_field(self):
+    def sort_field(self) -> str:
         if self._index_field == self.ID_INDEX_FIELD:
             return self.ID_SORT_FIELD
         return self._index_field
 
     @property
-    def is_source_field(self):
+    def is_source_field(self) -> bool:
         return self._is_source_field
 
     @property
-    def index_field(self):
+    def index_field(self) -> str:
         return self._index_field
 
     @index_field.setter
-    def index_field(self, index_field):
+    def index_field(self, index_field: Optional[str]) -> None:
         if index_field is None or index_field == Index.ID_INDEX_FIELD:
             self._index_field = Index.ID_INDEX_FIELD
             self._is_source_field = False
@@ -64,18 +76,18 @@ class Index:
             self._index_field = index_field
             self._is_source_field = True
 
-    def __len__(self):
+    def __len__(self) -> int:
         return self._query_compiler._index_count()
 
     # Make iterable
-    def __next__(self):
+    def __next__(self) -> None:
         # TODO resolve this hack to make this 'iterable'
         raise StopIteration()
 
-    def __iter__(self):
+    def __iter__(self) -> "Index":
         return self
 
-    def info_es(self, buf):
+    def info_es(self, buf: TextIO) -> None:
         buf.write("Index:\n")
         buf.write(f" index_field: {self.index_field}\n")
         buf.write(f" is_source_field: {self.is_source_field}\n")

--- a/eland/operations.py
+++ b/eland/operations.py
@@ -14,6 +14,7 @@
 
 import copy
 import warnings
+from typing import Optional
 
 import numpy as np
 
@@ -98,7 +99,7 @@ class Operations:
         else:
             self._arithmetic_op_fields_task.update(display_name, arithmetic_series)
 
-    def get_arithmetic_op_fields(self):
+    def get_arithmetic_op_fields(self) -> Optional[ArithmeticOpFieldsTask]:
         # get an ArithmeticOpFieldsTask if it exists
         return self._arithmetic_op_fields_task
 

--- a/eland/query.py
+++ b/eland/query.py
@@ -42,10 +42,16 @@ class Query:
         Add exists query
         https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-exists-query.html
         """
-        filter = NotNull(field) if must else IsNull(field)
-        if not self._query.empty():
-            filter = self._query & filter
-        self._query = filter
+        if must:
+            if self._query.empty():
+                self._query = NotNull(field)
+            else:
+                self._query = self._query & NotNull(field)
+        else:
+            if self._query.empty():
+                self._query = IsNull(field)
+            else:
+                self._query = self._query & IsNull(field)
 
     def ids(self, items: List[Any], must: bool = True) -> None:
         """

--- a/eland/query.py
+++ b/eland/query.py
@@ -14,6 +14,7 @@
 
 import warnings
 from copy import deepcopy
+from typing import Optional, Dict, List, Any
 
 from eland.filter import BooleanFilter, NotNull, IsNull, IsIn
 
@@ -23,7 +24,11 @@ class Query:
     Simple class to manage building Elasticsearch queries.
     """
 
-    def __init__(self, query=None):
+    def __init__(self, query: Optional["Query"] = None):
+        # type defs
+        self._query: BooleanFilter
+        self._aggs: Dict[str, Any]
+
         if query is None:
             self._query = BooleanFilter()
             self._aggs = {}
@@ -32,23 +37,17 @@ class Query:
             self._query = deepcopy(query._query)
             self._aggs = deepcopy(query._aggs)
 
-    def exists(self, field, must=True):
+    def exists(self, field: str, must: bool = True) -> None:
         """
         Add exists query
         https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-exists-query.html
         """
-        if must:
-            if self._query.empty():
-                self._query = NotNull(field)
-            else:
-                self._query = self._query & NotNull(field)
-        else:
-            if self._query.empty():
-                self._query = IsNull(field)
-            else:
-                self._query = self._query & IsNull(field)
+        filter = NotNull(field) if must else IsNull(field)
+        if not self._query.empty():
+            filter = self._query & filter
+        self._query = filter
 
-    def ids(self, items, must=True):
+    def ids(self, items: List[Any], must: bool = True) -> None:
         """
         Add ids query
         https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-ids-query.html
@@ -64,7 +63,7 @@ class Query:
             else:
                 self._query = self._query & ~(IsIn("ids", items))
 
-    def terms(self, field, items, must=True):
+    def terms(self, field: str, items: List[str], must: bool = True) -> None:
         """
         Add ids query
         https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-terms-query.html
@@ -80,7 +79,7 @@ class Query:
             else:
                 self._query = self._query & ~(IsIn(field, items))
 
-    def terms_aggs(self, name, func, field, es_size):
+    def terms_aggs(self, name: str, func: str, field: str, es_size: int) -> None:
         """
         Add terms agg e.g
 
@@ -96,7 +95,7 @@ class Query:
         agg = {func: {"field": field, "size": es_size}}
         self._aggs[name] = agg
 
-    def metric_aggs(self, name, func, field):
+    def metric_aggs(self, name: str, func: str, field: str) -> None:
         """
         Add metric agg e.g
 
@@ -111,7 +110,14 @@ class Query:
         agg = {func: {"field": field}}
         self._aggs[name] = agg
 
-    def hist_aggs(self, name, field, min_aggs, max_aggs, num_bins):
+    def hist_aggs(
+        self,
+        name: str,
+        field: str,
+        min_aggs: Dict[str, Any],
+        max_aggs: Dict[str, Any],
+        num_bins: int,
+    ) -> None:
         """
         Add histogram agg e.g.
         "aggs": {
@@ -127,14 +133,15 @@ class Query:
         max = max_aggs[field]
 
         interval = (max - min) / num_bins
-        offset = min
-
-        agg = {"histogram": {"field": field, "interval": interval, "offset": offset}}
 
         if interval != 0:
+            offset = min
+            agg = {
+                "histogram": {"field": field, "interval": interval, "offset": offset}
+            }
             self._aggs[name] = agg
 
-    def to_search_body(self):
+    def to_search_body(self) -> Dict[str, Any]:
         body = {}
         if self._aggs:
             body["aggs"] = self._aggs
@@ -142,19 +149,19 @@ class Query:
             body["query"] = self._query.build()
         return body
 
-    def to_count_body(self):
+    def to_count_body(self) -> Optional[Dict[str, Any]]:
         if len(self._aggs) > 0:
-            warnings.warn("Requesting count for agg query {}", self)
+            warnings.warn(f"Requesting count for agg query {self}")
         if self._query.empty():
             return None
         else:
             return {"query": self._query.build()}
 
-    def update_boolean_filter(self, boolean_filter):
+    def update_boolean_filter(self, boolean_filter: BooleanFilter) -> None:
         if self._query.empty():
             self._query = boolean_filter
         else:
             self._query = self._query & boolean_filter
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return repr(self.to_search_body())

--- a/eland/query_compiler.py
+++ b/eland/query_compiler.py
@@ -14,6 +14,7 @@
 
 import copy
 from datetime import datetime
+from typing import Optional, TYPE_CHECKING
 
 import numpy as np
 import pandas as pd
@@ -27,6 +28,9 @@ from eland.common import (
     DEFAULT_PROGRESS_REPORTING_NUM_ROWS,
     elasticsearch_date_to_pandas_date,
 )
+
+if TYPE_CHECKING:
+    from .tasks import ArithmeticOpFieldsTask  # noqa: F401
 
 
 class QueryCompiler:
@@ -348,7 +352,7 @@ class QueryCompiler:
 
         return out
 
-    def _index_count(self):
+    def _index_count(self) -> int:
         """
         Returns
         -------
@@ -562,10 +566,10 @@ class QueryCompiler:
 
         return result
 
-    def get_arithmetic_op_fields(self):
+    def get_arithmetic_op_fields(self) -> Optional["ArithmeticOpFieldsTask"]:
         return self._operations.get_arithmetic_op_fields()
 
-    def display_name_to_aggregatable_name(self, display_name):
+    def display_name_to_aggregatable_name(self, display_name: str) -> str:
         aggregatable_field_name = self._mappings.aggregatable_field_name(display_name)
 
         return aggregatable_field_name

--- a/eland/tasks.py
+++ b/eland/tasks.py
@@ -22,8 +22,8 @@ from eland.arithmetics import ArithmeticSeries
 
 if TYPE_CHECKING:
     from .actions import PostProcessingAction  # noqa: F401
-    from .filter import BooleanFilter
-    from .query_compiler import QueryCompiler
+    from .filter import BooleanFilter  # noqa: F401
+    from .query_compiler import QueryCompiler  # noqa: F401
 
 QUERY_PARAMS_TYPE = Dict[str, Any]
 RESOLVED_TASK_TYPE = Tuple[QUERY_PARAMS_TYPE, List["PostProcessingAction"]]
@@ -51,7 +51,7 @@ class Task(ABC):
         self,
         query_params: QUERY_PARAMS_TYPE,
         post_processing: List["PostProcessingAction"],
-        query_compiler: QueryCompiler,
+        query_compiler: "QueryCompiler",
     ) -> RESOLVED_TASK_TYPE:
         pass
 
@@ -82,7 +82,7 @@ class HeadTask(SizeTask):
         self,
         query_params: QUERY_PARAMS_TYPE,
         post_processing: List["PostProcessingAction"],
-        query_compiler: QueryCompiler,
+        query_compiler: "QueryCompiler",
     ) -> RESOLVED_TASK_TYPE:
         # head - sort asc, size n
         # |12345-------------|
@@ -130,7 +130,7 @@ class TailTask(SizeTask):
         self,
         query_params: QUERY_PARAMS_TYPE,
         post_processing: List["PostProcessingAction"],
-        query_compiler: QueryCompiler,
+        query_compiler: "QueryCompiler",
     ) -> RESOLVED_TASK_TYPE:
         # tail - sort desc, size n, post-process sort asc
         # |-------------12345|
@@ -251,7 +251,7 @@ class QueryTermsTask(Task):
 
 
 class BooleanFilterTask(Task):
-    def __init__(self, boolean_filter: BooleanFilter):
+    def __init__(self, boolean_filter: "BooleanFilter"):
         """
         Parameters
         ----------

--- a/eland/tasks.py
+++ b/eland/tasks.py
@@ -13,10 +13,20 @@
 # limitations under the License.
 
 from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, List, Dict, Any, Tuple
 
 from eland import SortOrder
 from eland.actions import HeadAction, TailAction, SortIndexAction
 from eland.arithmetics import ArithmeticSeries
+
+
+if TYPE_CHECKING:
+    from .actions import PostProcessingAction  # noqa: F401
+    from .filter import BooleanFilter
+    from .query_compiler import QueryCompiler
+
+QUERY_PARAMS_TYPE = Dict[str, Any]
+RESOLVED_TASK_TYPE = Tuple[QUERY_PARAMS_TYPE, List["PostProcessingAction"]]
 
 
 class Task(ABC):
@@ -29,44 +39,51 @@ class Task(ABC):
             The task type (e.g. head, tail etc.)
     """
 
-    def __init__(self, task_type):
+    def __init__(self, task_type: str):
         self._task_type = task_type
 
     @property
-    def type(self):
+    def type(self) -> str:
         return self._task_type
 
     @abstractmethod
-    def resolve_task(self, query_params, post_processing, query_compiler):
+    def resolve_task(
+        self,
+        query_params: QUERY_PARAMS_TYPE,
+        post_processing: List["PostProcessingAction"],
+        query_compiler: QueryCompiler,
+    ) -> RESOLVED_TASK_TYPE:
         pass
 
     @abstractmethod
-    def __repr__(self):
+    def __repr__(self) -> str:
         pass
 
 
 class SizeTask(Task):
-    def __init__(self, task_type):
-        super().__init__(task_type)
-
     @abstractmethod
-    def size(self):
+    def size(self) -> int:
         # must override
         pass
 
 
 class HeadTask(SizeTask):
-    def __init__(self, sort_field, count):
+    def __init__(self, sort_field: str, count: int):
         super().__init__("head")
 
         # Add a task that is an ascending sort with size=count
         self._sort_field = sort_field
         self._count = count
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"('{self._task_type}': ('sort_field': '{self._sort_field}', 'count': {self._count}))"
 
-    def resolve_task(self, query_params, post_processing, query_compiler):
+    def resolve_task(
+        self,
+        query_params: QUERY_PARAMS_TYPE,
+        post_processing: List["PostProcessingAction"],
+        query_compiler: QueryCompiler,
+    ) -> RESOLVED_TASK_TYPE:
         # head - sort asc, size n
         # |12345-------------|
         query_sort_field = self._sort_field
@@ -97,22 +114,24 @@ class HeadTask(SizeTask):
 
         return query_params, post_processing
 
-    def size(self):
+    def size(self) -> int:
         return self._count
 
 
 class TailTask(SizeTask):
-    def __init__(self, sort_field, count):
+    def __init__(self, sort_field: str, count: int):
         super().__init__("tail")
 
         # Add a task that is descending sort with size=count
         self._sort_field = sort_field
         self._count = count
 
-    def __repr__(self):
-        return f"('{self._task_type}': ('sort_field': '{self._sort_field}', 'count': {self._count}))"
-
-    def resolve_task(self, query_params, post_processing, query_compiler):
+    def resolve_task(
+        self,
+        query_params: QUERY_PARAMS_TYPE,
+        post_processing: List["PostProcessingAction"],
+        query_compiler: QueryCompiler,
+    ) -> RESOLVED_TASK_TYPE:
         # tail - sort desc, size n, post-process sort asc
         # |-------------12345|
         query_sort_field = self._sort_field
@@ -123,7 +142,10 @@ class TailTask(SizeTask):
         if (
             query_params["query_size"] is not None
             and query_params["query_sort_order"] == query_sort_order
-            and post_processing == ["sort_index"]
+            and (
+                len(post_processing) == 1
+                and isinstance(post_processing[0], SortIndexAction)
+            )
         ):
             if query_size < query_params["query_size"]:
                 query_params["query_size"] = query_size
@@ -156,12 +178,15 @@ class TailTask(SizeTask):
 
         return query_params, post_processing
 
-    def size(self):
+    def size(self) -> int:
         return self._count
+
+    def __repr__(self) -> str:
+        return f"('{self._task_type}': ('sort_field': '{self._sort_field}', 'count': {self._count}))"
 
 
 class QueryIdsTask(Task):
-    def __init__(self, must, ids):
+    def __init__(self, must: bool, ids: List[str]):
         """
         Parameters
         ----------
@@ -176,17 +201,21 @@ class QueryIdsTask(Task):
         self._must = must
         self._ids = ids
 
-    def resolve_task(self, query_params, post_processing, query_compiler):
+    def resolve_task(
+        self,
+        query_params: QUERY_PARAMS_TYPE,
+        post_processing: List["PostProcessingAction"],
+        query_compiler: "QueryCompiler",
+    ) -> RESOLVED_TASK_TYPE:
         query_params["query"].ids(self._ids, must=self._must)
-
         return query_params, post_processing
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"('{self._task_type}': ('must': {self._must}, 'ids': {self._ids}))"
 
 
 class QueryTermsTask(Task):
-    def __init__(self, must, field, terms):
+    def __init__(self, must: bool, field: str, terms: List[Any]):
         """
         Parameters
         ----------
@@ -205,20 +234,24 @@ class QueryTermsTask(Task):
         self._field = field
         self._terms = terms
 
-    def __repr__(self):
+    def resolve_task(
+        self,
+        query_params: QUERY_PARAMS_TYPE,
+        post_processing: List["PostProcessingAction"],
+        query_compiler: "QueryCompiler",
+    ) -> RESOLVED_TASK_TYPE:
+        query_params["query"].terms(self._field, self._terms, must=self._must)
+        return query_params, post_processing
+
+    def __repr__(self) -> str:
         return (
             f"('{self._task_type}': ('must': {self._must}, "
             f"'field': '{self._field}', 'terms': {self._terms}))"
         )
 
-    def resolve_task(self, query_params, post_processing, query_compiler):
-        query_params["query"].terms(self._field, self._terms, must=self._must)
-
-        return query_params, post_processing
-
 
 class BooleanFilterTask(Task):
-    def __init__(self, boolean_filter):
+    def __init__(self, boolean_filter: BooleanFilter):
         """
         Parameters
         ----------
@@ -229,17 +262,21 @@ class BooleanFilterTask(Task):
 
         self._boolean_filter = boolean_filter
 
-    def __repr__(self):
-        return f"('{self._task_type}': ('boolean_filter': {self._boolean_filter!r}))"
-
-    def resolve_task(self, query_params, post_processing, query_compiler):
+    def resolve_task(
+        self,
+        query_params: QUERY_PARAMS_TYPE,
+        post_processing: List["PostProcessingAction"],
+        query_compiler: "QueryCompiler",
+    ) -> RESOLVED_TASK_TYPE:
         query_params["query"].update_boolean_filter(self._boolean_filter)
-
         return query_params, post_processing
+
+    def __repr__(self) -> str:
+        return f"('{self._task_type}': ('boolean_filter': {self._boolean_filter!r}))"
 
 
 class ArithmeticOpFieldsTask(Task):
-    def __init__(self, display_name, arithmetic_series):
+    def __init__(self, display_name: str, arithmetic_series: ArithmeticSeries):
         super().__init__("arithmetic_op_fields")
 
         self._display_name = display_name
@@ -248,19 +285,16 @@ class ArithmeticOpFieldsTask(Task):
             raise TypeError(f"Expecting ArithmeticSeries got {type(arithmetic_series)}")
         self._arithmetic_series = arithmetic_series
 
-    def __repr__(self):
-        return (
-            f"('{self._task_type}': ("
-            f"'display_name': {self._display_name}, "
-            f"'arithmetic_object': {self._arithmetic_series}"
-            f"))"
-        )
-
-    def update(self, display_name, arithmetic_series):
+    def update(self, display_name: str, arithmetic_series: ArithmeticSeries) -> None:
         self._display_name = display_name
         self._arithmetic_series = arithmetic_series
 
-    def resolve_task(self, query_params, post_processing, query_compiler):
+    def resolve_task(
+        self,
+        query_params: QUERY_PARAMS_TYPE,
+        post_processing: List["PostProcessingAction"],
+        query_compiler: "QueryCompiler",
+    ) -> RESOLVED_TASK_TYPE:
         # https://www.elastic.co/guide/en/elasticsearch/painless/current/painless-api-reference-shared-java-lang.html#painless-api-reference-shared-Math
         """
         "script_fields": {
@@ -272,7 +306,10 @@ class ArithmeticOpFieldsTask(Task):
         }
         """
         if query_params["query_script_fields"] is None:
-            query_params["query_script_fields"] = dict()
+            query_params["query_script_fields"] = {}
+
+        # TODO: Remove this once 'query_params' becomes a dataclass.
+        assert isinstance(query_params["query_script_fields"], dict)
 
         if self._display_name in query_params["query_script_fields"]:
             raise NotImplementedError(
@@ -286,3 +323,11 @@ class ArithmeticOpFieldsTask(Task):
         }
 
         return query_params, post_processing
+
+    def __repr__(self) -> str:
+        return (
+            f"('{self._task_type}': ("
+            f"'display_name': {self._display_name}, "
+            f"'arithmetic_object': {self._arithmetic_series}"
+            f"))"
+        )

--- a/eland/utils.py
+++ b/eland/utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import csv
+from typing import Union, List, Tuple, Optional, Mapping
 
 import pandas as pd
 from pandas.io.parsers import _c_parser_defaults
@@ -20,10 +21,14 @@ from pandas.io.parsers import _c_parser_defaults
 from eland import DataFrame
 from eland.field_mappings import FieldMappings
 from eland.common import ensure_es_client, DEFAULT_CHUNK_SIZE
+from elasticsearch import Elasticsearch
 from elasticsearch.helpers import bulk
 
 
-def read_es(es_client, es_index_pattern):
+def read_es(
+    es_client: Union[str, List[str], Tuple[str, ...], Elasticsearch],
+    es_index_pattern: str,
+) -> DataFrame:
     """
     Utility method to create an eland.Dataframe from an Elasticsearch index_pattern.
     (Similar to pandas.read_csv, but source data is an Elasticsearch index rather than
@@ -50,16 +55,16 @@ def read_es(es_client, es_index_pattern):
 
 
 def pandas_to_eland(
-    pd_df,
-    es_client,
-    es_dest_index,
-    es_if_exists="fail",
-    es_refresh=False,
-    es_dropna=False,
-    es_type_overrides=None,
-    chunksize=None,
-    use_pandas_index_for_es_ids=True,
-):
+    pd_df: pd.DataFrame,
+    es_client: Union[str, List[str], Tuple[str, ...], Elasticsearch],
+    es_dest_index: str,
+    es_if_exists: str = "fail",
+    es_refresh: bool = False,
+    es_dropna: bool = False,
+    es_type_overrides: Optional[Mapping[str, str]] = None,
+    chunksize: Optional[int] = None,
+    use_pandas_index_for_es_ids: bool = True,
+) -> DataFrame:
     """
     Append a pandas DataFrame to an Elasticsearch index.
     Mainly used in testing.
@@ -217,7 +222,7 @@ def pandas_to_eland(
     return DataFrame(es_client, es_dest_index)
 
 
-def eland_to_pandas(ed_df, show_progress=False):
+def eland_to_pandas(ed_df: DataFrame, show_progress: bool = False) -> pd.DataFrame:
     """
     Convert an eland.Dataframe to a pandas.DataFrame
 


### PR DESCRIPTION
This starts on #19 by adding type hints to all the base modules in `eland`. After this may be useful to look at an "automatic" type hint generator since now most types can be inferred.

Also want to wait to do query_compiler.py and operations.py until we have a query_params dataclass (#193)