### PR TITLE
[ML] add multi:softmax|softprob XGBoost support

### DIFF
--- a/eland/ml/_model_serializer.py
+++ b/eland/ml/_model_serializer.py
@@ -19,7 +19,7 @@ import base64
 import gzip
 import json
 from abc import ABC
-from typing import Sequence, Dict, Any, Optional
+from typing import Sequence, Dict, Any, Optional, List
 
 
 def add_if_exists(d: Dict[str, Any], k: str, v: Any) -> None:
@@ -69,7 +69,7 @@ class TreeNode:
         right_child: Optional[int] = None,
         split_feature: Optional[int] = None,
         threshold: Optional[float] = None,
-        leaf_value: Optional[float] = None,
+        leaf_value: Optional[List[float]] = None,
     ):
         self._node_idx = node_idx
         self._decision_type = decision_type

--- a/eland/ml/imported_ml_model.py
+++ b/eland/ml/imported_ml_model.py
@@ -60,7 +60,17 @@ class ImportedMLModel(MLModel):
         - sklearn.ensemble.RandomForestRegressor
         - sklearn.ensemble.RandomForestClassifier
         - xgboost.XGBClassifier
+            - only the following operators are supported:
+                - "binary:logistic"
+                - "binary:hinge"
+                - "multi:softmax"
+                - "multi:softprob"
         - xgboost.XGBRegressor
+            - only the following operators are supportd:
+                - "reg:squarederror"
+                - "reg:linear"
+                - "reg:squaredlogerror"
+                - "reg:logistic"
 
     feature_names: List[str]
         Names of the features (required)

--- a/eland/ml/transformers/sklearn.py
+++ b/eland/ml/transformers/sklearn.py
@@ -79,10 +79,10 @@ class SKLearnTransformer(ModelTransformer):
             if (
                 value.shape[1] == 1
             ):  # classification requires more than one value, so assume regression
-                leaf_value = float(value[0][0])
+                leaf_value = [float(value[0][0])]
             else:
                 # the classification value, which is the index of the largest value
