### PR TITLE
[ML] add LGBMClassifier transform support

### DIFF
--- a/eland/ml/imported_ml_model.py
+++ b/eland/ml/imported_ml_model.py
@@ -39,7 +39,7 @@ if TYPE_CHECKING:
     except ImportError:
         pass
     try:
-        from lightgbm import LGBMRegressor  # type: ignore # noqa: f401
+        from lightgbm import LGBMRegressor, LGBMClassifier  # type: ignore # noqa: f401
     except ImportError:
         pass
 
@@ -72,6 +72,12 @@ class ImportedMLModel(MLModel):
                 - "fair"
                 - "quantile"
                 - "mape"
+        - lightgbm.LGBMClassifier
+            - Categorical fields are expected to already be processed
+            - Only the following objectives are supported
+                - "binary"
+                - "multiclass"
+                - "multiclassova"
         - xgboost.XGBClassifier
             - only the following objectives are supported:
                 - "binary:logistic"
@@ -144,6 +150,7 @@ class ImportedMLModel(MLModel):
             "XGBClassifier",
             "XGBRegressor",
             "LGBMRegressor",
+            "LGBMClassifier",
         ],
         feature_names: List[str],
         classification_labels: Optional[List[str]] = None,

--- a/eland/ml/transformers/__init__.py
+++ b/eland/ml/transformers/__init__.py
@@ -86,12 +86,20 @@ except ImportError:
 try:
     from .lightgbm import (
         LGBMRegressor,
+        LGBMClassifier,
         LGBMForestTransformer,
         LGBMRegressorTransformer,
+        LGBMClassifierTransformer,
         _MODEL_TRANSFORMERS as _LIGHTGBM_MODEL_TRANSFORMERS,
     )
 
-    __all__ += ["LGBMRegressor", "LGBMForestTransformer", "LGBMRegressorTransformer"]
+    __all__ += [
+        "LGBMRegressor",
+        "LGBMClassifier",
+        "LGBMForestTransformer",
+        "LGBMRegressorTransformer",
+        "LGBMClassifierTransformer",
+    ]
     _MODEL_TRANSFORMERS.update(_LIGHTGBM_MODEL_TRANSFORMERS)
 except ImportError:
     pass


### PR DESCRIPTION
Adds support for transforming LGBMClassifier models. 

We are able to support binary, multiclass, and multiclassova. These are the only valid ones for classification. 
But, still restricting to prevent a regression where lightgbm adds a new objective without us knowing.