### PR TITLE
Upgrade to elasticsearch-py v7.7

### DIFF
--- a/eland/_version.py
+++ b/eland/_version.py
@@ -5,7 +5,7 @@
 __title__ = "eland"
 __description__ = "Python elasticsearch client to analyse, explore and manipulate data that resides in elasticsearch."
 __url__ = "https://github.com/elastic/eland"
-__version__ = "7.6.0a5"
+__version__ = "7.7.0a1"
 __author__ = "Steve Dodson"
 __author_email__ = "steve.dodson@elastic.co"
 __maintainer__ = "Seth Michael Larson"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-elasticsearch==7.7.0a2
+elasticsearch>=7.7
 pandas>=1
 matplotlib
 pytest>=5.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-elasticsearch==7.7.0a2
+elasticsearch>=7.7
 pandas>=1
 matplotlib

--- a/setup.py
+++ b/setup.py
@@ -175,7 +175,7 @@ setup(
     classifiers=CLASSIFIERS,
     keywords="elastic eland pandas python",
     packages=find_packages(include=["eland", "eland.*"]),
-    install_requires=["elasticsearch==7.7.0a2", "pandas>=1", "matplotlib", "numpy"],
+    install_requires=["elasticsearch>=7.7", "pandas>=1", "matplotlib", "numpy"],
     python_requires=">=3.6",
     extras_require={
         "xgboost": ["xgboost>=0.90,<2"],


### PR DESCRIPTION
Now that `elasticsearch-py` has been released with `numpy` and `pandas` serialization support we no longer need to rely on alphas!