### PR TITLE
Update xgboost.py get_feature_id

### DIFF
--- a/eland/ml/transformers/xgboost.py
+++ b/eland/ml/transformers/xgboost.py
@@ -58,7 +58,7 @@ class XGBoostForestTransformer(ModelTransformer):
             except ValueError:
                 raise RuntimeError(f"Unable to interpret '{feature_id}'")
         f_id = self._feature_dict.get(feature_id)
-        if f_id:
+        if f_id or f_id == 0:
             return f_id
         else:
             try:


### PR DESCRIPTION
Correction of a code error that raised a RunTimeError when the feature name was a String and the f_id was 0.

Closes #256