-                leaf_value = int(np.argmax(value))
+                leaf_value = [float(np.argmax(value))]
             return TreeNode(
                 node_index,
                 decision_type=self._node_decision_type,

--- a/eland/ml/transformers/xgboost.py
+++ b/eland/ml/transformers/xgboost.py
@@ -178,21 +178,6 @@ class XGBoostForestTransformer(ModelTransformer):
 
 
 class XGBoostRegressorTransformer(XGBoostForestTransformer):
-    """
-    Transform trained XGBClassifier into an Elasticsearch supported format.
-
-    Parameters
-    ----------
-    model: XGBRegressor
-       Only a subset of the operators are supported: ["reg:squarederror",
-           "reg:linear",
-           "reg:squaredlogerror",
-           "reg:logistic",]
-       Any regression model built with a different operator will fail to be transformed.
-    feature_names: List[str]
-        model feature names
-    """
-
     def __init__(self, model: XGBRegressor, feature_names: List[str]):
         # XGBRegressor.base_score defaults to 0.5.
         base_score = model.base_score
@@ -222,23 +207,6 @@ class XGBoostRegressorTransformer(XGBoostForestTransformer):
 
 
 class XGBoostClassifierTransformer(XGBoostForestTransformer):
-    """
-    Transform trained XGBClassifier into an Elasticsearch supported format.
-
-    Parameters
-    ----------
-    model: XGBClassifier
-       Only a subset of the operators are supported: ["binary:logistic",
-           "binary:hinge",
-           "multi:softmax",
-           "multi:softprob"]
-       Any classification model built with a different operator will fail to be transformed.
-    feature_names: List[str]
-        model feature names
-    classification_labels: Optional[List[str]]
-        classification labels
-    """
-
     def __init__(
         self,
         model: XGBClassifier,

--- a/eland/ml/transformers/xgboost.py
+++ b/eland/ml/transformers/xgboost.py
@@ -178,6 +178,21 @@ class XGBoostForestTransformer(ModelTransformer):
 
 
 class XGBoostRegressorTransformer(XGBoostForestTransformer):
+    """
+    Transform trained XGBClassifier into an Elasticsearch supported format.
+
+    Parameters
+    ----------
+    model: XGBRegressor
+       Only a subset of the operators are supported: ["reg:squarederror",
+           "reg:linear",
+           "reg:squaredlogerror",
+           "reg:logistic",]
+       Any regression model built with a different operator will fail to be transformed.
+    feature_names: List[str]
+        model feature names
+    """
+
     def __init__(self, model: XGBRegressor, feature_names: List[str]):
         # XGBRegressor.base_score defaults to 0.5.
         base_score = model.base_score
@@ -207,6 +222,23 @@ class XGBoostRegressorTransformer(XGBoostForestTransformer):
 
 
 class XGBoostClassifierTransformer(XGBoostForestTransformer):
+    """
+    Transform trained XGBClassifier into an Elasticsearch supported format.
+
+    Parameters
+    ----------
+    model: XGBClassifier
+       Only a subset of the operators are supported: ["binary:logistic",
+           "binary:hinge",
+           "multi:softmax",
+           "multi:softprob"]
+       Any classification model built with a different operator will fail to be transformed.
+    feature_names: List[str]
+        model feature names
+    classification_labels: Optional[List[str]]
+        classification labels
+    """
+
     def __init__(
         self,
         model: XGBClassifier,

--- a/eland/tests/ml/test_imported_ml_model_pytest.py
+++ b/eland/tests/ml/test_imported_ml_model_pytest.py
@@ -228,8 +228,10 @@ class TestImportedMLModel:
     @pytest.mark.parametrize("compress_model_definition", [True, False])
     def test_xgb_classifier(self, compress_model_definition):
         # Train model
-        training_data = datasets.make_classification(n_features=5)
-        classifier = XGBClassifier(booster="gbtree")
+        training_data = datasets.make_classification(
+            n_features=5, n_classes=3, n_informative=3
+        )
+        classifier = XGBClassifier(booster="gbtree", objective="multi:softmax")
         classifier.fit(training_data[0], training_data[1])
 
         # Get some test results

--- a/eland/tests/ml/test_imported_ml_model_pytest.py
+++ b/eland/tests/ml/test_imported_ml_model_pytest.py
@@ -226,12 +226,19 @@ class TestImportedMLModel:
 
     @requires_xgboost
     @pytest.mark.parametrize("compress_model_definition", [True, False])
-    def test_xgb_classifier(self, compress_model_definition):
+    @pytest.mark.parametrize("multi_class", [True, False])
+    def test_xgb_classifier(self, compress_model_definition, multi_class):
+        # test both multiple and binary classification
+        if multi_class:
+            training_data = datasets.make_classification(
+                n_features=5, n_classes=3, n_informative=3
+            )
+            classifier = XGBClassifier(booster="gbtree", objective="multi:softmax")
+        else:
+            training_data = datasets.make_classification(n_features=5)
+            classifier = XGBClassifier(booster="gbtree")
+
         # Train model
-        training_data = datasets.make_classification(
-            n_features=5, n_classes=3, n_informative=3
-        )
-        classifier = XGBClassifier(booster="gbtree", objective="multi:softmax")
         classifier.fit(training_data[0], training_data[1])
 
         # Get some test results


### PR DESCRIPTION
This commit adds support for XGBoost multi-class classification model transformations.

XGBoost handles multiclass classification by having `n_classes * n_estimators` trees. 
Then, every `n_classes` tree corresponds to their respective classes

Since Elasticsearch supports multi-valued leaves, we can transform the xgboost format by choosing the
appropriate leaf value index given the tree id.

This commit also fixes a minor model transformation bug where if xgboost actually defined the feature_names instead of the default `f1,...fn` we would blow up. 

closes https://github.com/elastic/eland/issues/242