### PR TITLE
Fix bug when combining AndFilter/OrFilter with other bool filters

### DIFF
--- a/eland/filter.py
+++ b/eland/filter.py
@@ -12,17 +12,14 @@ class BooleanFilter:
         self._filter: Dict[str, Any] = {}
 
     def __and__(self, x: "BooleanFilter") -> "BooleanFilter":
-        # Combine results
-        if isinstance(self, AndFilter):
-            if "must_not" in x.subtree:
-                # nest a must_not under a must
-                self.subtree["must"].append(x.build())  # 'build includes bool'
+        if tuple(self.subtree.keys()) == ("must",):
+            if "bool" in self._filter:
+                self.subtree["must"].append(x.build())
             else:
-                # append a must to a must
-                self.subtree["must"].append(x.subtree)  # 'subtree strips bool'
+                self.subtree["must"].append(x.subtree)
             return self
-        elif isinstance(x, AndFilter):
-            if "must_not" in self.subtree:
+        elif tuple(x.subtree.keys()) == ("must",):
+            if "bool" in x._filter:
                 x.subtree["must"].append(self.build())
             else:
                 x.subtree["must"].append(self.subtree)
@@ -30,15 +27,14 @@ class BooleanFilter:
         return AndFilter(self, x)
 
     def __or__(self, x: "BooleanFilter") -> "BooleanFilter":
-        # Combine results
-        if isinstance(self, OrFilter):
-            if "must_not" in x.subtree:
+        if tuple(self.subtree.keys()) == ("should",):
+            if "bool" in x._filter:
                 self.subtree["should"].append(x.build())
             else:
                 self.subtree["should"].append(x.subtree)
             return self
-        elif isinstance(x, OrFilter):
-            if "must_not" in self.subtree:
+        elif tuple(x.subtree.keys()) == ("should",):
+            if "bool" in self._filter:
                 x.subtree["should"].append(self.build())
             else:
                 x.subtree["should"].append(self.subtree)
@@ -52,7 +48,7 @@ class BooleanFilter:
         return not bool(self._filter)
 
     def __repr__(self) -> str:
-        return str(self._filter)
+        return str(self.build())
 
     @property
     def subtree(self) -> Dict[str, Any]:

--- a/eland/tests/operators/test_operators_pytest.py
+++ b/eland/tests/operators/test_operators_pytest.py
@@ -56,6 +56,7 @@ class TestOperators:
 
     def test_and_filter2(self):
         exp = GreaterEqual("a", 2) & Less("b", 3) & Equal("c", 4)
+        print(exp.build())
         assert exp.build() == {
             "bool": {
                 "must": [
@@ -228,3 +229,22 @@ class TestOperators:
             }
         }
         assert a == b
+
+    def test_complex_filter(self):
+        exp = (
+            Greater("a", 10)
+            & ~Greater("a", 250)
+            & (Equal("b", "X") | (Equal("b", "Y")))
+            & (Equal("b", "Z"))
+        )
+
+        assert exp.build() == {
+            "bool": {
+                "must": [
+                    {"range": {"a": {"gt": 10}}},
+                    {"bool": {"must_not": {"range": {"a": {"gt": 250}}}}},
+                    {"bool": {"should": [{"term": {"b": "X"}}, {"term": {"b": "Y"}}]}},
+                    {"term": {"b": "Z"}},
+                ]
+            }
+        }


### PR DESCRIPTION
Changes how we detect whether to combine an `AndFilter`/`OrFilter` with another `bool` query.
Essentially we want the `"bool"` to appear in the `subtree["must"]` of the query being combined into.

From #203 the query that was being generated and causing an error is:
```json
{
  "bool": {
    "must": [
      {"range": {"a": {"gt": 10}}},
      {"range": {"a": {"gt": 250}}},
      {"should": [{"term": {"b": "X"}}, {"term": {"b": "Y"}}]},  <--- this entry is wrong
      {"term": {"b": "Z"}},
    ]
  }
}
```

with this change now this query will be generated:
```json
{
  "bool": {
    "must": [
      {"range": {"a": {"gt": 10}}},
      {"range": {"a": {"gt": 250}}},
      {"bool": {"should": [{"term": {"b": "X"}}, {"term": {"b": "Y"}}]}},
      {"term": {"b": "Z"}},
    ]
  }
}
```

Closes #203 
cc @penalva34