### PR TITLE
Fix bug with empty dataframe number of rows

### DIFF
--- a/eland/operations.py
+++ b/eland/operations.py
@@ -77,16 +77,16 @@ class Operations:
 
     def head(self, index, n):
         # Add a task that is an ascending sort with size=n
-        task = HeadTask(index.sort_field, n)
+        task = HeadTask(index, n)
         self._tasks.append(task)
 
     def tail(self, index, n):
         # Add a task that is descending sort with size=n
-        task = TailTask(index.sort_field, n)
+        task = TailTask(index, n)
         self._tasks.append(task)
 
     def sample(self, index, n, random_state):
-        task = SampleTask(index.sort_field, n, random_state)
+        task = SampleTask(index, n, random_state)
         self._tasks.append(task)
 
     def arithmetic_op_fields(self, display_name, arithmetic_series):

--- a/eland/tasks.py
+++ b/eland/tasks.py
@@ -57,12 +57,12 @@ class SizeTask(Task):
 
 
 class HeadTask(SizeTask):
-    def __init__(self, sort_field: str, count: int):
+    def __init__(self, index, count: int):
         super().__init__("head")
 
         # Add a task that is an ascending sort with size=count
-        self._sort_field = sort_field
-        self._count = count
+        self._sort_field = index.sort_field
+        self._count = min(len(index), count)
 
     def __repr__(self) -> str:
         return f"('{self._task_type}': ('sort_field': '{self._sort_field}', 'count': {self._count}))"
@@ -108,12 +108,12 @@ class HeadTask(SizeTask):
 
 
 class TailTask(SizeTask):
-    def __init__(self, sort_field: str, count: int):
+    def __init__(self, index, count: int):
         super().__init__("tail")
 
         # Add a task that is descending sort with size=count
-        self._sort_field = sort_field
-        self._count = count
+        self._sort_field = index.sort_field
+        self._count = min(len(index), count)
 
     def resolve_task(
         self,
@@ -175,11 +175,11 @@ class TailTask(SizeTask):
 
 
 class SampleTask(SizeTask):
-    def __init__(self, sort_field: str, count: int, random_state: int):
+    def __init__(self, index, count: int, random_state: int):
         super().__init__("sample")
-        self._count = count
+        self._count = min(len(index), count)
         self._random_state = random_state
-        self._sort_field = sort_field
+        self._sort_field = index.sort_field
 
     def resolve_task(
         self,

--- a/eland/tasks.py
+++ b/eland/tasks.py
@@ -50,6 +50,11 @@ class Task(ABC):
 
 
 class SizeTask(Task):
+    def __init__(self, task_type: str, index, count: int):
+        super().__init__(task_type)
+        self._sort_field = index.sort_field
+        self._count = min(len(index), count)
+
     @abstractmethod
     def size(self) -> int:
         # must override
@@ -58,11 +63,7 @@ class SizeTask(Task):
 
 class HeadTask(SizeTask):
     def __init__(self, index, count: int):
-        super().__init__("head")
-
-        # Add a task that is an ascending sort with size=count
-        self._sort_field = index.sort_field
-        self._count = min(len(index), count)
+        super().__init__("head", index, count)
 
     def __repr__(self) -> str:
         return f"('{self._task_type}': ('sort_field': '{self._sort_field}', 'count': {self._count}))"
@@ -109,11 +110,7 @@ class HeadTask(SizeTask):
 
 class TailTask(SizeTask):
     def __init__(self, index, count: int):
-        super().__init__("tail")
-
-        # Add a task that is descending sort with size=count
-        self._sort_field = index.sort_field
-        self._count = min(len(index), count)
+        super().__init__("tail", index, count)
 
     def resolve_task(
         self,
@@ -176,10 +173,8 @@ class TailTask(SizeTask):
 
 class SampleTask(SizeTask):
     def __init__(self, index, count: int, random_state: int):
-        super().__init__("sample")
-        self._count = min(len(index), count)
+        super().__init__("sample", index, count)
         self._random_state = random_state
-        self._sort_field = index.sort_field
 
     def resolve_task(
         self,

--- a/eland/tests/dataframe/test_head_tail_pytest.py
+++ b/eland/tests/dataframe/test_head_tail_pytest.py
@@ -6,6 +6,7 @@
 
 from eland.tests.common import TestData
 from eland.tests.common import assert_pandas_eland_frame_equal
+from eland.utils import eland_to_pandas
 
 
 class TestDataFrameHeadTail(TestData):
@@ -95,3 +96,9 @@ class TestDataFrameHeadTail(TestData):
         df = df[["timestamp", "OriginAirportID", "DestAirportID", "FlightDelayMin"]]
         df = df.tail()
         print(df)
+
+    def test_doc_test_tail_empty(self):
+        df = self.ed_flights()
+        df = df[df.OriginAirportID == "NADA"]
+        df = df.tail()
+        assert df.shape[0] == 0

--- a/eland/tests/dataframe/test_head_tail_pytest.py
+++ b/eland/tests/dataframe/test_head_tail_pytest.py
@@ -6,7 +6,6 @@
 
 from eland.tests.common import TestData
 from eland.tests.common import assert_pandas_eland_frame_equal
-from eland.utils import eland_to_pandas
 
 
 class TestDataFrameHeadTail(TestData):
@@ -102,3 +101,8 @@ class TestDataFrameHeadTail(TestData):
         df = df[df.OriginAirportID == "NADA"]
         df = df.tail()
         assert df.shape[0] == 0
+
+    def test_doc_test_tail_single(self):
+        df = self.ed_flights_small()
+        df = df[(df.Carrier == "Kibana Airlines") & (df.DestAirportID == "ITM")].tail()
+        assert df.shape[0] == 1


### PR DESCRIPTION
This is an attempt at solving the bug with the wrong shape, instead of only passing the sort field, one could pass the index and query the `len` in the constructor. An enhancement will be to create a unique constructor in SizeTask with the logic.

Closes #152 