### PR TITLE
Switch agg defaults to numeric_only=None

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-*.sh text eol=lf

--- a/eland/dataframe.py
+++ b/eland/dataframe.py
@@ -1381,7 +1381,7 @@ class DataFrame(NDFrame):
         Examples
         --------
         >>> df = ed.DataFrame('localhost', 'flights')
-        >>> df[['DistanceKilometers', 'AvgTicketPrice']].aggregate(['sum', 'min', 'std'],numeric_only=True).astype(int)
+        >>> df[['DistanceKilometers', 'AvgTicketPrice']].aggregate(['sum', 'min', 'std'], numeric_only=True).astype(int)
              DistanceKilometers  AvgTicketPrice
         sum            92616288         8204364
         min                   0             100

--- a/eland/dataframe.py
+++ b/eland/dataframe.py
@@ -1330,7 +1330,7 @@ class DataFrame(NDFrame):
 
     def aggregate(
         self,
-        func: List[str],
+        func: Union[str, List[str]],
         axis: int = 0,
         numeric_only: Optional[bool] = None,
         *args,
@@ -1380,34 +1380,30 @@ class DataFrame(NDFrame):
 
         Examples
         --------
-        >>> df = ed.DataFrame('localhost', 'flights')
-        >>> df[['DistanceKilometers', 'AvgTicketPrice']].aggregate(['sum', 'min', 'std'], numeric_only=True).astype(int)
-             DistanceKilometers  AvgTicketPrice
-        sum            92616288         8204364
-        min                   0             100
-        std                4578             266
+        >>> df = ed.DataFrame('localhost', 'flights').filter(['AvgTicketPrice', 'DistanceKilometers', 'timestamp', 'DestCountry'])
+        >>> df.aggregate(['sum', 'min', 'std'], numeric_only=True).astype(int)
+             AvgTicketPrice  DistanceKilometers
+        sum         8204364            92616288
+        min             100                   0
+        std             266                4578
 
-        >>> df = ed.DataFrame('localhost', 'flights')
-        >>> df[['AvgTicketPrice','timestamp', 'DestCountry']].aggregate(['sum', 'min', 'std'], numeric_only=True)
-             AvgTicketPrice
-        sum    8.204365e+06
-        min    1.000205e+02
-        std    2.664071e+02
+        >>> df.aggregate(['sum', 'min', 'std'], numeric_only=True)
+             AvgTicketPrice  DistanceKilometers
+        sum    8.204365e+06        9.261629e+07
+        min    1.000205e+02        0.000000e+00
+        std    2.664071e+02        4.578614e+03
 
-        >>> df = ed.DataFrame('localhost', 'flights')
-        >>> df[['AvgTicketPrice','timestamp', 'DestCountry']].aggregate(['sum', 'min', 'std'], numeric_only=False)
-             AvgTicketPrice  timestamp  DestCountry
-        sum    8.204365e+06        NaT          NaN
-        min    1.000205e+02 2018-01-01          NaN
-        std    2.664071e+02        NaT          NaN
+        >>> df.aggregate(['sum', 'min', 'std'], numeric_only=False)
+             AvgTicketPrice  DistanceKilometers  timestamp  DestCountry
+        sum    8.204365e+06        9.261629e+07        NaT          NaN
+        min    1.000205e+02        0.000000e+00 2018-01-01          NaN
+        std    2.664071e+02        4.578614e+03        NaT          NaN
 
-        >>> df = ed.DataFrame('localhost', 'flights')
-        >>> df[['AvgTicketPrice','timestamp', 'DestCountry']].aggregate(['sum', 'min', 'std'], numeric_only=None)
-             AvgTicketPrice  timestamp  DestCountry
-        sum    8.204365e+06        NaT          NaN
-        min    1.000205e+02 2018-01-01          NaN
-        std    2.664071e+02        NaT          NaN
-
+        >>> df.aggregate(['sum', 'min', 'std'], numeric_only=None)
+             AvgTicketPrice  DistanceKilometers  timestamp  DestCountry
+        sum    8.204365e+06        9.261629e+07        NaT          NaN
+        min    1.000205e+02        0.000000e+00 2018-01-01          NaN
+        std    2.664071e+02        4.578614e+03        NaT          NaN
         """
         axis = pd.DataFrame._get_axis_number(axis)
 

--- a/eland/dataframe.py
+++ b/eland/dataframe.py
@@ -1380,7 +1380,7 @@ class DataFrame(NDFrame):
 
         Examples
         --------
-        >>> df = ed.DataFrame('localhost', 'flights').filter(['AvgTicketPrice', 'DistanceKilometers', 'timestamp', 'DestCountry'])
+        >>> df = ed.DataFrame('localhost', 'flights', columns=['AvgTicketPrice', 'DistanceKilometers', 'timestamp', 'DestCountry'])
         >>> df.aggregate(['sum', 'min', 'std'], numeric_only=True).astype(int)
              AvgTicketPrice  DistanceKilometers
         sum         8204364            92616288

--- a/eland/field_mappings.py
+++ b/eland/field_mappings.py
@@ -100,7 +100,7 @@ class Field(NamedTuple):
 
         # Cardinality works for all types
         # Numerics and bools work for all aggs
-        # Except "median_absolute_deviation" supports only bool
+        # except "median_absolute_deviation" which doesn't support bool
         if es_agg == "median_absolute_deviation" and self.is_bool:
             return False
         if es_agg == "cardinality" or self.is_numeric or self.is_bool:

--- a/eland/field_mappings.py
+++ b/eland/field_mappings.py
@@ -100,6 +100,9 @@ class Field(NamedTuple):
 
         # Cardinality works for all types
         # Numerics and bools work for all aggs
+        # Except "median_absolute_deviation" supports only bool
+        if es_agg == "median_absolute_deviation" and self.is_bool:
+            return False
         if es_agg == "cardinality" or self.is_numeric or self.is_bool:
             return True
         # Timestamps also work for 'min', 'max' and 'avg'

--- a/eland/field_mappings.py
+++ b/eland/field_mappings.py
@@ -100,7 +100,7 @@ class Field(NamedTuple):
 
         # Cardinality works for all types
         # Numerics and bools work for all aggs
-        # except "median_absolute_deviation" which doesn't support bool
+        # Except "median_absolute_deviation" which doesn't support bool
         if es_agg == "median_absolute_deviation" and self.is_bool:
             return False
         if es_agg == "cardinality" or self.is_numeric or self.is_bool:

--- a/eland/ndframe.py
+++ b/eland/ndframe.py
@@ -172,10 +172,9 @@ class NDFrame(ABC):
         ----------
         numeric_only: {True, False, None} Default is None
             Which datatype to be returned
-            - True: returns all values with float64, NaN/NaT are ignored.
-            - False: returns all values with float64.
-            - None: returns all values with default datatypes, NaN/NaT are ignored.
-
+            - True: Returns all values as float64, NaN/NaT values are removed
+            - None: Returns all values as the same dtype where possible, NaN/NaT are removed
+            - False: Returns all values as the same dtype where possible, NaN/NaT are preserved
         Returns
         -------
         pandas.Series
@@ -190,14 +189,14 @@ class NDFrame(ABC):
         >>> df = ed.DataFrame('localhost', 'flights')
         >>> df.mean()
         AvgTicketPrice                              628.254
-        Cancelled                                      True
+        Cancelled                                  0.128494
         DistanceKilometers                          7092.14
         DistanceMiles                               4406.85
-        FlightDelay                                    True
-        FlightDelayMin                                   47
+        FlightDelay                                0.251168
+        FlightDelayMin                              47.3352
         FlightTimeHour                               8.5188
         FlightTimeMin                               511.128
-        dayOfWeek                                         2
+        dayOfWeek                                   2.83598
         timestamp             2018-01-21 19:20:45.564438232
         dtype: object
 
@@ -244,7 +243,6 @@ class NDFrame(ABC):
         dayOfWeek                                   2.83598
         timestamp             2018-01-21 19:20:45.564438232
         dtype: object
-
         """
         return self._query_compiler.mean(numeric_only=numeric_only)
 
@@ -258,9 +256,9 @@ class NDFrame(ABC):
         ----------
         numeric_only: {True, False, None} Default is None
             Which datatype to be returned
-            - True: returns all values with float64, NaN/NaT are ignored.
-            - False: returns all values with float64.
-            - None: returns all values with default datatypes, NaN/NaT are ignored.
+            - True: Returns all values as float64, NaN/NaT values are removed
+            - None: Returns all values as the same dtype where possible, NaN/NaT are removed
+            - False: Returns all values as the same dtype where possible, NaN/NaT are preserved
 
         Returns
         -------
@@ -276,10 +274,10 @@ class NDFrame(ABC):
         >>> df = ed.DataFrame('localhost', 'flights')
         >>> df.sum()
         AvgTicketPrice        8.20436e+06
-        Cancelled                    True
+        Cancelled                    1678
         DistanceKilometers    9.26163e+07
         DistanceMiles         5.75491e+07
-        FlightDelay                  True
+        FlightDelay                  3280
         FlightDelayMin             618150
         FlightTimeHour             111247
         FlightTimeMin         6.67482e+06
@@ -329,7 +327,6 @@ class NDFrame(ABC):
         dayOfWeek                   37035
         timestamp                     NaT
         dtype: object
-
         """
         return self._query_compiler.sum(numeric_only=numeric_only)
 
@@ -343,9 +340,9 @@ class NDFrame(ABC):
         ----------
         numeric_only: {True, False, None} Default is None
             Which datatype to be returned
-            - True: returns all values with float64, NaN/NaT are ignored.
-            - False: returns all values with float64.
-            - None: returns all values with default datatypes, NaN/NaT are ignored.
+            - True: Returns all values as float64, NaN/NaT values are removed
+            - None: Returns all values as the same dtype where possible, NaN/NaT are removed
+            - False: Returns all values as the same dtype where possible, NaN/NaT are preserved
 
         Returns
         -------
@@ -387,33 +384,33 @@ class NDFrame(ABC):
 
         >>> df = ed.DataFrame('localhost', 'flights')
         >>> df.min(numeric_only=False) # doctest: +SKIP
-        AvgTicketPrice                100.021
-        Cancelled                       False
-        Carrier                           NaN
-        Dest                              NaN
-        DestAirportID                     NaN
-        DestCityName                      NaN
-        DestCountry                       NaN
-        DestLocation                      NaN
-        DestRegion                        NaN
-        DestWeather                       NaN
-        DistanceKilometers                  0
-        DistanceMiles                       0
-        FlightDelay                     False
-        FlightDelayMin                      0
-        FlightDelayType                   NaN
-        FlightNum                         NaN
-        FlightTimeHour                      0
-        FlightTimeMin                       0
-        Origin                            NaN
-        OriginAirportID                   NaN
-        OriginCityName                    NaN
-        OriginCountry                     NaN
-        OriginLocation                    NaN
-        OriginRegion                      NaN
-        OriginWeather                     NaN
-        dayOfWeek                           0
-        timestamp         2018-01-01 00:00:00
+        AvgTicketPrice                    100.021
+        Cancelled                           False
+        Carrier                               NaN
+        Dest                                  NaN
+        DestAirportID                         NaN
+        DestCityName                          NaN
+        DestCountry                           NaN
+        DestLocation                          NaN
+        DestRegion                            NaN
+        DestWeather                           NaN
+        DistanceKilometers                      0
+        DistanceMiles                           0
+        FlightDelay                         False
+        FlightDelayMin                          0
+        FlightDelayType                       NaN
+        FlightNum                             NaN
+        FlightTimeHour                          0
+        FlightTimeMin                           0
+        Origin                                NaN
+        OriginAirportID                       NaN
+        OriginCityName                        NaN
+        OriginCountry                         NaN
+        OriginLocation                        NaN
+        OriginRegion                          NaN
+        OriginWeather                         NaN
+        dayOfWeek                               0
+        timestamp             2018-01-01 00:00:00
         dtype: object
         """
         return self._query_compiler.min(numeric_only=numeric_only)
@@ -426,9 +423,9 @@ class NDFrame(ABC):
         ----------
         numeric_only: {True, False, None} Default is None
             Which datatype to be returned
-            - True: returns all values with float64, NaN/NaT are ignored.
-            - False: returns all values with float64.
-            - None: returns all values with default datatypes, NaN/NaT are ignored.
+            - True: Returns all values as float64, NaN/NaT values are removed
+            - None: Returns all values as the same dtype where possible, NaN/NaT are removed
+            - False: Returns all values as the same dtype where possible, NaN/NaT are preserved
 
         Returns
         -------
@@ -444,14 +441,14 @@ class NDFrame(ABC):
         >>> df = ed.DataFrame('localhost', 'flights')
         >>> df.var()
         AvgTicketPrice            70964.6
-        Cancelled                    True
+        Cancelled                0.111987
         DistanceKilometers    2.09613e+07
         DistanceMiles          8.0932e+06
-        FlightDelay                  True
-        FlightDelayMin               9359
+        FlightDelay               0.18809
+        FlightDelayMin            9359.57
         FlightTimeHour            31.1266
         FlightTimeMin              112056
-        dayOfWeek                       3
+        dayOfWeek                 3.76128
         dtype: object
 
         >>> df = ed.DataFrame('localhost', 'flights')
@@ -470,7 +467,7 @@ class NDFrame(ABC):
         >>> df = ed.DataFrame('localhost', 'flights')
         >>> df.var(numeric_only=False) # doctest: +SKIP
         AvgTicketPrice            70964.6
-        Cancelled                    True
+        Cancelled                0.111987
         Carrier                       NaN
         Dest                          NaN
         DestAirportID                 NaN
@@ -481,8 +478,8 @@ class NDFrame(ABC):
         DestWeather                   NaN
         DistanceKilometers    2.09613e+07
         DistanceMiles          8.0932e+06
-        FlightDelay                  True
-        FlightDelayMin               9359
+        FlightDelay               0.18809
+        FlightDelayMin            9359.57
         FlightDelayType               NaN
         FlightNum                     NaN
         FlightTimeHour            31.1266
@@ -494,7 +491,7 @@ class NDFrame(ABC):
         OriginLocation                NaN
         OriginRegion                  NaN
         OriginWeather                 NaN
-        dayOfWeek                       3
+        dayOfWeek                 3.76128
         timestamp                     NaT
         dtype: object
         """
@@ -508,9 +505,9 @@ class NDFrame(ABC):
         ----------
         numeric_only: {True, False, None} Default is None
             Which datatype to be returned
-            - True: returns all values with float64, NaN/NaT are ignored.
-            - False: returns all values with float64.
-            - None: returns all values with default datatypes, NaN/NaT are ignored.
+            - True: Returns all values as float64, NaN/NaT values are removed
+            - None: Returns all values as the same dtype where possible, NaN/NaT are removed
+            - False: Returns all values as the same dtype where possible, NaN/NaT are preserved
 
         Returns
         -------
@@ -525,15 +522,15 @@ class NDFrame(ABC):
         --------
         >>> df = ed.DataFrame('localhost', 'flights')
         >>> df.std()
-        AvgTicketPrice        266.407
-        Cancelled                True
-        DistanceKilometers    4578.61
-        DistanceMiles         2845.02
-        FlightDelay              True
-        FlightDelayMin             96
-        FlightTimeHour        5.57945
-        FlightTimeMin         334.767
-        dayOfWeek                   1
+        AvgTicketPrice         266.407
+        Cancelled             0.334664
+        DistanceKilometers     4578.61
+        DistanceMiles          2845.02
+        FlightDelay           0.433718
+        FlightDelayMin         96.7504
+        FlightTimeHour         5.57945
+        FlightTimeMin          334.767
+        dayOfWeek              1.93951
         dtype: object
 
         >>> df = ed.DataFrame('localhost', 'flights')
@@ -550,7 +547,7 @@ class NDFrame(ABC):
         dtype: float64
 
         >>> df = ed.DataFrame('localhost', 'flights')
-        >>> df.std(numeric_only=False) # doctest: +SKIP
+        >>> df.std(numeric_only=False)  # doctest: +SKIP
         AvgTicketPrice         266.407
         Cancelled             0.334664
         Carrier                    NaN
@@ -579,7 +576,6 @@ class NDFrame(ABC):
         dayOfWeek              1.93951
         timestamp                  NaT
         dtype: object
-
         """
         return self._query_compiler.std(numeric_only=numeric_only)
 
@@ -591,9 +587,9 @@ class NDFrame(ABC):
         ----------
         numeric_only: {True, False, None} Default is None
             Which datatype to be returned
-            - True: returns all values with float64, NaN/NaT are ignored.
-            - False: returns all values with float64.
-            - None: returns all values with default datatypes, NaN/NaT are ignored.
+            - True: Returns all values as float64, NaN/NaT values are removed
+            - None: Returns all values as the same dtype where possible, NaN/NaT are removed
+            - False: Returns all values as the same dtype where possible, NaN/NaT are preserved
 
         Returns
         -------
@@ -615,27 +611,27 @@ class NDFrame(ABC):
         FlightDelay                                   False
         FlightDelayMin                                    0
         FlightTimeHour                              8.38582
-        FlightTimeMin                               502.987
+        FlightTimeMin                               503.149
         dayOfWeek                                         3
-        timestamp             2018-01-21 23:44:29.394281982
+        timestamp             2018-01-21 23:25:13.113169922
         dtype: object
 
         >>> df = ed.DataFrame('localhost', 'flights')
         >>> df.median(numeric_only=True) # doctest: +SKIP
-        AvgTicketPrice         640.424738
+        AvgTicketPrice         640.387285
         Cancelled                0.000000
-        DistanceKilometers    7612.145848
-        DistanceMiles         4728.752630
+        DistanceKilometers    7612.072403
+        DistanceMiles         4729.922470
         FlightDelay              0.000000
         FlightDelayMin           0.000000
-        FlightTimeHour           8.383711
-        FlightTimeMin          502.999492
+        FlightTimeHour           8.385816
+        FlightTimeMin          503.148975
         dayOfWeek                3.000000
         dtype: float64
 
         >>> df = ed.DataFrame('localhost', 'flights')
         >>> df.median(numeric_only=False) # doctest: +SKIP
-        AvgTicketPrice                              640.425
+        AvgTicketPrice                              640.387
         Cancelled                                     False
         Carrier                                         NaN
         Dest                                            NaN
@@ -645,14 +641,14 @@ class NDFrame(ABC):
         DestLocation                                    NaN
         DestRegion                                      NaN
         DestWeather                                     NaN
-        DistanceKilometers                          7612.15
-        DistanceMiles                               4728.75
+        DistanceKilometers                          7612.07
+        DistanceMiles                               4729.92
         FlightDelay                                   False
         FlightDelayMin                                    0
         FlightDelayType                                 NaN
         FlightNum                                       NaN
-        FlightTimeHour                              8.38457
-        FlightTimeMin                               503.074
+        FlightTimeHour                              8.38582
+        FlightTimeMin                               503.149
         Origin                                          NaN
         OriginAirportID                                 NaN
         OriginCityName                                  NaN
@@ -661,9 +657,8 @@ class NDFrame(ABC):
         OriginRegion                                    NaN
         OriginWeather                                   NaN
         dayOfWeek                                         3
-        timestamp             2018-01-21 23:33:14.554215332
+        timestamp             2018-01-22 00:43:09.223130126
         dtype: object
-
         """
         return self._query_compiler.median(numeric_only=numeric_only)
 
@@ -677,9 +672,9 @@ class NDFrame(ABC):
         ----------
         numeric_only: {True, False, None} Default is None
             Which datatype to be returned
-            - True: returns all values with float64, NaN/NaT are ignored.
-            - False: returns all values with float64.
-            - None: returns all values with default datatypes, NaN/NaT are ignored.
+            - True: Returns all values as float64, NaN/NaT values are removed
+            - None: Returns all values as the same dtype where possible, NaN/NaT are removed
+            - False: Returns all values as the same dtype where possible, NaN/NaT are preserved
 
         Returns
         -------
@@ -721,33 +716,33 @@ class NDFrame(ABC):
 
         >>> df = ed.DataFrame('localhost', 'flights')
         >>> df.max(numeric_only=False) # doctest: +SKIP
-        AvgTicketPrice                1199.73
-        Cancelled                        True
-        Carrier                           NaN
-        Dest                              NaN
-        DestAirportID                     NaN
-        DestCityName                      NaN
-        DestCountry                       NaN
-        DestLocation                      NaN
-        DestRegion                        NaN
-        DestWeather                       NaN
-        DistanceKilometers            19881.5
-        DistanceMiles                 12353.8
-        FlightDelay                      True
-        FlightDelayMin                    360
-        FlightDelayType                   NaN
-        FlightNum                         NaN
-        FlightTimeHour                 31.715
-        FlightTimeMin                  1902.9
-        Origin                            NaN
-        OriginAirportID                   NaN
-        OriginCityName                    NaN
-        OriginCountry                     NaN
-        OriginLocation                    NaN
-        OriginRegion                      NaN
-        OriginWeather                     NaN
-        dayOfWeek                           6
-        timestamp         2018-02-11 23:50:12
+        AvgTicketPrice                    1199.73
+        Cancelled                            True
+        Carrier                               NaN
+        Dest                                  NaN
+        DestAirportID                         NaN
+        DestCityName                          NaN
+        DestCountry                           NaN
+        DestLocation                          NaN
+        DestRegion                            NaN
+        DestWeather                           NaN
+        DistanceKilometers                19881.5
+        DistanceMiles                     12353.8
+        FlightDelay                          True
+        FlightDelayMin                        360
+        FlightDelayType                       NaN
+        FlightNum                             NaN
+        FlightTimeHour                     31.715
+        FlightTimeMin                      1902.9
+        Origin                                NaN
+        OriginAirportID                       NaN
+        OriginCityName                        NaN
+        OriginCountry                         NaN
+        OriginLocation                        NaN
+        OriginRegion                          NaN
+        OriginWeather                         NaN
+        dayOfWeek                               6
+        timestamp             2018-02-11 23:50:12
         dtype: object
         """
         return self._query_compiler.max(numeric_only=numeric_only)
@@ -815,16 +810,56 @@ class NDFrame(ABC):
         --------
         >>> df = ed.DataFrame('localhost', 'flights')
         >>> df.mad() # doctest: +SKIP
-        AvgTicketPrice         213.368709
-        Cancelled                0.000000
-        DistanceKilometers    2946.168236
-        DistanceMiles         1830.987236
-        FlightDelay              0.000000
+        AvgTicketPrice         213.443470
+        DistanceKilometers    2948.631194
+        DistanceMiles         1830.663947
         FlightDelayMin           0.000000
-        FlightTimeHour           3.819435
-        FlightTimeMin          229.142297
+        FlightTimeHour           3.819254
+        FlightTimeMin          229.158256
         dayOfWeek                2.000000
         dtype: float64
+
+        >>> df = ed.DataFrame('localhost', 'flights')
+        >>> df.mad(numeric_only=True) # doctest: +SKIP
+        AvgTicketPrice         213.368709
+        DistanceKilometers    2946.168236
+        DistanceMiles         1829.899362
+        FlightDelayMin           0.000000
+        FlightTimeHour           3.819654
+        FlightTimeMin          229.176708
+        dayOfWeek                2.000000
+        dtype: float64
+
+        >>> df = ed.DataFrame('localhost', 'flights')
+        >>> df.mad(numeric_only=False) # doctest: +SKIP
+        AvgTicketPrice        213.451
+        Cancelled                 NaN
+        Carrier                   NaN
+        Dest                      NaN
+        DestAirportID             NaN
+        DestCityName              NaN
+        DestCountry               NaN
+        DestLocation              NaN
+        DestRegion                NaN
+        DestWeather               NaN
+        DistanceKilometers    2946.98
+        DistanceMiles         1830.66
+        FlightDelay               NaN
+        FlightDelayMin              0
+        FlightDelayType           NaN
+        FlightNum                 NaN
+        FlightTimeHour        3.81919
+        FlightTimeMin         229.177
+        Origin                    NaN
+        OriginAirportID           NaN
+        OriginCityName            NaN
+        OriginCountry             NaN
+        OriginLocation            NaN
+        OriginRegion              NaN
+        OriginWeather             NaN
+        dayOfWeek                   2
+        timestamp                 NaT
+        dtype: object
         """
         return self._query_compiler.mad(numeric_only=numeric_only)
 

--- a/eland/ndframe.py
+++ b/eland/ndframe.py
@@ -17,7 +17,7 @@
 
 import sys
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Tuple
+from typing import TYPE_CHECKING, Tuple, Optional
 import pandas as pd
 from eland.query_compiler import QueryCompiler
 
@@ -162,11 +162,19 @@ class NDFrame(ABC):
     def _es_info(self, buf):
         self._query_compiler.es_info(buf)
 
-    def mean(self, numeric_only: bool = True) -> pd.Series:
+    def mean(self, numeric_only: Optional[bool] = None) -> pd.Series:
         """
         Return mean value for each numeric column
 
         TODO - implement remainder of pandas arguments, currently non-numerics are not supported
+
+        Parameters
+        ----------
+        numeric_only: {True, False, None} Default is None
+            Which datatype to be returned
+            - True: returns all values with float64, NaN/NaT are ignored.
+            - False: returns all values with float64.
+            - None: returns all values with default datatypes, NaN/NaT are ignored.
 
         Returns
         -------
@@ -181,6 +189,20 @@ class NDFrame(ABC):
         --------
         >>> df = ed.DataFrame('localhost', 'flights')
         >>> df.mean()
+        AvgTicketPrice                              628.254
+        Cancelled                                      True
+        DistanceKilometers                          7092.14
+        DistanceMiles                               4406.85
+        FlightDelay                                    True
+        FlightDelayMin                                   47
+        FlightTimeHour                               8.5188
+        FlightTimeMin                               511.128
+        dayOfWeek                                         2
+        timestamp             2018-01-21 19:20:45.564438232
+        dtype: object
+
+        >>> df = ed.DataFrame('localhost', 'flights')
+        >>> df.mean(numeric_only=True)
         AvgTicketPrice         628.253689
         Cancelled                0.128494
         DistanceKilometers    7092.142457
@@ -191,14 +213,54 @@ class NDFrame(ABC):
         FlightTimeMin          511.127842
         dayOfWeek                2.835975
         dtype: float64
+
+        >>> df = ed.DataFrame('localhost', 'flights')
+        >>> df.mean(numeric_only=False) # doctest: +SKIP
+        AvgTicketPrice                              628.254
+        Cancelled                                  0.128494
+        Carrier                                         NaN
+        Dest                                            NaN
+        DestAirportID                                   NaN
+        DestCityName                                    NaN
+        DestCountry                                     NaN
+        DestLocation                                    NaN
+        DestRegion                                      NaN
+        DestWeather                                     NaN
+        DistanceKilometers                          7092.14
+        DistanceMiles                               4406.85
+        FlightDelay                                0.251168
+        FlightDelayMin                              47.3352
+        FlightDelayType                                 NaN
+        FlightNum                                       NaN
+        FlightTimeHour                               8.5188
+        FlightTimeMin                               511.128
+        Origin                                          NaN
+        OriginAirportID                                 NaN
+        OriginCityName                                  NaN
+        OriginCountry                                   NaN
+        OriginLocation                                  NaN
+        OriginRegion                                    NaN
+        OriginWeather                                   NaN
+        dayOfWeek                                   2.83598
+        timestamp             2018-01-21 19:20:45.564438232
+        dtype: object
+
         """
         return self._query_compiler.mean(numeric_only=numeric_only)
 
-    def sum(self, numeric_only: bool = True) -> pd.Series:
+    def sum(self, numeric_only: Optional[bool] = None) -> pd.Series:
         """
         Return sum for each numeric column
 
         TODO - implement remainder of pandas arguments, currently non-numerics are not supported
+
+        Parameters
+        ----------
+        numeric_only: {True, False, None} Default is None
+            Which datatype to be returned
+            - True: returns all values with float64, NaN/NaT are ignored.
+            - False: returns all values with float64.
+            - None: returns all values with default datatypes, NaN/NaT are ignored.
 
         Returns
         -------
@@ -213,6 +275,19 @@ class NDFrame(ABC):
         --------
         >>> df = ed.DataFrame('localhost', 'flights')
         >>> df.sum()
+        AvgTicketPrice        8.20436e+06
+        Cancelled                    True
+        DistanceKilometers    9.26163e+07
+        DistanceMiles         5.75491e+07
+        FlightDelay                  True
+        FlightDelayMin             618150
+        FlightTimeHour             111247
+        FlightTimeMin         6.67482e+06
+        dayOfWeek                   37035
+        dtype: object
+
+        >>> df = ed.DataFrame('localhost', 'flights')
+        >>> df.sum(numeric_only=True)
         AvgTicketPrice        8.204365e+06
         Cancelled             1.678000e+03
         DistanceKilometers    9.261629e+07
@@ -223,14 +298,54 @@ class NDFrame(ABC):
         FlightTimeMin         6.674818e+06
         dayOfWeek             3.703500e+04
         dtype: float64
+
+        >>> df = ed.DataFrame('localhost', 'flights')
+        >>> df.sum(numeric_only=False) # doctest: +SKIP
+        AvgTicketPrice        8.20436e+06
+        Cancelled                    1678
+        Carrier                       NaN
+        Dest                          NaN
+        DestAirportID                 NaN
+        DestCityName                  NaN
+        DestCountry                   NaN
+        DestLocation                  NaN
+        DestRegion                    NaN
+        DestWeather                   NaN
+        DistanceKilometers    9.26163e+07
+        DistanceMiles         5.75491e+07
+        FlightDelay                  3280
+        FlightDelayMin             618150
+        FlightDelayType               NaN
+        FlightNum                     NaN
+        FlightTimeHour             111247
+        FlightTimeMin         6.67482e+06
+        Origin                        NaN
+        OriginAirportID               NaN
+        OriginCityName                NaN
+        OriginCountry                 NaN
+        OriginLocation                NaN
+        OriginRegion                  NaN
+        OriginWeather                 NaN
+        dayOfWeek                   37035
+        timestamp                     NaT
+        dtype: object
+
         """
         return self._query_compiler.sum(numeric_only=numeric_only)
 
-    def min(self, numeric_only: bool = True) -> pd.Series:
+    def min(self, numeric_only: Optional[bool] = None) -> pd.Series:
         """
         Return the minimum value for each numeric column
 
         TODO - implement remainder of pandas arguments, currently non-numerics are not supported
+
+        Parameters
+        ----------
+        numeric_only: {True, False, None} Default is None
+            Which datatype to be returned
+            - True: returns all values with float64, NaN/NaT are ignored.
+            - False: returns all values with float64.
+            - None: returns all values with default datatypes, NaN/NaT are ignored.
 
         Returns
         -------
@@ -245,22 +360,75 @@ class NDFrame(ABC):
         --------
         >>> df = ed.DataFrame('localhost', 'flights')
         >>> df.min()
-        AvgTicketPrice        100.021
-        Cancelled               False
-        DistanceKilometers          0
-        DistanceMiles               0
-        FlightDelay             False
-        FlightDelayMin              0
-        FlightTimeHour              0
-        FlightTimeMin               0
-        dayOfWeek                   0
+        AvgTicketPrice                    100.021
+        Cancelled                           False
+        DistanceKilometers                      0
+        DistanceMiles                           0
+        FlightDelay                         False
+        FlightDelayMin                          0
+        FlightTimeHour                          0
+        FlightTimeMin                           0
+        dayOfWeek                               0
+        timestamp             2018-01-01 00:00:00
+        dtype: object
+
+        >>> df = ed.DataFrame('localhost', 'flights')
+        >>> df.min(numeric_only=True)
+        AvgTicketPrice        100.020531
+        Cancelled               0.000000
+        DistanceKilometers      0.000000
+        DistanceMiles           0.000000
+        FlightDelay             0.000000
+        FlightDelayMin          0.000000
+        FlightTimeHour          0.000000
+        FlightTimeMin           0.000000
+        dayOfWeek               0.000000
+        dtype: float64
+
+        >>> df = ed.DataFrame('localhost', 'flights')
+        >>> df.min(numeric_only=False) # doctest: +SKIP
+        AvgTicketPrice                100.021
+        Cancelled                       False
+        Carrier                           NaN
+        Dest                              NaN
+        DestAirportID                     NaN
+        DestCityName                      NaN
+        DestCountry                       NaN
+        DestLocation                      NaN
+        DestRegion                        NaN
+        DestWeather                       NaN
+        DistanceKilometers                  0
+        DistanceMiles                       0
+        FlightDelay                     False
+        FlightDelayMin                      0
+        FlightDelayType                   NaN
+        FlightNum                         NaN
+        FlightTimeHour                      0
+        FlightTimeMin                       0
+        Origin                            NaN
+        OriginAirportID                   NaN
+        OriginCityName                    NaN
+        OriginCountry                     NaN
+        OriginLocation                    NaN
+        OriginRegion                      NaN
+        OriginWeather                     NaN
+        dayOfWeek                           0
+        timestamp         2018-01-01 00:00:00
         dtype: object
         """
         return self._query_compiler.min(numeric_only=numeric_only)
 
-    def var(self, numeric_only: bool = True) -> pd.Series:
+    def var(self, numeric_only: Optional[bool] = None) -> pd.Series:
         """
         Return variance for each numeric column
+
+        Parameters
+        ----------
+        numeric_only: {True, False, None} Default is None
+            Which datatype to be returned
+            - True: returns all values with float64, NaN/NaT are ignored.
+            - False: returns all values with float64.
+            - None: returns all values with default datatypes, NaN/NaT are ignored.
 
         Returns
         -------
@@ -274,23 +442,75 @@ class NDFrame(ABC):
         Examples
         --------
         >>> df = ed.DataFrame('localhost', 'flights')
-        >>> df.var() # doctest: +SKIP
-        AvgTicketPrice        7.096185e+04
-        Cancelled             1.119831e-01
-        DistanceKilometers    2.096049e+07
-        DistanceMiles         8.092892e+06
-        FlightDelay           1.880825e-01
-        FlightDelayMin        9.359209e+03
-        FlightTimeHour        3.112545e+01
-        FlightTimeMin         1.120516e+05
-        dayOfWeek             3.761135e+00
+        >>> df.var()
+        AvgTicketPrice            70964.6
+        Cancelled                    True
+        DistanceKilometers    2.09613e+07
+        DistanceMiles          8.0932e+06
+        FlightDelay                  True
+        FlightDelayMin               9359
+        FlightTimeHour            31.1266
+        FlightTimeMin              112056
+        dayOfWeek                       3
+        dtype: object
+
+        >>> df = ed.DataFrame('localhost', 'flights')
+        >>> df.var(numeric_only=True)
+        AvgTicketPrice        7.096457e+04
+        Cancelled             1.119874e-01
+        DistanceKilometers    2.096130e+07
+        DistanceMiles         8.093202e+06
+        FlightDelay           1.880897e-01
+        FlightDelayMin        9.359568e+03
+        FlightTimeHour        3.112664e+01
+        FlightTimeMin         1.120559e+05
+        dayOfWeek             3.761279e+00
         dtype: float64
+
+        >>> df = ed.DataFrame('localhost', 'flights')
+        >>> df.var(numeric_only=False) # doctest: +SKIP
+        AvgTicketPrice            70964.6
+        Cancelled                    True
+        Carrier                       NaN
+        Dest                          NaN
+        DestAirportID                 NaN
+        DestCityName                  NaN
+        DestCountry                   NaN
+        DestLocation                  NaN
+        DestRegion                    NaN
+        DestWeather                   NaN
+        DistanceKilometers    2.09613e+07
+        DistanceMiles          8.0932e+06
+        FlightDelay                  True
+        FlightDelayMin               9359
+        FlightDelayType               NaN
+        FlightNum                     NaN
+        FlightTimeHour            31.1266
+        FlightTimeMin              112056
+        Origin                        NaN
+        OriginAirportID               NaN
+        OriginCityName                NaN
+        OriginCountry                 NaN
+        OriginLocation                NaN
+        OriginRegion                  NaN
+        OriginWeather                 NaN
+        dayOfWeek                       3
+        timestamp                     NaT
+        dtype: object
         """
         return self._query_compiler.var(numeric_only=numeric_only)
 
-    def std(self, numeric_only: bool = True) -> pd.Series:
+    def std(self, numeric_only: Optional[bool] = None) -> pd.Series:
         """
         Return standard deviation for each numeric column
+
+        Parameters
+        ----------
+        numeric_only: {True, False, None} Default is None
+            Which datatype to be returned
+            - True: returns all values with float64, NaN/NaT are ignored.
+            - False: returns all values with float64.
+            - None: returns all values with default datatypes, NaN/NaT are ignored.
 
         Returns
         -------
@@ -304,23 +524,76 @@ class NDFrame(ABC):
         Examples
         --------
         >>> df = ed.DataFrame('localhost', 'flights')
-        >>> df.std() # doctest: +SKIP
-        AvgTicketPrice         266.386661
-        Cancelled                0.334639
-        DistanceKilometers    4578.263193
-        DistanceMiles         2844.800855
-        FlightDelay              0.433685
-        FlightDelayMin          96.743006
-        FlightTimeHour           5.579019
-        FlightTimeMin          334.741135
-        dayOfWeek                1.939365
+        >>> df.std()
+        AvgTicketPrice        266.407
+        Cancelled                True
+        DistanceKilometers    4578.61
+        DistanceMiles         2845.02
+        FlightDelay              True
+        FlightDelayMin             96
+        FlightTimeHour        5.57945
+        FlightTimeMin         334.767
+        dayOfWeek                   1
+        dtype: object
+
+        >>> df = ed.DataFrame('localhost', 'flights')
+        >>> df.std(numeric_only=True)
+        AvgTicketPrice         266.407061
+        Cancelled                0.334664
+        DistanceKilometers    4578.613803
+        DistanceMiles         2845.018714
+        FlightDelay              0.433718
+        FlightDelayMin          96.750415
+        FlightTimeHour           5.579446
+        FlightTimeMin          334.766770
+        dayOfWeek                1.939513
         dtype: float64
+
+        >>> df = ed.DataFrame('localhost', 'flights')
+        >>> df.std(numeric_only=False) # doctest: +SKIP
+        AvgTicketPrice         266.407
+        Cancelled             0.334664
+        Carrier                    NaN
+        Dest                       NaN
+        DestAirportID              NaN
+        DestCityName               NaN
+        DestCountry                NaN
+        DestLocation               NaN
+        DestRegion                 NaN
+        DestWeather                NaN
+        DistanceKilometers     4578.61
+        DistanceMiles          2845.02
+        FlightDelay           0.433718
+        FlightDelayMin         96.7504
+        FlightDelayType            NaN
+        FlightNum                  NaN
+        FlightTimeHour         5.57945
+        FlightTimeMin          334.767
+        Origin                     NaN
+        OriginAirportID            NaN
+        OriginCityName             NaN
+        OriginCountry              NaN
+        OriginLocation             NaN
+        OriginRegion               NaN
+        OriginWeather              NaN
+        dayOfWeek              1.93951
+        timestamp                  NaT
+        dtype: object
+
         """
         return self._query_compiler.std(numeric_only=numeric_only)
 
-    def median(self, numeric_only: bool = True) -> pd.Series:
+    def median(self, numeric_only: Optional[bool] = None) -> pd.Series:
         """
         Return the median value for each numeric column
+
+        Parameters
+        ----------
+        numeric_only: {True, False, None} Default is None
+            Which datatype to be returned
+            - True: returns all values with float64, NaN/NaT are ignored.
+            - False: returns all values with float64.
+            - None: returns all values with default datatypes, NaN/NaT are ignored.
 
         Returns
         -------
@@ -335,24 +608,78 @@ class NDFrame(ABC):
         --------
         >>> df = ed.DataFrame('localhost', 'flights')
         >>> df.median() # doctest: +SKIP
-        AvgTicketPrice         640.387285
+        AvgTicketPrice                              640.387
+        Cancelled                                     False
+        DistanceKilometers                          7612.07
+        DistanceMiles                               4729.92
+        FlightDelay                                   False
+        FlightDelayMin                                    0
+        FlightTimeHour                              8.38582
+        FlightTimeMin                               502.987
+        dayOfWeek                                         3
+        timestamp             2018-01-21 23:44:29.394281982
+        dtype: object
+
+        >>> df = ed.DataFrame('localhost', 'flights')
+        >>> df.median(numeric_only=True) # doctest: +SKIP
+        AvgTicketPrice         640.424738
         Cancelled                0.000000
-        DistanceKilometers    7612.072403
-        DistanceMiles         4729.922470
+        DistanceKilometers    7612.145848
+        DistanceMiles         4728.752630
         FlightDelay              0.000000
         FlightDelayMin           0.000000
-        FlightTimeHour           8.383113
-        FlightTimeMin          503.148975
+        FlightTimeHour           8.383711
+        FlightTimeMin          502.999492
         dayOfWeek                3.000000
         dtype: float64
+
+        >>> df = ed.DataFrame('localhost', 'flights')
+        >>> df.median(numeric_only=False) # doctest: +SKIP
+        AvgTicketPrice                              640.425
+        Cancelled                                     False
+        Carrier                                         NaN
+        Dest                                            NaN
+        DestAirportID                                   NaN
+        DestCityName                                    NaN
+        DestCountry                                     NaN
+        DestLocation                                    NaN
+        DestRegion                                      NaN
+        DestWeather                                     NaN
+        DistanceKilometers                          7612.15
+        DistanceMiles                               4728.75
+        FlightDelay                                   False
+        FlightDelayMin                                    0
+        FlightDelayType                                 NaN
+        FlightNum                                       NaN
+        FlightTimeHour                              8.38457
+        FlightTimeMin                               503.074
+        Origin                                          NaN
+        OriginAirportID                                 NaN
+        OriginCityName                                  NaN
+        OriginCountry                                   NaN
+        OriginLocation                                  NaN
+        OriginRegion                                    NaN
+        OriginWeather                                   NaN
+        dayOfWeek                                         3
+        timestamp             2018-01-21 23:33:14.554215332
+        dtype: object
+
         """
         return self._query_compiler.median(numeric_only=numeric_only)
 
-    def max(self, numeric_only: bool = True) -> pd.Series:
+    def max(self, numeric_only: Optional[bool] = None) -> pd.Series:
         """
         Return the maximum value for each numeric column
 
         TODO - implement remainder of pandas arguments, currently non-numerics are not supported
+
+        Parameters
+        ----------
+        numeric_only: {True, False, None} Default is None
+            Which datatype to be returned
+            - True: returns all values with float64, NaN/NaT are ignored.
+            - False: returns all values with float64.
+            - None: returns all values with default datatypes, NaN/NaT are ignored.
 
         Returns
         -------
@@ -367,15 +694,60 @@ class NDFrame(ABC):
         --------
         >>> df = ed.DataFrame('localhost', 'flights')
         >>> df.max()
-        AvgTicketPrice        1199.73
-        Cancelled                True
-        DistanceKilometers    19881.5
-        DistanceMiles         12353.8
-        FlightDelay              True
-        FlightDelayMin            360
-        FlightTimeHour         31.715
-        FlightTimeMin          1902.9
-        dayOfWeek                   6
+        AvgTicketPrice                    1199.73
+        Cancelled                            True
+        DistanceKilometers                19881.5
+        DistanceMiles                     12353.8
+        FlightDelay                          True
+        FlightDelayMin                        360
+        FlightTimeHour                     31.715
+        FlightTimeMin                      1902.9
+        dayOfWeek                               6
+        timestamp             2018-02-11 23:50:12
+        dtype: object
+
+        >>> df = ed.DataFrame('localhost', 'flights')
+        >>> df.max(numeric_only=True)
+        AvgTicketPrice         1199.729004
+        Cancelled                 1.000000
+        DistanceKilometers    19881.482422
+        DistanceMiles         12353.780273
+        FlightDelay               1.000000
+        FlightDelayMin          360.000000
+        FlightTimeHour           31.715034
+        FlightTimeMin          1902.901978
+        dayOfWeek                 6.000000
+        dtype: float64
+
+        >>> df = ed.DataFrame('localhost', 'flights')
+        >>> df.max(numeric_only=False) # doctest: +SKIP
+        AvgTicketPrice                1199.73
+        Cancelled                        True
+        Carrier                           NaN
+        Dest                              NaN
+        DestAirportID                     NaN
+        DestCityName                      NaN
+        DestCountry                       NaN
+        DestLocation                      NaN
+        DestRegion                        NaN
+        DestWeather                       NaN
+        DistanceKilometers            19881.5
+        DistanceMiles                 12353.8
+        FlightDelay                      True
+        FlightDelayMin                    360
+        FlightDelayType                   NaN
+        FlightNum                         NaN
+        FlightTimeHour                 31.715
+        FlightTimeMin                  1902.9
+        Origin                            NaN
+        OriginAirportID                   NaN
+        OriginCityName                    NaN
+        OriginCountry                     NaN
+        OriginLocation                    NaN
+        OriginRegion                      NaN
+        OriginWeather                     NaN
+        dayOfWeek                           6
+        timestamp         2018-02-11 23:50:12
         dtype: object
         """
         return self._query_compiler.max(numeric_only=numeric_only)

--- a/eland/ndframe.py
+++ b/eland/ndframe.py
@@ -186,62 +186,26 @@ class NDFrame(ABC):
 
         Examples
         --------
-        >>> df = ed.DataFrame('localhost', 'flights')
+        >>> df = ed.DataFrame('localhost', 'flights').filter(["AvgTicketPrice", "Cancelled", "dayOfWeek", "timestamp", "DestCountry"])
         >>> df.mean()
-        AvgTicketPrice                              628.254
-        Cancelled                                  0.128494
-        DistanceKilometers                          7092.14
-        DistanceMiles                               4406.85
-        FlightDelay                                0.251168
-        FlightDelayMin                              47.3352
-        FlightTimeHour                               8.5188
-        FlightTimeMin                               511.128
-        dayOfWeek                                   2.83598
-        timestamp             2018-01-21 19:20:45.564438232
+        AvgTicketPrice                          628.254
+        Cancelled                              0.128494
+        dayOfWeek                               2.83598
+        timestamp         2018-01-21 19:20:45.564438232
         dtype: object
 
-        >>> df = ed.DataFrame('localhost', 'flights')
         >>> df.mean(numeric_only=True)
-        AvgTicketPrice         628.253689
-        Cancelled                0.128494
-        DistanceKilometers    7092.142457
-        DistanceMiles         4406.853010
-        FlightDelay              0.251168
-        FlightDelayMin          47.335171
-        FlightTimeHour           8.518797
-        FlightTimeMin          511.127842
-        dayOfWeek                2.835975
+        AvgTicketPrice    628.253689
+        Cancelled           0.128494
+        dayOfWeek           2.835975
         dtype: float64
 
-        >>> df = ed.DataFrame('localhost', 'flights')
-        >>> df.mean(numeric_only=False) # doctest: +SKIP
-        AvgTicketPrice                              628.254
-        Cancelled                                  0.128494
-        Carrier                                         NaN
-        Dest                                            NaN
-        DestAirportID                                   NaN
-        DestCityName                                    NaN
-        DestCountry                                     NaN
-        DestLocation                                    NaN
-        DestRegion                                      NaN
-        DestWeather                                     NaN
-        DistanceKilometers                          7092.14
-        DistanceMiles                               4406.85
-        FlightDelay                                0.251168
-        FlightDelayMin                              47.3352
-        FlightDelayType                                 NaN
-        FlightNum                                       NaN
-        FlightTimeHour                               8.5188
-        FlightTimeMin                               511.128
-        Origin                                          NaN
-        OriginAirportID                                 NaN
-        OriginCityName                                  NaN
-        OriginCountry                                   NaN
-        OriginLocation                                  NaN
-        OriginRegion                                    NaN
-        OriginWeather                                   NaN
-        dayOfWeek                                   2.83598
-        timestamp             2018-01-21 19:20:45.564438232
+        >>> df.mean(numeric_only=False)
+        AvgTicketPrice                          628.254
+        Cancelled                              0.128494
+        dayOfWeek                               2.83598
+        timestamp         2018-01-21 19:20:45.564438232
+        DestCountry                                 NaN
         dtype: object
         """
         return self._query_compiler.mean(numeric_only=numeric_only)
@@ -271,61 +235,25 @@ class NDFrame(ABC):
 
         Examples
         --------
-        >>> df = ed.DataFrame('localhost', 'flights')
+        >>> df = ed.DataFrame('localhost', 'flights').filter(["AvgTicketPrice", "Cancelled", "dayOfWeek", "timestamp", "DestCountry"])
         >>> df.sum()
-        AvgTicketPrice        8.20436e+06
-        Cancelled                    1678
-        DistanceKilometers    9.26163e+07
-        DistanceMiles         5.75491e+07
-        FlightDelay                  3280
-        FlightDelayMin             618150
-        FlightTimeHour             111247
-        FlightTimeMin         6.67482e+06
-        dayOfWeek                   37035
+        AvgTicketPrice    8.20436e+06
+        Cancelled                1678
+        dayOfWeek               37035
         dtype: object
 
-        >>> df = ed.DataFrame('localhost', 'flights')
         >>> df.sum(numeric_only=True)
-        AvgTicketPrice        8.204365e+06
-        Cancelled             1.678000e+03
-        DistanceKilometers    9.261629e+07
-        DistanceMiles         5.754909e+07
-        FlightDelay           3.280000e+03
-        FlightDelayMin        6.181500e+05
-        FlightTimeHour        1.112470e+05
-        FlightTimeMin         6.674818e+06
-        dayOfWeek             3.703500e+04
+        AvgTicketPrice    8.204365e+06
+        Cancelled         1.678000e+03
+        dayOfWeek         3.703500e+04
         dtype: float64
 
-        >>> df = ed.DataFrame('localhost', 'flights')
-        >>> df.sum(numeric_only=False) # doctest: +SKIP
-        AvgTicketPrice        8.20436e+06
-        Cancelled                    1678
-        Carrier                       NaN
-        Dest                          NaN
-        DestAirportID                 NaN
-        DestCityName                  NaN
-        DestCountry                   NaN
-        DestLocation                  NaN
-        DestRegion                    NaN
-        DestWeather                   NaN
-        DistanceKilometers    9.26163e+07
-        DistanceMiles         5.75491e+07
-        FlightDelay                  3280
-        FlightDelayMin             618150
-        FlightDelayType               NaN
-        FlightNum                     NaN
-        FlightTimeHour             111247
-        FlightTimeMin         6.67482e+06
-        Origin                        NaN
-        OriginAirportID               NaN
-        OriginCityName                NaN
-        OriginCountry                 NaN
-        OriginLocation                NaN
-        OriginRegion                  NaN
-        OriginWeather                 NaN
-        dayOfWeek                   37035
-        timestamp                     NaT
+        >>> df.sum(numeric_only=False)
+        AvgTicketPrice    8.20436e+06
+        Cancelled                1678
+        dayOfWeek               37035
+        timestamp                 NaT
+        DestCountry               NaN
         dtype: object
         """
         return self._query_compiler.sum(numeric_only=numeric_only)
@@ -355,62 +283,26 @@ class NDFrame(ABC):
 
         Examples
         --------
-        >>> df = ed.DataFrame('localhost', 'flights')
+        >>> df = ed.DataFrame('localhost', 'flights').filter(["AvgTicketPrice", "Cancelled", "dayOfWeek", "timestamp", "DestCountry"])
         >>> df.min()
-        AvgTicketPrice                    100.021
-        Cancelled                           False
-        DistanceKilometers                      0
-        DistanceMiles                           0
-        FlightDelay                         False
-        FlightDelayMin                          0
-        FlightTimeHour                          0
-        FlightTimeMin                           0
-        dayOfWeek                               0
-        timestamp             2018-01-01 00:00:00
+        AvgTicketPrice                100.021
+        Cancelled                       False
+        dayOfWeek                           0
+        timestamp         2018-01-01 00:00:00
         dtype: object
 
-        >>> df = ed.DataFrame('localhost', 'flights')
         >>> df.min(numeric_only=True)
-        AvgTicketPrice        100.020531
-        Cancelled               0.000000
-        DistanceKilometers      0.000000
-        DistanceMiles           0.000000
-        FlightDelay             0.000000
-        FlightDelayMin          0.000000
-        FlightTimeHour          0.000000
-        FlightTimeMin           0.000000
-        dayOfWeek               0.000000
+        AvgTicketPrice    100.020531
+        Cancelled           0.000000
+        dayOfWeek           0.000000
         dtype: float64
 
-        >>> df = ed.DataFrame('localhost', 'flights')
-        >>> df.min(numeric_only=False) # doctest: +SKIP
-        AvgTicketPrice                    100.021
-        Cancelled                           False
-        Carrier                               NaN
-        Dest                                  NaN
-        DestAirportID                         NaN
-        DestCityName                          NaN
-        DestCountry                           NaN
-        DestLocation                          NaN
-        DestRegion                            NaN
-        DestWeather                           NaN
-        DistanceKilometers                      0
-        DistanceMiles                           0
-        FlightDelay                         False
-        FlightDelayMin                          0
-        FlightDelayType                       NaN
-        FlightNum                             NaN
-        FlightTimeHour                          0
-        FlightTimeMin                           0
-        Origin                                NaN
-        OriginAirportID                       NaN
-        OriginCityName                        NaN
-        OriginCountry                         NaN
-        OriginLocation                        NaN
-        OriginRegion                          NaN
-        OriginWeather                         NaN
-        dayOfWeek                               0
-        timestamp             2018-01-01 00:00:00
+        >>> df.min(numeric_only=False)
+        AvgTicketPrice                100.021
+        Cancelled                       False
+        dayOfWeek                           0
+        timestamp         2018-01-01 00:00:00
+        DestCountry                       NaN
         dtype: object
         """
         return self._query_compiler.min(numeric_only=numeric_only)
@@ -438,61 +330,25 @@ class NDFrame(ABC):
 
         Examples
         --------
-        >>> df = ed.DataFrame('localhost', 'flights')
+        >>> df = ed.DataFrame('localhost', 'flights').filter(["AvgTicketPrice", "Cancelled", "dayOfWeek", "timestamp", "DestCountry"])
         >>> df.var()
-        AvgTicketPrice            70964.6
-        Cancelled                0.111987
-        DistanceKilometers    2.09613e+07
-        DistanceMiles          8.0932e+06
-        FlightDelay               0.18809
-        FlightDelayMin            9359.57
-        FlightTimeHour            31.1266
-        FlightTimeMin              112056
-        dayOfWeek                 3.76128
-        dtype: object
-
-        >>> df = ed.DataFrame('localhost', 'flights')
-        >>> df.var(numeric_only=True)
-        AvgTicketPrice        7.096457e+04
-        Cancelled             1.119874e-01
-        DistanceKilometers    2.096130e+07
-        DistanceMiles         8.093202e+06
-        FlightDelay           1.880897e-01
-        FlightDelayMin        9.359568e+03
-        FlightTimeHour        3.112664e+01
-        FlightTimeMin         1.120559e+05
-        dayOfWeek             3.761279e+00
+        AvgTicketPrice    70964.570234
+        Cancelled             0.111987
+        dayOfWeek             3.761279
         dtype: float64
 
-        >>> df = ed.DataFrame('localhost', 'flights')
-        >>> df.var(numeric_only=False) # doctest: +SKIP
-        AvgTicketPrice            70964.6
-        Cancelled                0.111987
-        Carrier                       NaN
-        Dest                          NaN
-        DestAirportID                 NaN
-        DestCityName                  NaN
-        DestCountry                   NaN
-        DestLocation                  NaN
-        DestRegion                    NaN
-        DestWeather                   NaN
-        DistanceKilometers    2.09613e+07
-        DistanceMiles          8.0932e+06
-        FlightDelay               0.18809
-        FlightDelayMin            9359.57
-        FlightDelayType               NaN
-        FlightNum                     NaN
-        FlightTimeHour            31.1266
-        FlightTimeMin              112056
-        Origin                        NaN
-        OriginAirportID               NaN
-        OriginCityName                NaN
-        OriginCountry                 NaN
-        OriginLocation                NaN
-        OriginRegion                  NaN
-        OriginWeather                 NaN
-        dayOfWeek                 3.76128
-        timestamp                     NaT
+        >>> df.var(numeric_only=True)
+        AvgTicketPrice    70964.570234
+        Cancelled             0.111987
+        dayOfWeek             3.761279
+        dtype: float64
+
+        >>> df.var(numeric_only=False)
+        AvgTicketPrice     70964.6
+        Cancelled         0.111987
+        dayOfWeek          3.76128
+        timestamp              NaT
+        DestCountry            NaN
         dtype: object
         """
         return self._query_compiler.var(numeric_only=numeric_only)
@@ -520,61 +376,25 @@ class NDFrame(ABC):
 
         Examples
         --------
-        >>> df = ed.DataFrame('localhost', 'flights')
+        >>> df = ed.DataFrame('localhost', 'flights').filter(["AvgTicketPrice", "Cancelled", "dayOfWeek", "timestamp", "DestCountry"])
         >>> df.std()
-        AvgTicketPrice         266.407
-        Cancelled             0.334664
-        DistanceKilometers     4578.61
-        DistanceMiles          2845.02
-        FlightDelay           0.433718
-        FlightDelayMin         96.7504
-        FlightTimeHour         5.57945
-        FlightTimeMin          334.767
-        dayOfWeek              1.93951
-        dtype: object
-
-        >>> df = ed.DataFrame('localhost', 'flights')
-        >>> df.std(numeric_only=True)
-        AvgTicketPrice         266.407061
-        Cancelled                0.334664
-        DistanceKilometers    4578.613803
-        DistanceMiles         2845.018714
-        FlightDelay              0.433718
-        FlightDelayMin          96.750415
-        FlightTimeHour           5.579446
-        FlightTimeMin          334.766770
-        dayOfWeek                1.939513
+        AvgTicketPrice    266.407061
+        Cancelled           0.334664
+        dayOfWeek           1.939513
         dtype: float64
 
-        >>> df = ed.DataFrame('localhost', 'flights')
-        >>> df.std(numeric_only=False)  # doctest: +SKIP
-        AvgTicketPrice         266.407
-        Cancelled             0.334664
-        Carrier                    NaN
-        Dest                       NaN
-        DestAirportID              NaN
-        DestCityName               NaN
-        DestCountry                NaN
-        DestLocation               NaN
-        DestRegion                 NaN
-        DestWeather                NaN
-        DistanceKilometers     4578.61
-        DistanceMiles          2845.02
-        FlightDelay           0.433718
-        FlightDelayMin         96.7504
-        FlightDelayType            NaN
-        FlightNum                  NaN
-        FlightTimeHour         5.57945
-        FlightTimeMin          334.767
-        Origin                     NaN
-        OriginAirportID            NaN
-        OriginCityName             NaN
-        OriginCountry              NaN
-        OriginLocation             NaN
-        OriginRegion               NaN
-        OriginWeather              NaN
-        dayOfWeek              1.93951
-        timestamp                  NaT
+        >>> df.std(numeric_only=True)
+        AvgTicketPrice    266.407061
+        Cancelled           0.334664
+        dayOfWeek           1.939513
+        dtype: float64
+
+        >>> df.std(numeric_only=False)
+        AvgTicketPrice     266.407
+        Cancelled         0.334664
+        dayOfWeek          1.93951
+        timestamp              NaT
+        DestCountry            NaN
         dtype: object
         """
         return self._query_compiler.std(numeric_only=numeric_only)
@@ -602,62 +422,26 @@ class NDFrame(ABC):
 
         Examples
         --------
-        >>> df = ed.DataFrame('localhost', 'flights')
+        >>> df = ed.DataFrame('localhost', 'flights').filter(["AvgTicketPrice", "Cancelled", "dayOfWeek", "timestamp", "DestCountry"])
         >>> df.median() # doctest: +SKIP
-        AvgTicketPrice                              640.387
-        Cancelled                                     False
-        DistanceKilometers                          7612.07
-        DistanceMiles                               4729.92
-        FlightDelay                                   False
-        FlightDelayMin                                    0
-        FlightTimeHour                              8.38582
-        FlightTimeMin                               503.149
-        dayOfWeek                                         3
-        timestamp             2018-01-21 23:25:13.113169922
+        AvgTicketPrice                          640.363
+        Cancelled                                 False
+        dayOfWeek                                     3
+        timestamp         2018-01-21 23:54:06.624776611
         dtype: object
 
-        >>> df = ed.DataFrame('localhost', 'flights')
         >>> df.median(numeric_only=True) # doctest: +SKIP
-        AvgTicketPrice         640.387285
-        Cancelled                0.000000
-        DistanceKilometers    7612.072403
-        DistanceMiles         4729.922470
-        FlightDelay              0.000000
-        FlightDelayMin           0.000000
-        FlightTimeHour           8.385816
-        FlightTimeMin          503.148975
-        dayOfWeek                3.000000
+        AvgTicketPrice    640.362667
+        Cancelled           0.000000
+        dayOfWeek           3.000000
         dtype: float64
 
-        >>> df = ed.DataFrame('localhost', 'flights')
         >>> df.median(numeric_only=False) # doctest: +SKIP
-        AvgTicketPrice                              640.387
-        Cancelled                                     False
-        Carrier                                         NaN
-        Dest                                            NaN
-        DestAirportID                                   NaN
-        DestCityName                                    NaN
-        DestCountry                                     NaN
-        DestLocation                                    NaN
-        DestRegion                                      NaN
-        DestWeather                                     NaN
-        DistanceKilometers                          7612.07
-        DistanceMiles                               4729.92
-        FlightDelay                                   False
-        FlightDelayMin                                    0
-        FlightDelayType                                 NaN
-        FlightNum                                       NaN
-        FlightTimeHour                              8.38582
-        FlightTimeMin                               503.149
-        Origin                                          NaN
-        OriginAirportID                                 NaN
-        OriginCityName                                  NaN
-        OriginCountry                                   NaN
-        OriginLocation                                  NaN
-        OriginRegion                                    NaN
-        OriginWeather                                   NaN
-        dayOfWeek                                         3
-        timestamp             2018-01-22 00:43:09.223130126
+        AvgTicketPrice                          640.387
+        Cancelled                                 False
+        dayOfWeek                                     3
+        timestamp         2018-01-21 23:54:06.624776611
+        DestCountry                                 NaN
         dtype: object
         """
         return self._query_compiler.median(numeric_only=numeric_only)
@@ -687,62 +471,26 @@ class NDFrame(ABC):
 
         Examples
         --------
-        >>> df = ed.DataFrame('localhost', 'flights')
+        >>> df = ed.DataFrame('localhost', 'flights').filter(["AvgTicketPrice", "Cancelled", "dayOfWeek", "timestamp","DestCountry"])
         >>> df.max()
-        AvgTicketPrice                    1199.73
-        Cancelled                            True
-        DistanceKilometers                19881.5
-        DistanceMiles                     12353.8
-        FlightDelay                          True
-        FlightDelayMin                        360
-        FlightTimeHour                     31.715
-        FlightTimeMin                      1902.9
-        dayOfWeek                               6
-        timestamp             2018-02-11 23:50:12
+        AvgTicketPrice                1199.73
+        Cancelled                        True
+        dayOfWeek                           6
+        timestamp         2018-02-11 23:50:12
         dtype: object
 
-        >>> df = ed.DataFrame('localhost', 'flights')
         >>> df.max(numeric_only=True)
-        AvgTicketPrice         1199.729004
-        Cancelled                 1.000000
-        DistanceKilometers    19881.482422
-        DistanceMiles         12353.780273
-        FlightDelay               1.000000
-        FlightDelayMin          360.000000
-        FlightTimeHour           31.715034
-        FlightTimeMin          1902.901978
-        dayOfWeek                 6.000000
+        AvgTicketPrice    1199.729004
+        Cancelled            1.000000
+        dayOfWeek            6.000000
         dtype: float64
 
-        >>> df = ed.DataFrame('localhost', 'flights')
-        >>> df.max(numeric_only=False) # doctest: +SKIP
-        AvgTicketPrice                    1199.73
-        Cancelled                            True
-        Carrier                               NaN
-        Dest                                  NaN
-        DestAirportID                         NaN
-        DestCityName                          NaN
-        DestCountry                           NaN
-        DestLocation                          NaN
-        DestRegion                            NaN
-        DestWeather                           NaN
-        DistanceKilometers                19881.5
-        DistanceMiles                     12353.8
-        FlightDelay                          True
-        FlightDelayMin                        360
-        FlightDelayType                       NaN
-        FlightNum                             NaN
-        FlightTimeHour                     31.715
-        FlightTimeMin                      1902.9
-        Origin                                NaN
-        OriginAirportID                       NaN
-        OriginCityName                        NaN
-        OriginCountry                         NaN
-        OriginLocation                        NaN
-        OriginRegion                          NaN
-        OriginWeather                         NaN
-        dayOfWeek                               6
-        timestamp             2018-02-11 23:50:12
+        >>> df.max(numeric_only=False)
+        AvgTicketPrice                1199.73
+        Cancelled                        True
+        dayOfWeek                           6
+        timestamp         2018-02-11 23:50:12
+        DestCountry                       NaN
         dtype: object
         """
         return self._query_compiler.max(numeric_only=numeric_only)
@@ -808,57 +556,23 @@ class NDFrame(ABC):
 
         Examples
         --------
-        >>> df = ed.DataFrame('localhost', 'flights')
+        >>> df = ed.DataFrame('localhost', 'flights').filter(["AvgTicketPrice", "Cancelled", "dayOfWeek", "timestamp", "DestCountry"])
         >>> df.mad() # doctest: +SKIP
-        AvgTicketPrice         213.443470
-        DistanceKilometers    2948.631194
-        DistanceMiles         1830.663947
-        FlightDelayMin           0.000000
-        FlightTimeHour           3.819254
-        FlightTimeMin          229.158256
-        dayOfWeek                2.000000
+        AvgTicketPrice    213.35497
+        dayOfWeek           2.00000
         dtype: float64
 
-        >>> df = ed.DataFrame('localhost', 'flights')
         >>> df.mad(numeric_only=True) # doctest: +SKIP
-        AvgTicketPrice         213.368709
-        DistanceKilometers    2946.168236
-        DistanceMiles         1829.899362
-        FlightDelayMin           0.000000
-        FlightTimeHour           3.819654
-        FlightTimeMin          229.176708
-        dayOfWeek                2.000000
+        AvgTicketPrice    213.473011
+        dayOfWeek           2.000000
         dtype: float64
 
-        >>> df = ed.DataFrame('localhost', 'flights')
         >>> df.mad(numeric_only=False) # doctest: +SKIP
-        AvgTicketPrice        213.451
-        Cancelled                 NaN
-        Carrier                   NaN
-        Dest                      NaN
-        DestAirportID             NaN
-        DestCityName              NaN
-        DestCountry               NaN
-        DestLocation              NaN
-        DestRegion                NaN
-        DestWeather               NaN
-        DistanceKilometers    2946.98
-        DistanceMiles         1830.66
-        FlightDelay               NaN
-        FlightDelayMin              0
-        FlightDelayType           NaN
-        FlightNum                 NaN
-        FlightTimeHour        3.81919
-        FlightTimeMin         229.177
-        Origin                    NaN
-        OriginAirportID           NaN
-        OriginCityName            NaN
-        OriginCountry             NaN
-        OriginLocation            NaN
-        OriginRegion              NaN
-        OriginWeather             NaN
-        dayOfWeek                   2
-        timestamp                 NaT
+        AvgTicketPrice    213.484
+        Cancelled             NaN
+        dayOfWeek               2
+        timestamp             NaT
+        DestCountry           NaN
         dtype: object
         """
         return self._query_compiler.mad(numeric_only=numeric_only)

--- a/eland/ndframe.py
+++ b/eland/ndframe.py
@@ -186,7 +186,7 @@ class NDFrame(ABC):
 
         Examples
         --------
-        >>> df = ed.DataFrame('localhost', 'flights').filter(["AvgTicketPrice", "Cancelled", "dayOfWeek", "timestamp", "DestCountry"])
+        >>> df = ed.DataFrame('localhost', 'flights', columns=["AvgTicketPrice", "Cancelled", "dayOfWeek", "timestamp", "DestCountry"])
         >>> df.mean()
         AvgTicketPrice                          628.254
         Cancelled                              0.128494
@@ -235,7 +235,7 @@ class NDFrame(ABC):
 
         Examples
         --------
-        >>> df = ed.DataFrame('localhost', 'flights').filter(["AvgTicketPrice", "Cancelled", "dayOfWeek", "timestamp", "DestCountry"])
+        >>> df = ed.DataFrame('localhost', 'flights', columns=["AvgTicketPrice", "Cancelled", "dayOfWeek", "timestamp", "DestCountry"])
         >>> df.sum()
         AvgTicketPrice    8.20436e+06
         Cancelled                1678
@@ -283,7 +283,7 @@ class NDFrame(ABC):
 
         Examples
         --------
-        >>> df = ed.DataFrame('localhost', 'flights').filter(["AvgTicketPrice", "Cancelled", "dayOfWeek", "timestamp", "DestCountry"])
+        >>> df = ed.DataFrame('localhost', 'flights', columns=["AvgTicketPrice", "Cancelled", "dayOfWeek", "timestamp", "DestCountry"])
         >>> df.min()
         AvgTicketPrice                100.021
         Cancelled                       False
@@ -330,7 +330,7 @@ class NDFrame(ABC):
 
         Examples
         --------
-        >>> df = ed.DataFrame('localhost', 'flights').filter(["AvgTicketPrice", "Cancelled", "dayOfWeek", "timestamp", "DestCountry"])
+        >>> df = ed.DataFrame('localhost', 'flights', columns=["AvgTicketPrice", "Cancelled", "dayOfWeek", "timestamp", "DestCountry"])
         >>> df.var()
         AvgTicketPrice    70964.570234
         Cancelled             0.111987
@@ -376,7 +376,7 @@ class NDFrame(ABC):
 
         Examples
         --------
-        >>> df = ed.DataFrame('localhost', 'flights').filter(["AvgTicketPrice", "Cancelled", "dayOfWeek", "timestamp", "DestCountry"])
+        >>> df = ed.DataFrame('localhost', 'flights', columns=["AvgTicketPrice", "Cancelled", "dayOfWeek", "timestamp", "DestCountry"])
         >>> df.std()
         AvgTicketPrice    266.407061
         Cancelled           0.334664
@@ -422,7 +422,7 @@ class NDFrame(ABC):
 
         Examples
         --------
-        >>> df = ed.DataFrame('localhost', 'flights').filter(["AvgTicketPrice", "Cancelled", "dayOfWeek", "timestamp", "DestCountry"])
+        >>> df = ed.DataFrame('localhost', 'flights', columns=["AvgTicketPrice", "Cancelled", "dayOfWeek", "timestamp", "DestCountry"])
         >>> df.median() # doctest: +SKIP
         AvgTicketPrice                          640.363
         Cancelled                                 False
@@ -471,7 +471,7 @@ class NDFrame(ABC):
 
         Examples
         --------
-        >>> df = ed.DataFrame('localhost', 'flights').filter(["AvgTicketPrice", "Cancelled", "dayOfWeek", "timestamp","DestCountry"])
+        >>> df = ed.DataFrame('localhost', 'flights', columns=["AvgTicketPrice", "Cancelled", "dayOfWeek", "timestamp", "DestCountry"])
         >>> df.max()
         AvgTicketPrice                1199.73
         Cancelled                        True
@@ -556,7 +556,7 @@ class NDFrame(ABC):
 
         Examples
         --------
-        >>> df = ed.DataFrame('localhost', 'flights').filter(["AvgTicketPrice", "Cancelled", "dayOfWeek", "timestamp", "DestCountry"])
+        >>> df = ed.DataFrame('localhost', 'flights', columns=["AvgTicketPrice", "Cancelled", "dayOfWeek", "timestamp", "DestCountry"])
         >>> df.mad() # doctest: +SKIP
         AvgTicketPrice    213.35497
         dayOfWeek           2.00000

--- a/eland/query_compiler.py
+++ b/eland/query_compiler.py
@@ -490,34 +490,34 @@ class QueryCompiler:
         result._operations.filter(self, items=items, like=like, regex=regex)
         return result
 
-    def aggs(self, func):
-        return self._operations.aggs(self, func)
+    def aggs(self, func, numeric_only: Optional[bool] = None):
+        return self._operations.aggs(self, func, numeric_only=numeric_only)
 
     def count(self):
         return self._operations.count(self)
 
-    def mean(self, numeric_only=None):
+    def mean(self, numeric_only: Optional[bool] = None):
         return self._operations.mean(self, numeric_only=numeric_only)
 
-    def var(self, numeric_only=None):
+    def var(self, numeric_only: Optional[bool] = None):
         return self._operations.var(self, numeric_only=numeric_only)
 
-    def std(self, numeric_only=None):
+    def std(self, numeric_only: Optional[bool] = None):
         return self._operations.std(self, numeric_only=numeric_only)
 
-    def mad(self, numeric_only=None):
+    def mad(self, numeric_only: Optional[bool] = None):
         return self._operations.mad(self, numeric_only=numeric_only)
 
-    def median(self, numeric_only=None):
+    def median(self, numeric_only: Optional[bool] = None):
         return self._operations.median(self, numeric_only=numeric_only)
 
-    def sum(self, numeric_only=None):
+    def sum(self, numeric_only: Optional[bool] = None):
         return self._operations.sum(self, numeric_only=numeric_only)
 
-    def min(self, numeric_only=None):
+    def min(self, numeric_only: Optional[bool] = None):
         return self._operations.min(self, numeric_only=numeric_only)
 
-    def max(self, numeric_only=None):
+    def max(self, numeric_only: Optional[bool] = None):
         return self._operations.max(self, numeric_only=numeric_only)
 
     def nunique(self):

--- a/eland/query_compiler.py
+++ b/eland/query_compiler.py
@@ -17,7 +17,7 @@
 
 import copy
 from datetime import datetime
-from typing import Optional, TYPE_CHECKING
+from typing import Optional, TYPE_CHECKING, List
 
 import numpy as np
 import pandas as pd
@@ -490,38 +490,56 @@ class QueryCompiler:
         result._operations.filter(self, items=items, like=like, regex=regex)
         return result
 
-    def aggs(self, func, numeric_only: Optional[bool] = None):
+    def aggs(self, func: List[str], numeric_only: Optional[bool] = None):
         return self._operations.aggs(self, func, numeric_only=numeric_only)
 
     def count(self):
         return self._operations.count(self)
 
     def mean(self, numeric_only: Optional[bool] = None):
-        return self._operations.mean(self, numeric_only=numeric_only)
+        return self._operations._metric_agg_series(
+            self, ["mean"], numeric_only=numeric_only
+        )
 
     def var(self, numeric_only: Optional[bool] = None):
-        return self._operations.var(self, numeric_only=numeric_only)
+        return self._operations._metric_agg_series(
+            self, ["var"], numeric_only=numeric_only
+        )
 
     def std(self, numeric_only: Optional[bool] = None):
-        return self._operations.std(self, numeric_only=numeric_only)
+        return self._operations._metric_agg_series(
+            self, ["std"], numeric_only=numeric_only
+        )
 
     def mad(self, numeric_only: Optional[bool] = None):
-        return self._operations.mad(self, numeric_only=numeric_only)
+        return self._operations._metric_agg_series(
+            self, ["mad"], numeric_only=numeric_only
+        )
 
     def median(self, numeric_only: Optional[bool] = None):
-        return self._operations.median(self, numeric_only=numeric_only)
+        return self._operations._metric_agg_series(
+            self, ["median"], numeric_only=numeric_only
+        )
 
     def sum(self, numeric_only: Optional[bool] = None):
-        return self._operations.sum(self, numeric_only=numeric_only)
+        return self._operations._metric_agg_series(
+            self, ["sum"], numeric_only=numeric_only
+        )
 
     def min(self, numeric_only: Optional[bool] = None):
-        return self._operations.min(self, numeric_only=numeric_only)
+        return self._operations._metric_agg_series(
+            self, ["min"], numeric_only=numeric_only
+        )
 
     def max(self, numeric_only: Optional[bool] = None):
-        return self._operations.max(self, numeric_only=numeric_only)
+        return self._operations._metric_agg_series(
+            self, ["max"], numeric_only=numeric_only
+        )
 
     def nunique(self):
-        return self._operations.nunique(self)
+        return self._operations._metric_agg_series(
+            self, ["nunique"], numeric_only=False
+        )
 
     def value_counts(self, es_size):
         return self._operations.value_counts(self, es_size)

--- a/eland/tests/dataframe/test_aggs_pytest.py
+++ b/eland/tests/dataframe/test_aggs_pytest.py
@@ -87,8 +87,8 @@ class TestDataFrameAggs(TestData):
             ["taxful_total_price", "taxless_total_price", "total_quantity"]
         ].agg(["median", "var"], numeric_only=True)
 
-        # print(pd_aggs, pd_aggs.dtypes)
-        # print(ed_aggs, ed_aggs.dtypes)
+        print(pd_aggs, pd_aggs.dtypes)
+        print(ed_aggs, ed_aggs.dtypes)
 
         # Eland returns all float values for all metric aggs, pandas can return int
         # TODO - investigate this more

--- a/eland/tests/dataframe/test_aggs_pytest.py
+++ b/eland/tests/dataframe/test_aggs_pytest.py
@@ -29,7 +29,9 @@ class TestDataFrameAggs(TestData):
         ed_flights = self.ed_flights()
 
         pd_sum_min = pd_flights.select_dtypes(include=[np.number]).agg(["sum", "min"])
-        ed_sum_min = ed_flights.select_dtypes(include=[np.number]).agg(["sum", "min"])
+        ed_sum_min = ed_flights.select_dtypes(include=[np.number]).agg(
+            ["sum", "min"], numeric_only=True
+        )
 
         # Eland returns all float values for all metric aggs, pandas can return int
         # TODO - investigate this more
@@ -40,22 +42,22 @@ class TestDataFrameAggs(TestData):
             ["sum", "min", "std"]
         )
         ed_sum_min_std = ed_flights.select_dtypes(include=[np.number]).agg(
-            ["sum", "min", "std"]
+            ["sum", "min", "std"], numeric_only=True
         )
 
         print(pd_sum_min_std.dtypes)
         print(ed_sum_min_std.dtypes)
 
-        assert_frame_equal(
-            pd_sum_min_std, ed_sum_min_std, check_exact=False, check_less_precise=True
-        )
+        assert_frame_equal(pd_sum_min_std, ed_sum_min_std, check_exact=False, rtol=True)
 
     def test_terms_aggs(self):
         pd_flights = self.pd_flights()
         ed_flights = self.ed_flights()
 
         pd_sum_min = pd_flights.select_dtypes(include=[np.number]).agg(["sum", "min"])
-        ed_sum_min = ed_flights.select_dtypes(include=[np.number]).agg(["sum", "min"])
+        ed_sum_min = ed_flights.select_dtypes(include=[np.number]).agg(
+            ["sum", "min"], numeric_only=True
+        )
 
         # Eland returns all float values for all metric aggs, pandas can return int
         # TODO - investigate this more
@@ -66,15 +68,13 @@ class TestDataFrameAggs(TestData):
             ["sum", "min", "std"]
         )
         ed_sum_min_std = ed_flights.select_dtypes(include=[np.number]).agg(
-            ["sum", "min", "std"]
+            ["sum", "min", "std"], numeric_only=True
         )
 
         print(pd_sum_min_std.dtypes)
         print(ed_sum_min_std.dtypes)
 
-        assert_frame_equal(
-            pd_sum_min_std, ed_sum_min_std, check_exact=False, check_less_precise=True
-        )
+        assert_frame_equal(pd_sum_min_std, ed_sum_min_std, check_exact=False, rtol=True)
 
     def test_aggs_median_var(self):
         pd_ecommerce = self.pd_ecommerce()
@@ -85,10 +85,10 @@ class TestDataFrameAggs(TestData):
         ].agg(["median", "var"])
         ed_aggs = ed_ecommerce[
             ["taxful_total_price", "taxless_total_price", "total_quantity"]
-        ].agg(["median", "var"])
+        ].agg(["median", "var"], numeric_only=True)
 
-        print(pd_aggs, pd_aggs.dtypes)
-        print(ed_aggs, ed_aggs.dtypes)
+        # print(pd_aggs, pd_aggs.dtypes)
+        # print(ed_aggs, ed_aggs.dtypes)
 
         # Eland returns all float values for all metric aggs, pandas can return int
         # TODO - investigate this more
@@ -102,7 +102,9 @@ class TestDataFrameAggs(TestData):
         ed_flights = self.ed_flights()
 
         pd_sum_min_std = pd_flights.select_dtypes(include=[np.number]).agg(agg)
-        ed_sum_min_std = ed_flights.select_dtypes(include=[np.number]).agg(agg)
+        ed_sum_min_std = ed_flights.select_dtypes(include=[np.number]).agg(
+            agg, numeric_only=True
+        )
 
         assert_series_equal(pd_sum_min_std, ed_sum_min_std)
 
@@ -112,7 +114,9 @@ class TestDataFrameAggs(TestData):
         ed_flights = self.ed_flights()
 
         pd_sum_min = pd_flights.select_dtypes(include=[np.number]).agg(["mean"])
-        ed_sum_min = ed_flights.select_dtypes(include=[np.number]).agg(["mean"])
+        ed_sum_min = ed_flights.select_dtypes(include=[np.number]).agg(
+            ["mean"], numeric_only=True
+        )
 
         assert_frame_equal(pd_sum_min, ed_sum_min)
 

--- a/eland/tests/dataframe/test_metrics_pytest.py
+++ b/eland/tests/dataframe/test_metrics_pytest.py
@@ -26,6 +26,13 @@ from eland.tests.common import TestData
 class TestDataFrameMetrics(TestData):
     funcs = ["max", "min", "mean", "sum"]
     extended_funcs = ["median", "mad", "var", "std"]
+    filter_data = [
+        "AvgTicketPrice",
+        "Cancelled",
+        "dayOfWeek",
+        "timestamp",
+        "DestCountry",
+    ]
 
     def test_flights_extended_metrics(self):
         pd_flights = self.pd_flights()
@@ -135,14 +142,14 @@ class TestDataFrameMetrics(TestData):
     def test_flights_datetime_metrics_agg(self):
         ed_timestamps = self.ed_flights()[["timestamp"]]
         expected_values = {
-            "mad": pd.NaT,
             "max": pd.Timestamp("2018-02-11 23:50:12"),
-            "mean": pd.Timestamp("2018-01-21 19:20:45.564438232"),
             "min": pd.Timestamp("2018-01-01 00:00:00"),
-            "nunique": 12236,
-            "std": pd.NaT,
+            "mean": pd.Timestamp("2018-01-21 19:20:45.564438232"),
             "sum": pd.NaT,
+            "mad": pd.NaT,
             "var": pd.NaT,
+            "std": pd.NaT,
+            "nunique": 12236,
         }
 
         ed_metrics = ed_timestamps.agg(
@@ -253,384 +260,244 @@ class TestDataFrameMetrics(TestData):
     # Mean
     @pytest.mark.parametrize("numeric_only", [True, False, None])
     def test_mean_numeric_only(self, numeric_only):
-        filter_data = [
-            "AvgTicketPrice",
-            "Cancelled",
-            "dayOfWeek",
-            "timestamp",
-            "DestCountry",
-        ]
-        ed_flights = self.ed_flights().filter(filter_data)
+        ed_flights = self.ed_flights().filter(self.filter_data)
         if numeric_only is True:
-            expected_values = {
-                "AvgTicketPrice": 628.2536888148849,
-                "Cancelled": 0.1284937590933456,
-                "dayOfWeek": 2.835975189524466,
-            }
             calculated_values = ed_flights.mean(numeric_only=numeric_only)
+            assert calculated_values.to_list() == [
+                628.2536888148849,
+                0.1284937590933456,
+                2.835975189524466,
+            ]
             dtype_list = [calculated_values[i].dtype for i in calculated_values.index]
-            assert expected_values == calculated_values.to_dict()
             assert dtype_list == [
                 np.dtype("float64"),
                 np.dtype("float64"),
                 np.dtype("float64"),
             ]
         elif numeric_only is False:
-            expected_values = {
-                "AvgTicketPrice": 628.2536888148849,
-                "Cancelled": True,
-                "dayOfWeek": 2,
-            }
             calculated_values = ed_flights.mean(numeric_only=numeric_only)
             assert isinstance(calculated_values["timestamp"], pd.Timestamp)
             assert np.isnan(calculated_values["DestCountry"])
             calculated_values = calculated_values.drop(["timestamp", "DestCountry"])
-            assert expected_values == calculated_values.to_dict()
-            dtype_list = [calculated_values[i].dtype for i in calculated_values.index]
-            assert dtype_list == [
-                np.dtype("float64"),
-                np.dtype("bool"),
-                np.dtype("int64"),
+            assert calculated_values.to_list() == [
+                628.2536888148849,
+                0.1284937590933456,
+                2.835975189524466,
             ]
+            assert isinstance(calculated_values["AvgTicketPrice"], float)
+            assert isinstance(calculated_values["dayOfWeek"], float)
+            assert isinstance(calculated_values["Cancelled"], float)
         elif numeric_only is None:
-            expected_values = {
-                "AvgTicketPrice": 628.2536888148849,
-                "Cancelled": True,
-                "dayOfWeek": 2,
-                "timestamp": pd.Timestamp("2018-01-21 19:20:45.564438232"),
-            }
             calculated_values = ed_flights.mean(numeric_only=numeric_only)
-            assert expected_values == calculated_values.to_dict()
+            assert calculated_values.to_list() == [
+                628.2536888148849,
+                0.1284937590933456,
+                2.835975189524466,
+                pd.Timestamp("2018-01-21 19:20:45.564438232"),
+            ]
             assert isinstance(calculated_values["timestamp"], pd.Timestamp)
             calculated_values = calculated_values.drop("timestamp")
-            dtype_list = [calculated_values[i].dtype for i in calculated_values.index]
-            assert dtype_list == [
-                np.dtype("float64"),
-                np.dtype("bool"),
-                np.dtype("int64"),
-            ]
+            assert isinstance(calculated_values["AvgTicketPrice"], float)
+            assert isinstance(calculated_values["dayOfWeek"], float)
+            assert isinstance(calculated_values["Cancelled"], float)
 
     # Min
     @pytest.mark.parametrize("numeric_only", [True, False, None])
     def test_min_numeric_only(self, numeric_only):
-        filter_data = [
-            "AvgTicketPrice",
-            "Cancelled",
-            "dayOfWeek",
-            "timestamp",
-            "DestCountry",
-        ]
-        ed_flights = self.ed_flights().filter(filter_data)
+        ed_flights = self.ed_flights().filter(self.filter_data)
         if numeric_only is True:
-            expected_values = {
-                "AvgTicketPrice": 100.0205307006836,
-                "Cancelled": 0.0,
-                "dayOfWeek": 0.0,
-            }
             calculated_values = ed_flights.min(numeric_only=numeric_only)
+            assert calculated_values.to_list() == [100.0205307006836, 0.0, 0.0]
             dtype_list = [calculated_values[i].dtype for i in calculated_values.index]
-            assert expected_values == calculated_values.to_dict()
             assert dtype_list == [
                 np.dtype("float64"),
                 np.dtype("float64"),
                 np.dtype("float64"),
             ]
         elif numeric_only is False:
-            expected_values = {
-                "AvgTicketPrice": 100.0205307006836,
-                "Cancelled": False,
-                "dayOfWeek": 0,
-            }
             calculated_values = ed_flights.min(numeric_only=numeric_only)
             assert isinstance(calculated_values["timestamp"], pd.Timestamp)
             assert np.isnan(calculated_values["DestCountry"])
             calculated_values = calculated_values.drop(["timestamp", "DestCountry"])
-            assert expected_values == calculated_values.to_dict()
-            dtype_list = [calculated_values[i].dtype for i in calculated_values.index]
-            assert dtype_list == [
-                np.dtype("float64"),
-                np.dtype("bool"),
-                np.dtype("int64"),
-            ]
+            assert calculated_values.to_list() == [100.0205307006836, 0, False]
+            assert isinstance(calculated_values["AvgTicketPrice"], np.float64)
+            assert isinstance(calculated_values["dayOfWeek"], np.int64)
+            assert isinstance(calculated_values["Cancelled"], np.bool_)
         elif numeric_only is None:
-            expected_values = {
-                "AvgTicketPrice": 100.0205307006836,
-                "Cancelled": False,
-                "dayOfWeek": 0,
-                "timestamp": pd.Timestamp("2018-01-01 00:00:00"),
-            }
             calculated_values = ed_flights.min(numeric_only=numeric_only)
-            assert expected_values == calculated_values.to_dict()
-            assert isinstance(calculated_values["timestamp"], pd.Timestamp)
-            calculated_values = calculated_values.drop("timestamp")
-            dtype_list = [calculated_values[i].dtype for i in calculated_values.index]
-            assert dtype_list == [
-                np.dtype("float64"),
-                np.dtype("bool"),
-                np.dtype("int64"),
+            assert calculated_values.to_list() == [
+                100.0205307006836,
+                0,
+                False,
+                pd.Timestamp("2018-01-01 00:00:00"),
             ]
+            assert isinstance(calculated_values["timestamp"], pd.Timestamp)
+            assert isinstance(calculated_values["AvgTicketPrice"], np.float64)
+            assert isinstance(calculated_values["dayOfWeek"], np.int64)
+            assert isinstance(calculated_values["Cancelled"], np.bool_)
 
     # max
     @pytest.mark.parametrize("numeric_only", [True, False, None])
     def test_max_numeric_only(self, numeric_only):
-        filter_data = [
-            "AvgTicketPrice",
-            "Cancelled",
-            "dayOfWeek",
-            "timestamp",
-            "DestCountry",
-        ]
-        ed_flights = self.ed_flights().filter(filter_data)
+        ed_flights = self.ed_flights().filter(self.filter_data)
         if numeric_only is True:
-            expected_values = {
-                "AvgTicketPrice": 1199.72900390625,
-                "Cancelled": 1.0,
-                "dayOfWeek": 6.0,
-            }
             calculated_values = ed_flights.max(numeric_only=numeric_only)
+            assert calculated_values.to_list() == [1199.72900390625, 1.0, 6.0]
             dtype_list = [calculated_values[i].dtype for i in calculated_values.index]
-            assert expected_values == calculated_values.to_dict()
             assert dtype_list == [
                 np.dtype("float64"),
                 np.dtype("float64"),
                 np.dtype("float64"),
             ]
         elif numeric_only is False:
-            expected_values = {
-                "AvgTicketPrice": 1199.72900390625,
-                "Cancelled": True,
-                "dayOfWeek": 6,
-            }
             calculated_values = ed_flights.max(numeric_only=numeric_only)
             assert isinstance(calculated_values["timestamp"], pd.Timestamp)
             assert np.isnan(calculated_values["DestCountry"])
             calculated_values = calculated_values.drop(["timestamp", "DestCountry"])
-            assert expected_values == calculated_values.to_dict()
-            dtype_list = [calculated_values[i].dtype for i in calculated_values.index]
-            assert dtype_list == [
-                np.dtype("float64"),
-                np.dtype("bool"),
-                np.dtype("int64"),
-            ]
+            assert calculated_values.to_list() == [1199.72900390625, True, 6]
+            assert isinstance(calculated_values["AvgTicketPrice"], np.float64)
+            assert isinstance(calculated_values["dayOfWeek"], np.int64)
+            assert isinstance(calculated_values["Cancelled"], np.bool_)
         elif numeric_only is None:
-            expected_values = {
-                "AvgTicketPrice": 1199.72900390625,
-                "Cancelled": True,
-                "dayOfWeek": 6,
-                "timestamp": pd.Timestamp("2018-02-11 23:50:12"),
-            }
             calculated_values = ed_flights.max(numeric_only=numeric_only)
-            assert expected_values == calculated_values.to_dict()
             assert isinstance(calculated_values["timestamp"], pd.Timestamp)
             calculated_values = calculated_values.drop("timestamp")
-            dtype_list = [calculated_values[i].dtype for i in calculated_values.index]
-            assert dtype_list == [
-                np.dtype("float64"),
-                np.dtype("bool"),
-                np.dtype("int64"),
-            ]
+            assert calculated_values.to_list() == [1199.72900390625, True, 6]
+            assert isinstance(calculated_values["AvgTicketPrice"], np.float64)
+            assert isinstance(calculated_values["dayOfWeek"], np.int64)
+            assert isinstance(calculated_values["Cancelled"], np.bool_)
 
     # sum
     @pytest.mark.parametrize("numeric_only", [True, False, None])
     def test_sum_numeric_only(self, numeric_only):
-        filter_data = [
-            "AvgTicketPrice",
-            "Cancelled",
-            "dayOfWeek",
-            "timestamp",
-            "DestCountry",
-        ]
-        ed_flights = self.ed_flights().filter(filter_data)
+        ed_flights = self.ed_flights().filter(self.filter_data)
         if numeric_only is True:
-            expected_values = {
-                "AvgTicketPrice": 8204364.922233582,
-                "Cancelled": 1678.0,
-                "dayOfWeek": 37035.0,
-            }
             calculated_values = ed_flights.sum(numeric_only=numeric_only)
             dtype_list = [calculated_values[i].dtype for i in calculated_values.index]
-            assert expected_values == calculated_values.to_dict()
+            assert calculated_values.to_list() == [8204364.922233582, 1678.0, 37035.0]
             assert dtype_list == [
                 np.dtype("float64"),
                 np.dtype("float64"),
                 np.dtype("float64"),
             ]
         elif numeric_only is False:
-            expected_values = {
-                "AvgTicketPrice": 8204364.922233582,
-                "Cancelled": True,
-                "dayOfWeek": 37035,
-            }
             calculated_values = ed_flights.sum(numeric_only=numeric_only)
             assert pd.isnull(calculated_values["timestamp"])
             assert np.isnan(calculated_values["DestCountry"])
             calculated_values = calculated_values.drop(["timestamp", "DestCountry"])
-            assert expected_values == calculated_values.to_dict()
-            dtype_list = [calculated_values[i].dtype for i in calculated_values.index]
-            assert dtype_list == [
-                np.dtype("float64"),
-                np.dtype("bool"),
-                np.dtype("int64"),
-            ]
+            assert calculated_values.to_list() == [8204364.922233582, 1678, 37035]
+            assert isinstance(calculated_values["AvgTicketPrice"], np.float64)
+            assert isinstance(calculated_values["dayOfWeek"], np.int64)
+            assert isinstance(calculated_values["Cancelled"], np.int64)
         elif numeric_only is None:
-            expected_values = {
-                "AvgTicketPrice": 8204364.922233582,
-                "Cancelled": True,
-                "dayOfWeek": 37035,
-            }
             calculated_values = ed_flights.sum(numeric_only=numeric_only)
-            assert expected_values == calculated_values.to_dict()
+            assert calculated_values.to_list() == [8204364.922233582, 1678, 37035]
             dtype_list = [calculated_values[i].dtype for i in calculated_values.index]
             assert dtype_list == [
                 np.dtype("float64"),
-                np.dtype("bool"),
+                np.dtype("int64"),
                 np.dtype("int64"),
             ]
 
     # std
     @pytest.mark.parametrize("numeric_only", [True, False, None])
     def test_std_numeric_only(self, numeric_only):
-        filter_data = [
-            "AvgTicketPrice",
-            "Cancelled",
-            "dayOfWeek",
-            "timestamp",
-            "DestCountry",
-        ]
-        ed_flights = self.ed_flights().filter(filter_data)
+        ed_flights = self.ed_flights().filter(self.filter_data)
         if numeric_only is True:
-            expected_values = {
-                "AvgTicketPrice": 266.4070611666801,
-                "Cancelled": 0.33466440694020916,
-                "dayOfWeek": 1.9395130445445228,
-            }
             calculated_values = ed_flights.std(numeric_only=numeric_only)
             dtype_list = [calculated_values[i].dtype for i in calculated_values.index]
-            assert expected_values == calculated_values.to_dict()
+            assert calculated_values.to_list() == [
+                266.4070611666801,
+                0.33466440694020916,
+                1.9395130445445228,
+            ]
             assert dtype_list == [
                 np.dtype("float64"),
                 np.dtype("float64"),
                 np.dtype("float64"),
             ]
         elif numeric_only is False:
-            expected_values = {
-                "AvgTicketPrice": 266.4070611666801,
-                "Cancelled": True,
-                "dayOfWeek": 1,
-            }
             calculated_values = ed_flights.std(numeric_only=numeric_only)
             assert pd.isnull(calculated_values["timestamp"])
             assert np.isnan(calculated_values["DestCountry"])
             calculated_values = calculated_values.drop(["timestamp", "DestCountry"])
-            assert expected_values == calculated_values.to_dict()
-            dtype_list = [calculated_values[i].dtype for i in calculated_values.index]
-            assert dtype_list == [
-                np.dtype("float64"),
-                np.dtype("bool"),
-                np.dtype("int64"),
+            assert calculated_values.to_list() == [
+                266.4070611666801,
+                0.33466440694020916,
+                1.9395130445445228,
             ]
+            assert isinstance(calculated_values["AvgTicketPrice"], float)
+            assert isinstance(calculated_values["dayOfWeek"], float)
+            assert isinstance(calculated_values["Cancelled"], float)
         elif numeric_only is None:
-            expected_values = {
-                "AvgTicketPrice": 266.4070611666801,
-                "Cancelled": True,
-                "dayOfWeek": 1,
-            }
             calculated_values = ed_flights.std(numeric_only=numeric_only)
-            assert expected_values == calculated_values.to_dict()
-            dtype_list = [calculated_values[i].dtype for i in calculated_values.index]
-            assert dtype_list == [
-                np.dtype("float64"),
-                np.dtype("bool"),
-                np.dtype("int64"),
+            assert calculated_values.to_list() == [
+                266.4070611666801,
+                0.33466440694020916,
+                1.9395130445445228,
             ]
+            assert isinstance(calculated_values["AvgTicketPrice"], float)
+            assert isinstance(calculated_values["dayOfWeek"], float)
+            assert isinstance(calculated_values["Cancelled"], float)
 
     # var
     @pytest.mark.parametrize("numeric_only", [True, False, None])
     def test_var_numeric_only(self, numeric_only):
-        filter_data = [
-            "AvgTicketPrice",
-            "Cancelled",
-            "dayOfWeek",
-            "timestamp",
-            "DestCountry",
-        ]
-        ed_flights = self.ed_flights().filter(filter_data)
+        ed_flights = self.ed_flights().filter(self.filter_data)
         if numeric_only is True:
-            expected_values = {
-                "AvgTicketPrice": 70964.57023354847,
-                "Cancelled": 0.111987400797438,
-                "dayOfWeek": 3.7612787756607213,
-            }
             calculated_values = ed_flights.var(numeric_only=numeric_only)
             dtype_list = [calculated_values[i].dtype for i in calculated_values.index]
-            assert expected_values == calculated_values.to_dict()
+            assert calculated_values.to_list() == [
+                70964.57023354847,
+                0.111987400797438,
+                3.7612787756607213,
+            ]
             assert dtype_list == [
                 np.dtype("float64"),
                 np.dtype("float64"),
                 np.dtype("float64"),
             ]
         elif numeric_only is False:
-            expected_values = {
-                "AvgTicketPrice": 70964.57023354847,
-                "Cancelled": True,
-                "dayOfWeek": 3,
-            }
             calculated_values = ed_flights.var(numeric_only=numeric_only)
             assert pd.isnull(calculated_values["timestamp"])
             assert np.isnan(calculated_values["DestCountry"])
             calculated_values = calculated_values.drop(["timestamp", "DestCountry"])
-            assert expected_values == calculated_values.to_dict()
-            dtype_list = [calculated_values[i].dtype for i in calculated_values.index]
-            assert dtype_list == [
-                np.dtype("float64"),
-                np.dtype("bool"),
-                np.dtype("int64"),
+            assert calculated_values.to_list() == [
+                70964.57023354847,
+                0.111987400797438,
+                3.7612787756607213,
             ]
+            assert isinstance(calculated_values["AvgTicketPrice"], np.float64)
+            assert isinstance(calculated_values["dayOfWeek"], np.float64)
+            assert isinstance(calculated_values["Cancelled"], np.float64)
         elif numeric_only is None:
-            expected_values = {
-                "AvgTicketPrice": 70964.57023354847,
-                "Cancelled": True,
-                "dayOfWeek": 3,
-            }
             calculated_values = ed_flights.var(numeric_only=numeric_only)
-            assert expected_values == calculated_values.to_dict()
+            assert calculated_values.to_list() == [
+                70964.57023354847,
+                0.111987400797438,
+                3.7612787756607213,
+            ]
             dtype_list = [calculated_values[i].dtype for i in calculated_values.index]
             assert dtype_list == [
                 np.dtype("float64"),
-                np.dtype("bool"),
-                np.dtype("int64"),
+                np.dtype("float64"),
+                np.dtype("float64"),
             ]
 
     # median
     @pytest.mark.parametrize("numeric_only", [True, False, None])
     def test_median_numeric_only(self, numeric_only):
-        filter_data = [
-            "AvgTicketPrice",
-            "Cancelled",
-            "dayOfWeek",
-            "timestamp",
-            "DestCountry",
-        ]
-        ed_flights = self.ed_flights().filter(filter_data)
+        ed_flights = self.ed_flights().filter(self.filter_data)
         if numeric_only is True:
-            expected_values = {
-                "AvgTicketPrice": 640.3872852064159,
-                "Cancelled": 0.0,
-                "dayOfWeek": 3.0,
-            }
             calculated_values = ed_flights.median(numeric_only=numeric_only)
             dtype_list = [calculated_values[i].dtype for i in calculated_values.index]
             assert (
-                expected_values["Cancelled"] == calculated_values.to_dict()["Cancelled"]
-            )
-            assert (
-                expected_values["dayOfWeek"] == calculated_values.to_dict()["dayOfWeek"]
-            )
-            assert (
                 (calculated_values.to_dict()["AvgTicketPrice"] * 0.9)
-                <= expected_values["AvgTicketPrice"]
+                <= 640.3872852064159
                 <= (calculated_values.to_dict()["AvgTicketPrice"] * 1.1)
             )
+            assert calculated_values["Cancelled"] == 0.0
+            assert calculated_values["dayOfWeek"] == 3.0
             assert dtype_list == [
                 np.dtype("float64"),
                 np.dtype("float64"),
@@ -689,18 +556,10 @@ class TestDataFrameMetrics(TestData):
     # mad
     @pytest.mark.parametrize("numeric_only", [True, False, None])
     def test_mad_numeric_only(self, numeric_only):
-        filter_data = [
-            "AvgTicketPrice",
-            "Cancelled",
-            "dayOfWeek",
-            "timestamp",
-            "DestCountry",
-        ]
-        ed_flights = self.ed_flights().filter(filter_data)
+        ed_flights = self.ed_flights().filter(self.filter_data)
         if numeric_only is True:
             expected_values = {"AvgTicketPrice": 213.47889841845912, "dayOfWeek": 2.0}
             calculated_values = ed_flights.mad(numeric_only=numeric_only)
-            dtype_list = [calculated_values[i].dtype for i in calculated_values.index]
             assert (
                 expected_values["dayOfWeek"] == calculated_values.to_dict()["dayOfWeek"]
             )
@@ -709,10 +568,7 @@ class TestDataFrameMetrics(TestData):
                 <= expected_values["AvgTicketPrice"]
                 <= (calculated_values["AvgTicketPrice"] * 1.1)
             )
-            assert dtype_list == [
-                np.dtype("float64"),
-                np.dtype("float64"),
-            ]
+            assert calculated_values["AvgTicketPrice"].dtype == np.dtype("float64")
         elif numeric_only is False:
             expected_values = {"AvgTicketPrice": 213.36870923117985, "dayOfWeek": 2.0}
             calculated_values = ed_flights.mad(numeric_only=numeric_only)
@@ -730,8 +586,8 @@ class TestDataFrameMetrics(TestData):
                 <= expected_values["AvgTicketPrice"]
                 <= (calculated_values["AvgTicketPrice"] * 1.1)
             )
-            isinstance(calculated_values["AvgTicketPrice"], float)
-            isinstance(calculated_values["dayOfWeek"], float)
+            assert isinstance(calculated_values["AvgTicketPrice"], float)
+            assert isinstance(calculated_values["dayOfWeek"], float)
 
         elif numeric_only is None:
             expected_values = {"AvgTicketPrice": 213.4408885767035, "dayOfWeek": 2.0}
@@ -741,8 +597,5 @@ class TestDataFrameMetrics(TestData):
                 <= expected_values["AvgTicketPrice"]
                 <= (calculated_values["AvgTicketPrice"] * 1.1)
             )
-            dtype_list = [calculated_values[i].dtype for i in calculated_values.index]
-            assert dtype_list == [
-                np.dtype("float64"),
-                np.dtype("float64"),
-            ]
+            assert isinstance(calculated_values["AvgTicketPrice"], float)
+            assert isinstance(calculated_values["dayOfWeek"], float)

--- a/eland/tests/dataframe/test_metrics_pytest.py
+++ b/eland/tests/dataframe/test_metrics_pytest.py
@@ -16,40 +16,16 @@
 #  under the License.
 
 # File called _pytest for PyCharm compatibility
-
 import pytest
 import numpy as np
 import pandas as pd
 from pandas.testing import assert_series_equal
-
 from eland.tests.common import TestData
 
 
 class TestDataFrameMetrics(TestData):
     funcs = ["max", "min", "mean", "sum"]
     extended_funcs = ["median", "mad", "var", "std"]
-
-    @pytest.mark.parametrize("numeric_only", [False, None])
-    def test_flights_metrics(self, numeric_only):
-        pd_flights = self.pd_flights()
-        ed_flights = self.ed_flights()
-
-        for func in self.funcs:
-            # Pandas v1.0 doesn't support mean() on datetime
-            # Pandas and Eland don't support sum() on datetime
-            if not numeric_only:
-                dtype_include = (
-                    [np.number, np.datetime64]
-                    if func not in ("mean", "sum")
-                    else [np.number]
-                )
-                pd_flights = pd_flights.select_dtypes(include=dtype_include)
-                ed_flights = ed_flights.select_dtypes(include=dtype_include)
-
-            pd_metric = getattr(pd_flights, func)(numeric_only=numeric_only)
-            ed_metric = getattr(ed_flights, func)(numeric_only=numeric_only)
-
-            assert_series_equal(pd_metric, ed_metric)
 
     def test_flights_extended_metrics(self):
         pd_flights = self.pd_flights()
@@ -86,11 +62,9 @@ class TestDataFrameMetrics(TestData):
 
         for func in self.extended_funcs:
             pd_metric = getattr(pd_flights_1, func)()
-            ed_metric = getattr(ed_flights_1, func)()
+            ed_metric = getattr(ed_flights_1, func)(numeric_only=False)
 
-            assert_series_equal(
-                pd_metric, ed_metric, check_exact=False, check_less_precise=True
-            )
+            assert_series_equal(pd_metric, ed_metric, check_exact=False)
 
         # Test on zero rows to test NaN behaviour of sample std/variance
         pd_flights_0 = pd_flights[pd_flights.FlightNum == "XXX"][["AvgTicketPrice"]]
@@ -98,11 +72,9 @@ class TestDataFrameMetrics(TestData):
 
         for func in self.extended_funcs:
             pd_metric = getattr(pd_flights_0, func)()
-            ed_metric = getattr(ed_flights_0, func)()
+            ed_metric = getattr(ed_flights_0, func)(numeric_only=False)
 
-            assert_series_equal(
-                pd_metric, ed_metric, check_exact=False, check_less_precise=True
-            )
+            assert_series_equal(pd_metric, ed_metric, check_exact=False)
 
     def test_ecommerce_selected_non_numeric_source_fields(self):
         # None of these are numeric
@@ -114,14 +86,14 @@ class TestDataFrameMetrics(TestData):
             "user",
         ]
 
-        pd_ecommerce = self.pd_ecommerce()[columns]
-        ed_ecommerce = self.ed_ecommerce()[columns]
+        pd_ecommerce = self.pd_ecommerce().filter(columns)
+        ed_ecommerce = self.ed_ecommerce().filter(columns)
 
         for func in self.funcs:
             assert_series_equal(
                 getattr(pd_ecommerce, func)(numeric_only=True),
                 getattr(ed_ecommerce, func)(numeric_only=True),
-                check_less_precise=True,
+                check_exact=False,
             )
 
     def test_ecommerce_selected_mixed_numeric_source_fields(self):
@@ -136,48 +108,48 @@ class TestDataFrameMetrics(TestData):
             "user",
         ]
 
-        pd_ecommerce = self.pd_ecommerce()[columns]
-        ed_ecommerce = self.ed_ecommerce()[columns]
+        pd_ecommerce = self.pd_ecommerce().filter(columns)
+        ed_ecommerce = self.ed_ecommerce().filter(columns)
 
         for func in self.funcs:
             assert_series_equal(
                 getattr(pd_ecommerce, func)(numeric_only=True),
                 getattr(ed_ecommerce, func)(numeric_only=True),
-                check_less_precise=True,
+                check_exact=False,
             )
 
     def test_ecommerce_selected_all_numeric_source_fields(self):
         # All of these are numeric
         columns = ["total_quantity", "taxful_total_price", "taxless_total_price"]
 
-        pd_ecommerce = self.pd_ecommerce()[columns]
-        ed_ecommerce = self.ed_ecommerce()[columns]
+        pd_ecommerce = self.pd_ecommerce().filter(columns)
+        ed_ecommerce = self.ed_ecommerce().filter(columns)
 
         for func in self.funcs:
             assert_series_equal(
                 getattr(pd_ecommerce, func)(numeric_only=True),
                 getattr(ed_ecommerce, func)(numeric_only=True),
-                check_less_precise=True,
+                check_exact=False,
             )
 
     def test_flights_datetime_metrics_agg(self):
         ed_timestamps = self.ed_flights()[["timestamp"]]
         expected_values = {
-            "timestamp": {
-                "min": pd.Timestamp("2018-01-01 00:00:00"),
-                "mean": pd.Timestamp("2018-01-21 19:20:45.564438232"),
-                "max": pd.Timestamp("2018-02-11 23:50:12"),
-                "nunique": 12236,
-                "mad": pd.NaT,
-                "std": pd.NaT,
-                "sum": pd.NaT,
-                "var": pd.NaT,
-            }
+            "mad": pd.NaT,
+            "max": pd.Timestamp("2018-02-11 23:50:12"),
+            "mean": pd.Timestamp("2018-01-21 19:20:45.564438232"),
+            "min": pd.Timestamp("2018-01-01 00:00:00"),
+            "nunique": 12236,
+            "std": pd.NaT,
+            "sum": pd.NaT,
+            "var": pd.NaT,
         }
 
-        ed_metrics = ed_timestamps.agg(self.funcs + self.extended_funcs + ["nunique"])
-        ed_metrics_dict = ed_metrics.to_dict()
-        ed_metrics_dict["timestamp"].pop("median")  # Median is tested below.
+        ed_metrics = ed_timestamps.agg(
+            self.funcs + self.extended_funcs + ["nunique"], numeric_only=False
+        )
+        ed_metrics_dict = ed_metrics["timestamp"].to_dict()
+        ed_metrics_dict.pop("median")  # Median is tested below.
         assert ed_metrics_dict == expected_values
 
     @pytest.mark.parametrize("agg", ["mean", "min", "max", "nunique"])
@@ -230,7 +202,7 @@ class TestDataFrameMetrics(TestData):
         )
 
     def test_metric_agg_keep_dtypes(self):
-        # max, min, and median maintain their dtypes
+        # max, min, and median maintain their dtypes for numeric_only=None
         df = self.ed_flights_small()[["AvgTicketPrice", "Cancelled", "dayOfWeek"]]
         assert df.min().tolist() == [131.81910705566406, False, 0]
         assert df.max().tolist() == [989.9527587890625, True, 0]
@@ -250,3 +222,527 @@ class TestDataFrameMetrics(TestData):
             "Cancelled": {"max": True, "median": False, "min": False},
             "dayOfWeek": {"max": 0, "median": 0, "min": 0},
         }
+
+    def test_flights_numeric_only(self):
+        filter_data = [
+            "AvgTicketPrice",
+            "Cancelled",
+            "dayOfWeek",
+            "timestamp",
+            "DestCountry",
+        ]
+        # All Aggregations Data Check
+        ed_flights = self.ed_flights().filter(filter_data)
+        pd_flights = self.pd_flights().filter(filter_data)
+        # agg => numeric_only True returns float64 values
+        # We compare it with individual non-agg functions of pandas with numeric_only=True
+        # not checking mad because it returns nan value for booleans.
+        filtered_aggs = self.funcs + self.extended_funcs
+        filtered_aggs.remove("mad")
+        agg_data = ed_flights.agg(filtered_aggs, numeric_only=True).transpose()
+        for agg in filtered_aggs:
+            assert_series_equal(
+                agg_data[agg].rename(None),
+                getattr(pd_flights, agg)(
+                    **({"numeric_only": True} if agg != "mad" else {})
+                ),
+                check_exact=False,
+                rtol=True,
+            )
+
+    # Mean
+    @pytest.mark.parametrize("numeric_only", [True, False, None])
+    def test_mean_numeric_only(self, numeric_only):
+        filter_data = [
+            "AvgTicketPrice",
+            "Cancelled",
+            "dayOfWeek",
+            "timestamp",
+            "DestCountry",
+        ]
+        ed_flights = self.ed_flights().filter(filter_data)
+        if numeric_only is True:
+            expected_values = {
+                "AvgTicketPrice": 628.2536888148849,
+                "Cancelled": 0.1284937590933456,
+                "dayOfWeek": 2.835975189524466,
+            }
+            calculated_values = ed_flights.mean(numeric_only=numeric_only)
+            dtype_list = [calculated_values[i].dtype for i in calculated_values.index]
+            assert expected_values == calculated_values.to_dict()
+            assert dtype_list == [
+                np.dtype("float64"),
+                np.dtype("float64"),
+                np.dtype("float64"),
+            ]
+        elif numeric_only is False:
+            expected_values = {
+                "AvgTicketPrice": 628.2536888148849,
+                "Cancelled": True,
+                "dayOfWeek": 2,
+            }
+            calculated_values = ed_flights.mean(numeric_only=numeric_only)
+            assert isinstance(calculated_values["timestamp"], pd.Timestamp)
+            assert np.isnan(calculated_values["DestCountry"])
+            calculated_values = calculated_values.drop(["timestamp", "DestCountry"])
+            assert expected_values == calculated_values.to_dict()
+            dtype_list = [calculated_values[i].dtype for i in calculated_values.index]
+            assert dtype_list == [
+                np.dtype("float64"),
+                np.dtype("bool"),
+                np.dtype("int64"),
+            ]
+        elif numeric_only is None:
+            expected_values = {
+                "AvgTicketPrice": 628.2536888148849,
+                "Cancelled": True,
+                "dayOfWeek": 2,
+                "timestamp": pd.Timestamp("2018-01-21 19:20:45.564438232"),
+            }
+            calculated_values = ed_flights.mean(numeric_only=numeric_only)
+            assert expected_values == calculated_values.to_dict()
+            assert isinstance(calculated_values["timestamp"], pd.Timestamp)
+            calculated_values = calculated_values.drop("timestamp")
+            dtype_list = [calculated_values[i].dtype for i in calculated_values.index]
+            assert dtype_list == [
+                np.dtype("float64"),
+                np.dtype("bool"),
+                np.dtype("int64"),
+            ]
+
+    # Min
+    @pytest.mark.parametrize("numeric_only", [True, False, None])
+    def test_min_numeric_only(self, numeric_only):
+        filter_data = [
+            "AvgTicketPrice",
+            "Cancelled",
+            "dayOfWeek",
+            "timestamp",
+            "DestCountry",
+        ]
+        ed_flights = self.ed_flights().filter(filter_data)
+        if numeric_only is True:
+            expected_values = {
+                "AvgTicketPrice": 100.0205307006836,
+                "Cancelled": 0.0,
+                "dayOfWeek": 0.0,
+            }
+            calculated_values = ed_flights.min(numeric_only=numeric_only)
+            dtype_list = [calculated_values[i].dtype for i in calculated_values.index]
+            assert expected_values == calculated_values.to_dict()
+            assert dtype_list == [
+                np.dtype("float64"),
+                np.dtype("float64"),
+                np.dtype("float64"),
+            ]
+        elif numeric_only is False:
+            expected_values = {
+                "AvgTicketPrice": 100.0205307006836,
+                "Cancelled": False,
+                "dayOfWeek": 0,
+            }
+            calculated_values = ed_flights.min(numeric_only=numeric_only)
+            assert isinstance(calculated_values["timestamp"], pd.Timestamp)
+            assert np.isnan(calculated_values["DestCountry"])
+            calculated_values = calculated_values.drop(["timestamp", "DestCountry"])
+            assert expected_values == calculated_values.to_dict()
+            dtype_list = [calculated_values[i].dtype for i in calculated_values.index]
+            assert dtype_list == [
+                np.dtype("float64"),
+                np.dtype("bool"),
+                np.dtype("int64"),
+            ]
+        elif numeric_only is None:
+            expected_values = {
+                "AvgTicketPrice": 100.0205307006836,
+                "Cancelled": False,
+                "dayOfWeek": 0,
+                "timestamp": pd.Timestamp("2018-01-01 00:00:00"),
+            }
+            calculated_values = ed_flights.min(numeric_only=numeric_only)
+            assert expected_values == calculated_values.to_dict()
+            assert isinstance(calculated_values["timestamp"], pd.Timestamp)
+            calculated_values = calculated_values.drop("timestamp")
+            dtype_list = [calculated_values[i].dtype for i in calculated_values.index]
+            assert dtype_list == [
+                np.dtype("float64"),
+                np.dtype("bool"),
+                np.dtype("int64"),
+            ]
+
+    # max
+    @pytest.mark.parametrize("numeric_only", [True, False, None])
+    def test_max_numeric_only(self, numeric_only):
+        filter_data = [
+            "AvgTicketPrice",
+            "Cancelled",
+            "dayOfWeek",
+            "timestamp",
+            "DestCountry",
+        ]
+        ed_flights = self.ed_flights().filter(filter_data)
+        if numeric_only is True:
+            expected_values = {
+                "AvgTicketPrice": 1199.72900390625,
+                "Cancelled": 1.0,
+                "dayOfWeek": 6.0,
+            }
+            calculated_values = ed_flights.max(numeric_only=numeric_only)
+            dtype_list = [calculated_values[i].dtype for i in calculated_values.index]
+            assert expected_values == calculated_values.to_dict()
+            assert dtype_list == [
+                np.dtype("float64"),
+                np.dtype("float64"),
+                np.dtype("float64"),
+            ]
+        elif numeric_only is False:
+            expected_values = {
+                "AvgTicketPrice": 1199.72900390625,
+                "Cancelled": True,
+                "dayOfWeek": 6,
+            }
+            calculated_values = ed_flights.max(numeric_only=numeric_only)
+            assert isinstance(calculated_values["timestamp"], pd.Timestamp)
+            assert np.isnan(calculated_values["DestCountry"])
+            calculated_values = calculated_values.drop(["timestamp", "DestCountry"])
+            assert expected_values == calculated_values.to_dict()
+            dtype_list = [calculated_values[i].dtype for i in calculated_values.index]
+            assert dtype_list == [
+                np.dtype("float64"),
+                np.dtype("bool"),
+                np.dtype("int64"),
+            ]
+        elif numeric_only is None:
+            expected_values = {
+                "AvgTicketPrice": 1199.72900390625,
+                "Cancelled": True,
+                "dayOfWeek": 6,
+                "timestamp": pd.Timestamp("2018-02-11 23:50:12"),
+            }
+            calculated_values = ed_flights.max(numeric_only=numeric_only)
+            assert expected_values == calculated_values.to_dict()
+            assert isinstance(calculated_values["timestamp"], pd.Timestamp)
+            calculated_values = calculated_values.drop("timestamp")
+            dtype_list = [calculated_values[i].dtype for i in calculated_values.index]
+            assert dtype_list == [
+                np.dtype("float64"),
+                np.dtype("bool"),
+                np.dtype("int64"),
+            ]
+
+    # sum
+    @pytest.mark.parametrize("numeric_only", [True, False, None])
+    def test_sum_numeric_only(self, numeric_only):
+        filter_data = [
+            "AvgTicketPrice",
+            "Cancelled",
+            "dayOfWeek",
+            "timestamp",
+            "DestCountry",
+        ]
+        ed_flights = self.ed_flights().filter(filter_data)
+        if numeric_only is True:
+            expected_values = {
+                "AvgTicketPrice": 8204364.922233582,
+                "Cancelled": 1678.0,
+                "dayOfWeek": 37035.0,
+            }
+            calculated_values = ed_flights.sum(numeric_only=numeric_only)
+            dtype_list = [calculated_values[i].dtype for i in calculated_values.index]
+            assert expected_values == calculated_values.to_dict()
+            assert dtype_list == [
+                np.dtype("float64"),
+                np.dtype("float64"),
+                np.dtype("float64"),
+            ]
+        elif numeric_only is False:
+            expected_values = {
+                "AvgTicketPrice": 8204364.922233582,
+                "Cancelled": True,
+                "dayOfWeek": 37035,
+            }
+            calculated_values = ed_flights.sum(numeric_only=numeric_only)
+            assert pd.isnull(calculated_values["timestamp"])
+            assert np.isnan(calculated_values["DestCountry"])
+            calculated_values = calculated_values.drop(["timestamp", "DestCountry"])
+            assert expected_values == calculated_values.to_dict()
+            dtype_list = [calculated_values[i].dtype for i in calculated_values.index]
+            assert dtype_list == [
+                np.dtype("float64"),
+                np.dtype("bool"),
+                np.dtype("int64"),
+            ]
+        elif numeric_only is None:
+            expected_values = {
+                "AvgTicketPrice": 8204364.922233582,
+                "Cancelled": True,
+                "dayOfWeek": 37035,
+            }
+            calculated_values = ed_flights.sum(numeric_only=numeric_only)
+            assert expected_values == calculated_values.to_dict()
+            dtype_list = [calculated_values[i].dtype for i in calculated_values.index]
+            assert dtype_list == [
+                np.dtype("float64"),
+                np.dtype("bool"),
+                np.dtype("int64"),
+            ]
+
+    # std
+    @pytest.mark.parametrize("numeric_only", [True, False, None])
+    def test_std_numeric_only(self, numeric_only):
+        filter_data = [
+            "AvgTicketPrice",
+            "Cancelled",
+            "dayOfWeek",
+            "timestamp",
+            "DestCountry",
+        ]
+        ed_flights = self.ed_flights().filter(filter_data)
+        if numeric_only is True:
+            expected_values = {
+                "AvgTicketPrice": 266.4070611666801,
+                "Cancelled": 0.33466440694020916,
+                "dayOfWeek": 1.9395130445445228,
+            }
+            calculated_values = ed_flights.std(numeric_only=numeric_only)
+            dtype_list = [calculated_values[i].dtype for i in calculated_values.index]
+            assert expected_values == calculated_values.to_dict()
+            assert dtype_list == [
+                np.dtype("float64"),
+                np.dtype("float64"),
+                np.dtype("float64"),
+            ]
+        elif numeric_only is False:
+            expected_values = {
+                "AvgTicketPrice": 266.4070611666801,
+                "Cancelled": True,
+                "dayOfWeek": 1,
+            }
+            calculated_values = ed_flights.std(numeric_only=numeric_only)
+            assert pd.isnull(calculated_values["timestamp"])
+            assert np.isnan(calculated_values["DestCountry"])
+            calculated_values = calculated_values.drop(["timestamp", "DestCountry"])
+            assert expected_values == calculated_values.to_dict()
+            dtype_list = [calculated_values[i].dtype for i in calculated_values.index]
+            assert dtype_list == [
+                np.dtype("float64"),
+                np.dtype("bool"),
+                np.dtype("int64"),
+            ]
+        elif numeric_only is None:
+            expected_values = {
+                "AvgTicketPrice": 266.4070611666801,
+                "Cancelled": True,
+                "dayOfWeek": 1,
+            }
+            calculated_values = ed_flights.std(numeric_only=numeric_only)
+            assert expected_values == calculated_values.to_dict()
+            dtype_list = [calculated_values[i].dtype for i in calculated_values.index]
+            assert dtype_list == [
+                np.dtype("float64"),
+                np.dtype("bool"),
+                np.dtype("int64"),
+            ]
+
+    # var
+    @pytest.mark.parametrize("numeric_only", [True, False, None])
+    def test_var_numeric_only(self, numeric_only):
+        filter_data = [
+            "AvgTicketPrice",
+            "Cancelled",
+            "dayOfWeek",
+            "timestamp",
+            "DestCountry",
+        ]
+        ed_flights = self.ed_flights().filter(filter_data)
+        if numeric_only is True:
+            expected_values = {
+                "AvgTicketPrice": 70964.57023354847,
+                "Cancelled": 0.111987400797438,
+                "dayOfWeek": 3.7612787756607213,
+            }
+            calculated_values = ed_flights.var(numeric_only=numeric_only)
+            dtype_list = [calculated_values[i].dtype for i in calculated_values.index]
+            assert expected_values == calculated_values.to_dict()
+            assert dtype_list == [
+                np.dtype("float64"),
+                np.dtype("float64"),
+                np.dtype("float64"),
+            ]
+        elif numeric_only is False:
+            expected_values = {
+                "AvgTicketPrice": 70964.57023354847,
+                "Cancelled": True,
+                "dayOfWeek": 3,
+            }
+            calculated_values = ed_flights.var(numeric_only=numeric_only)
+            assert pd.isnull(calculated_values["timestamp"])
+            assert np.isnan(calculated_values["DestCountry"])
+            calculated_values = calculated_values.drop(["timestamp", "DestCountry"])
+            assert expected_values == calculated_values.to_dict()
+            dtype_list = [calculated_values[i].dtype for i in calculated_values.index]
+            assert dtype_list == [
+                np.dtype("float64"),
+                np.dtype("bool"),
+                np.dtype("int64"),
+            ]
+        elif numeric_only is None:
+            expected_values = {
+                "AvgTicketPrice": 70964.57023354847,
+                "Cancelled": True,
+                "dayOfWeek": 3,
+            }
+            calculated_values = ed_flights.var(numeric_only=numeric_only)
+            assert expected_values == calculated_values.to_dict()
+            dtype_list = [calculated_values[i].dtype for i in calculated_values.index]
+            assert dtype_list == [
+                np.dtype("float64"),
+                np.dtype("bool"),
+                np.dtype("int64"),
+            ]
+
+    # median
+    @pytest.mark.parametrize("numeric_only", [True, False, None])
+    def test_median_numeric_only(self, numeric_only):
+        filter_data = [
+            "AvgTicketPrice",
+            "Cancelled",
+            "dayOfWeek",
+            "timestamp",
+            "DestCountry",
+        ]
+        ed_flights = self.ed_flights().filter(filter_data)
+        if numeric_only is True:
+            expected_values = {
+                "AvgTicketPrice": 640.3872852064159,
+                "Cancelled": 0.0,
+                "dayOfWeek": 3.0,
+            }
+            calculated_values = ed_flights.median(numeric_only=numeric_only)
+            dtype_list = [calculated_values[i].dtype for i in calculated_values.index]
+            assert (
+                expected_values["Cancelled"] == calculated_values.to_dict()["Cancelled"]
+            )
+            assert (
+                expected_values["dayOfWeek"] == calculated_values.to_dict()["dayOfWeek"]
+            )
+            assert (
+                (calculated_values.to_dict()["AvgTicketPrice"] * 0.9)
+                <= expected_values["AvgTicketPrice"]
+                <= (calculated_values.to_dict()["AvgTicketPrice"] * 1.1)
+            )
+            assert dtype_list == [
+                np.dtype("float64"),
+                np.dtype("float64"),
+                np.dtype("float64"),
+            ]
+        elif numeric_only is False:
+            expected_values = {
+                "AvgTicketPrice": 640.3222933002547,
+                "Cancelled": False,
+                "dayOfWeek": 3,
+                "timestamp": pd.Timestamp("2018-01-21 23:58:10.414120850"),
+            }
+            calculated_values = ed_flights.median(numeric_only=numeric_only)
+            assert isinstance(calculated_values["timestamp"], pd.Timestamp)
+            assert np.isnan(calculated_values["DestCountry"])
+            assert (
+                expected_values["Cancelled"] == calculated_values.to_dict()["Cancelled"]
+            )
+            assert (
+                (calculated_values.to_dict()["AvgTicketPrice"] * 0.9)
+                <= expected_values["AvgTicketPrice"]
+                <= (calculated_values.to_dict()["AvgTicketPrice"] * 1.1)
+            )
+            assert (
+                pd.to_datetime("2018-01-21 23:00:00.000")
+                <= expected_values["timestamp"]
+                <= pd.to_datetime("2018-01-21 23:59:59.000")
+            )
+            assert (
+                expected_values["dayOfWeek"] == calculated_values.to_dict()["dayOfWeek"]
+            )
+            assert isinstance(calculated_values["Cancelled"], np.bool_)
+            assert isinstance(calculated_values["dayOfWeek"], np.int64)
+        elif numeric_only is None:
+            expected_values = {
+                "AvgTicketPrice": 640.3872852064159,
+                "Cancelled": False,
+                "dayOfWeek": 3,
+                "timestamp": pd.Timestamp("2018-01-21 23:58:10.414120850"),
+            }
+            calculated_values = ed_flights.median(numeric_only=numeric_only)
+            assert isinstance(calculated_values["timestamp"], pd.Timestamp)
+            assert (
+                (calculated_values.to_dict()["AvgTicketPrice"] * 0.9)
+                <= expected_values["AvgTicketPrice"]
+                <= (calculated_values.to_dict()["AvgTicketPrice"] * 1.1)
+            )
+            assert (
+                pd.to_datetime("2018-01-21 23:00:00.000")
+                <= expected_values["timestamp"]
+                <= pd.to_datetime("2018-01-21 23:59:00.000")
+            )
+            assert isinstance(calculated_values["Cancelled"], np.bool_)
+            assert isinstance(calculated_values["dayOfWeek"], np.int64)
+
+    # mad
+    @pytest.mark.parametrize("numeric_only", [True, False, None])
+    def test_mad_numeric_only(self, numeric_only):
+        filter_data = [
+            "AvgTicketPrice",
+            "Cancelled",
+            "dayOfWeek",
+            "timestamp",
+            "DestCountry",
+        ]
+        ed_flights = self.ed_flights().filter(filter_data)
+        if numeric_only is True:
+            expected_values = {"AvgTicketPrice": 213.47889841845912, "dayOfWeek": 2.0}
+            calculated_values = ed_flights.mad(numeric_only=numeric_only)
+            dtype_list = [calculated_values[i].dtype for i in calculated_values.index]
+            assert (
+                expected_values["dayOfWeek"] == calculated_values.to_dict()["dayOfWeek"]
+            )
+            assert (
+                (calculated_values["AvgTicketPrice"] * 0.9)
+                <= expected_values["AvgTicketPrice"]
+                <= (calculated_values["AvgTicketPrice"] * 1.1)
+            )
+            assert dtype_list == [
+                np.dtype("float64"),
+                np.dtype("float64"),
+            ]
+        elif numeric_only is False:
+            expected_values = {"AvgTicketPrice": 213.36870923117985, "dayOfWeek": 2.0}
+            calculated_values = ed_flights.mad(numeric_only=numeric_only)
+            assert pd.isnull(calculated_values["timestamp"])
+            assert np.isnan(calculated_values["DestCountry"])
+            assert np.isnan(calculated_values["Cancelled"])
+            calculated_values = calculated_values.drop(
+                ["timestamp", "DestCountry", "Cancelled"]
+            )
+            assert (
+                expected_values["dayOfWeek"] == calculated_values.to_dict()["dayOfWeek"]
+            )
+            assert (
+                (calculated_values["AvgTicketPrice"] * 0.9)
+                <= expected_values["AvgTicketPrice"]
+                <= (calculated_values["AvgTicketPrice"] * 1.1)
+            )
+            isinstance(calculated_values["AvgTicketPrice"], float)
+            isinstance(calculated_values["dayOfWeek"], float)
+
+        elif numeric_only is None:
+            expected_values = {"AvgTicketPrice": 213.4408885767035, "dayOfWeek": 2.0}
+            calculated_values = ed_flights.mad(numeric_only=numeric_only)
+            assert (
+                (calculated_values["AvgTicketPrice"] * 0.9)
+                <= expected_values["AvgTicketPrice"]
+                <= (calculated_values["AvgTicketPrice"] * 1.1)
+            )
+            dtype_list = [calculated_values[i].dtype for i in calculated_values.index]
+            assert dtype_list == [
+                np.dtype("float64"),
+                np.dtype("float64"),
+            ]

--- a/eland/tests/dataframe/test_metrics_pytest.py
+++ b/eland/tests/dataframe/test_metrics_pytest.py
@@ -34,6 +34,28 @@ class TestDataFrameMetrics(TestData):
         "DestCountry",
     ]
 
+    @pytest.mark.parametrize("numeric_only", [False, None])
+    def test_flights_metrics(self, numeric_only):
+        pd_flights = self.pd_flights()
+        ed_flights = self.ed_flights()
+
+        for func in self.funcs:
+            # Pandas v1.0 doesn't support mean() on datetime
+            # Pandas and Eland don't support sum() on datetime
+            if not numeric_only:
+                dtype_include = (
+                    [np.number, np.datetime64]
+                    if func not in ("mean", "sum")
+                    else [np.number]
+                )
+                pd_flights = pd_flights.select_dtypes(include=dtype_include)
+                ed_flights = ed_flights.select_dtypes(include=dtype_include)
+
+            pd_metric = getattr(pd_flights, func)(numeric_only=numeric_only)
+            ed_metric = getattr(ed_flights, func)(numeric_only=numeric_only)
+
+            assert_series_equal(pd_metric, ed_metric, check_dtype=False)
+
     def test_flights_extended_metrics(self):
         pd_flights = self.pd_flights()
         ed_flights = self.ed_flights()
@@ -93,8 +115,8 @@ class TestDataFrameMetrics(TestData):
             "user",
         ]
 
-        pd_ecommerce = self.pd_ecommerce().filter(columns)
-        ed_ecommerce = self.ed_ecommerce().filter(columns)
+        pd_ecommerce = self.pd_ecommerce()[columns]
+        ed_ecommerce = self.ed_ecommerce()[columns]
 
         for func in self.funcs:
             assert_series_equal(
@@ -115,8 +137,8 @@ class TestDataFrameMetrics(TestData):
             "user",
         ]
 
-        pd_ecommerce = self.pd_ecommerce().filter(columns)
-        ed_ecommerce = self.ed_ecommerce().filter(columns)
+        pd_ecommerce = self.pd_ecommerce()[columns]
+        ed_ecommerce = self.ed_ecommerce()[columns]
 
         for func in self.funcs:
             assert_series_equal(
@@ -129,8 +151,8 @@ class TestDataFrameMetrics(TestData):
         # All of these are numeric
         columns = ["total_quantity", "taxful_total_price", "taxless_total_price"]
 
-        pd_ecommerce = self.pd_ecommerce().filter(columns)
-        ed_ecommerce = self.ed_ecommerce().filter(columns)
+        pd_ecommerce = self.pd_ecommerce()[columns]
+        ed_ecommerce = self.ed_ecommerce()[columns]
 
         for func in self.funcs:
             assert_series_equal(
@@ -171,8 +193,10 @@ class TestDataFrameMetrics(TestData):
         ed_metric = ed_timestamps.agg([agg])
 
         if agg == "nunique":
+            # df with timestamp column should return int64
             assert ed_metric.dtypes["timestamp"] == np.int64
         else:
+            # df with timestamp column should return datetime64[ns]
             assert ed_metric.dtypes["timestamp"] == np.dtype("datetime64[ns]")
         assert ed_metric["timestamp"][0] == expected_values[agg]
 
@@ -209,7 +233,7 @@ class TestDataFrameMetrics(TestData):
         )
 
     def test_metric_agg_keep_dtypes(self):
-        # max, min, and median maintain their dtypes for numeric_only=None
+        # max, min and median maintain their dtypes
         df = self.ed_flights_small()[["AvgTicketPrice", "Cancelled", "dayOfWeek"]]
         assert df.min().tolist() == [131.81910705566406, False, 0]
         assert df.max().tolist() == [989.9527587890625, True, 0]
@@ -229,373 +253,162 @@ class TestDataFrameMetrics(TestData):
             "Cancelled": {"max": True, "median": False, "min": False},
             "dayOfWeek": {"max": 0, "median": 0, "min": 0},
         }
+        # sum should always be the same dtype as the input, except for bool where the sum of bools should be an int64.
+        sum_agg = df.agg(["sum"])
+        assert sum_agg.dtypes.to_list() == [
+            np.dtype("float64"),
+            np.dtype("int64"),
+            np.dtype("int64"),
+        ]
+        assert sum_agg.to_dict() == {
+            "AvgTicketPrice": {"sum": 26521.624084472656},
+            "Cancelled": {"sum": 6},
+            "dayOfWeek": {"sum": 0},
+        }
 
     def test_flights_numeric_only(self):
-        filter_data = [
-            "AvgTicketPrice",
-            "Cancelled",
-            "dayOfWeek",
-            "timestamp",
-            "DestCountry",
-        ]
         # All Aggregations Data Check
-        ed_flights = self.ed_flights().filter(filter_data)
-        pd_flights = self.pd_flights().filter(filter_data)
+        ed_flights = self.ed_flights().filter(self.filter_data)
+        pd_flights = self.pd_flights().filter(self.filter_data)
         # agg => numeric_only True returns float64 values
-        # We compare it with individual non-agg functions of pandas with numeric_only=True
-        # not checking mad because it returns nan value for booleans.
+        # We compare it with individual single agg functions of pandas with numeric_only=True
         filtered_aggs = self.funcs + self.extended_funcs
-        filtered_aggs.remove("mad")
         agg_data = ed_flights.agg(filtered_aggs, numeric_only=True).transpose()
         for agg in filtered_aggs:
-            assert_series_equal(
-                agg_data[agg].rename(None),
-                getattr(pd_flights, agg)(
-                    **({"numeric_only": True} if agg != "mad" else {})
-                ),
-                check_exact=False,
-                rtol=True,
-            )
+            # Explicitly check for mad because it returns nan for bools
+            if agg == "mad":
+                assert np.isnan(agg_data[agg]["Cancelled"])
+            else:
+                assert_series_equal(
+                    agg_data[agg].rename(None),
+                    getattr(pd_flights, agg)(numeric_only=True),
+                    check_exact=False,
+                    rtol=True,
+                )
 
-    # Mean
-    @pytest.mark.parametrize("numeric_only", [True, False, None])
-    def test_mean_numeric_only(self, numeric_only):
+    # all single aggs return float64 for numeric_only=True
+    def test_numeric_only_true_single_aggs(self):
         ed_flights = self.ed_flights().filter(self.filter_data)
-        if numeric_only is True:
-            calculated_values = ed_flights.mean(numeric_only=numeric_only)
-            assert calculated_values.to_list() == [
-                628.2536888148849,
-                0.1284937590933456,
-                2.835975189524466,
-            ]
-            dtype_list = [calculated_values[i].dtype for i in calculated_values.index]
-            assert dtype_list == [
-                np.dtype("float64"),
-                np.dtype("float64"),
-                np.dtype("float64"),
-            ]
-        elif numeric_only is False:
-            calculated_values = ed_flights.mean(numeric_only=numeric_only)
+        for agg in self.funcs + self.extended_funcs:
+            result = getattr(ed_flights, agg)(numeric_only=True)
+            assert result.dtype == np.dtype("float64")
+            assert result.shape == ((3,) if agg != "mad" else (2,))
+
+    # check dtypes and shape of min, max and median for numeric_only=False | None
+    @pytest.mark.parametrize("agg", ["min", "max", "median"])
+    @pytest.mark.parametrize("numeric_only", [False, None])
+    def test_min_max_median_numeric_only(self, agg, numeric_only):
+        ed_flights = self.ed_flights().filter(self.filter_data)
+        if numeric_only is False:
+            calculated_values = getattr(ed_flights, agg)(numeric_only=numeric_only)
+            assert isinstance(calculated_values["AvgTicketPrice"], np.float64)
+            assert isinstance(calculated_values["Cancelled"], np.bool_)
+            assert isinstance(calculated_values["dayOfWeek"], np.int64)
             assert isinstance(calculated_values["timestamp"], pd.Timestamp)
             assert np.isnan(calculated_values["DestCountry"])
-            calculated_values = calculated_values.drop(["timestamp", "DestCountry"])
-            assert calculated_values.to_list() == [
-                628.2536888148849,
-                0.1284937590933456,
-                2.835975189524466,
-            ]
-            assert isinstance(calculated_values["AvgTicketPrice"], float)
-            assert isinstance(calculated_values["dayOfWeek"], float)
-            assert isinstance(calculated_values["Cancelled"], float)
+            assert calculated_values.shape == (5,)
         elif numeric_only is None:
-            calculated_values = ed_flights.mean(numeric_only=numeric_only)
-            assert calculated_values.to_list() == [
-                628.2536888148849,
-                0.1284937590933456,
-                2.835975189524466,
-                pd.Timestamp("2018-01-21 19:20:45.564438232"),
-            ]
+            calculated_values = getattr(ed_flights, agg)(numeric_only=numeric_only)
+            assert isinstance(calculated_values["AvgTicketPrice"], np.float64)
+            assert isinstance(calculated_values["Cancelled"], np.bool_)
+            assert isinstance(calculated_values["dayOfWeek"], np.int64)
             assert isinstance(calculated_values["timestamp"], pd.Timestamp)
-            calculated_values = calculated_values.drop("timestamp")
-            assert isinstance(calculated_values["AvgTicketPrice"], float)
-            assert isinstance(calculated_values["dayOfWeek"], float)
-            assert isinstance(calculated_values["Cancelled"], float)
+            assert calculated_values.shape == (4,)
 
-    # Min
-    @pytest.mark.parametrize("numeric_only", [True, False, None])
-    def test_min_numeric_only(self, numeric_only):
-        ed_flights = self.ed_flights().filter(self.filter_data)
-        if numeric_only is True:
-            calculated_values = ed_flights.min(numeric_only=numeric_only)
-            assert calculated_values.to_list() == [100.0205307006836, 0.0, 0.0]
-            dtype_list = [calculated_values[i].dtype for i in calculated_values.index]
-            assert dtype_list == [
-                np.dtype("float64"),
-                np.dtype("float64"),
-                np.dtype("float64"),
-            ]
-        elif numeric_only is False:
-            calculated_values = ed_flights.min(numeric_only=numeric_only)
-            assert isinstance(calculated_values["timestamp"], pd.Timestamp)
-            assert np.isnan(calculated_values["DestCountry"])
-            calculated_values = calculated_values.drop(["timestamp", "DestCountry"])
-            assert calculated_values.to_list() == [100.0205307006836, 0, False]
-            assert isinstance(calculated_values["AvgTicketPrice"], np.float64)
-            assert isinstance(calculated_values["dayOfWeek"], np.int64)
-            assert isinstance(calculated_values["Cancelled"], np.bool_)
-        elif numeric_only is None:
-            calculated_values = ed_flights.min(numeric_only=numeric_only)
-            assert calculated_values.to_list() == [
-                100.0205307006836,
-                0,
-                False,
-                pd.Timestamp("2018-01-01 00:00:00"),
-            ]
-            assert isinstance(calculated_values["timestamp"], pd.Timestamp)
-            assert isinstance(calculated_values["AvgTicketPrice"], np.float64)
-            assert isinstance(calculated_values["dayOfWeek"], np.int64)
-            assert isinstance(calculated_values["Cancelled"], np.bool_)
-
-    # max
-    @pytest.mark.parametrize("numeric_only", [True, False, None])
-    def test_max_numeric_only(self, numeric_only):
-        ed_flights = self.ed_flights().filter(self.filter_data)
-        if numeric_only is True:
-            calculated_values = ed_flights.max(numeric_only=numeric_only)
-            assert calculated_values.to_list() == [1199.72900390625, 1.0, 6.0]
-            dtype_list = [calculated_values[i].dtype for i in calculated_values.index]
-            assert dtype_list == [
-                np.dtype("float64"),
-                np.dtype("float64"),
-                np.dtype("float64"),
-            ]
-        elif numeric_only is False:
-            calculated_values = ed_flights.max(numeric_only=numeric_only)
-            assert isinstance(calculated_values["timestamp"], pd.Timestamp)
-            assert np.isnan(calculated_values["DestCountry"])
-            calculated_values = calculated_values.drop(["timestamp", "DestCountry"])
-            assert calculated_values.to_list() == [1199.72900390625, True, 6]
-            assert isinstance(calculated_values["AvgTicketPrice"], np.float64)
-            assert isinstance(calculated_values["dayOfWeek"], np.int64)
-            assert isinstance(calculated_values["Cancelled"], np.bool_)
-        elif numeric_only is None:
-            calculated_values = ed_flights.max(numeric_only=numeric_only)
-            assert isinstance(calculated_values["timestamp"], pd.Timestamp)
-            calculated_values = calculated_values.drop("timestamp")
-            assert calculated_values.to_list() == [1199.72900390625, True, 6]
-            assert isinstance(calculated_values["AvgTicketPrice"], np.float64)
-            assert isinstance(calculated_values["dayOfWeek"], np.int64)
-            assert isinstance(calculated_values["Cancelled"], np.bool_)
-
-    # sum
-    @pytest.mark.parametrize("numeric_only", [True, False, None])
+    # check dtypes and shape for sum
+    @pytest.mark.parametrize("numeric_only", [False, None])
     def test_sum_numeric_only(self, numeric_only):
         ed_flights = self.ed_flights().filter(self.filter_data)
-        if numeric_only is True:
+        if numeric_only is False:
             calculated_values = ed_flights.sum(numeric_only=numeric_only)
-            dtype_list = [calculated_values[i].dtype for i in calculated_values.index]
-            assert calculated_values.to_list() == [8204364.922233582, 1678.0, 37035.0]
-            assert dtype_list == [
-                np.dtype("float64"),
-                np.dtype("float64"),
-                np.dtype("float64"),
-            ]
-        elif numeric_only is False:
-            calculated_values = ed_flights.sum(numeric_only=numeric_only)
-            assert pd.isnull(calculated_values["timestamp"])
-            assert np.isnan(calculated_values["DestCountry"])
-            calculated_values = calculated_values.drop(["timestamp", "DestCountry"])
-            assert calculated_values.to_list() == [8204364.922233582, 1678, 37035]
             assert isinstance(calculated_values["AvgTicketPrice"], np.float64)
             assert isinstance(calculated_values["dayOfWeek"], np.int64)
             assert isinstance(calculated_values["Cancelled"], np.int64)
+            assert pd.isnull(calculated_values["timestamp"])
+            assert np.isnan(calculated_values["DestCountry"])
+            assert calculated_values.shape == (5,)
         elif numeric_only is None:
             calculated_values = ed_flights.sum(numeric_only=numeric_only)
-            assert calculated_values.to_list() == [8204364.922233582, 1678, 37035]
             dtype_list = [calculated_values[i].dtype for i in calculated_values.index]
             assert dtype_list == [
                 np.dtype("float64"),
                 np.dtype("int64"),
                 np.dtype("int64"),
             ]
+            assert calculated_values.shape == (3,)
 
-    # std
-    @pytest.mark.parametrize("numeric_only", [True, False, None])
+    # check dtypes and shape for std
+    @pytest.mark.parametrize("numeric_only", [False, None])
     def test_std_numeric_only(self, numeric_only):
         ed_flights = self.ed_flights().filter(self.filter_data)
-        if numeric_only is True:
+        if numeric_only is False:
             calculated_values = ed_flights.std(numeric_only=numeric_only)
-            dtype_list = [calculated_values[i].dtype for i in calculated_values.index]
-            assert calculated_values.to_list() == [
-                266.4070611666801,
-                0.33466440694020916,
-                1.9395130445445228,
-            ]
-            assert dtype_list == [
-                np.dtype("float64"),
-                np.dtype("float64"),
-                np.dtype("float64"),
-            ]
-        elif numeric_only is False:
-            calculated_values = ed_flights.std(numeric_only=numeric_only)
+            assert isinstance(calculated_values["AvgTicketPrice"], float)
+            assert isinstance(calculated_values["Cancelled"], float)
+            assert isinstance(calculated_values["dayOfWeek"], float)
             assert pd.isnull(calculated_values["timestamp"])
             assert np.isnan(calculated_values["DestCountry"])
-            calculated_values = calculated_values.drop(["timestamp", "DestCountry"])
-            assert calculated_values.to_list() == [
-                266.4070611666801,
-                0.33466440694020916,
-                1.9395130445445228,
-            ]
-            assert isinstance(calculated_values["AvgTicketPrice"], float)
-            assert isinstance(calculated_values["dayOfWeek"], float)
-            assert isinstance(calculated_values["Cancelled"], float)
+            assert calculated_values.shape == (5,)
         elif numeric_only is None:
             calculated_values = ed_flights.std(numeric_only=numeric_only)
-            assert calculated_values.to_list() == [
-                266.4070611666801,
-                0.33466440694020916,
-                1.9395130445445228,
-            ]
             assert isinstance(calculated_values["AvgTicketPrice"], float)
-            assert isinstance(calculated_values["dayOfWeek"], float)
             assert isinstance(calculated_values["Cancelled"], float)
+            assert isinstance(calculated_values["dayOfWeek"], float)
+            assert calculated_values.shape == (3,)
 
-    # var
-    @pytest.mark.parametrize("numeric_only", [True, False, None])
+    # check dtypes and shape for var
+    @pytest.mark.parametrize("numeric_only", [False, None])
     def test_var_numeric_only(self, numeric_only):
         ed_flights = self.ed_flights().filter(self.filter_data)
-        if numeric_only is True:
+        if numeric_only is False:
             calculated_values = ed_flights.var(numeric_only=numeric_only)
-            dtype_list = [calculated_values[i].dtype for i in calculated_values.index]
-            assert calculated_values.to_list() == [
-                70964.57023354847,
-                0.111987400797438,
-                3.7612787756607213,
-            ]
-            assert dtype_list == [
-                np.dtype("float64"),
-                np.dtype("float64"),
-                np.dtype("float64"),
-            ]
-        elif numeric_only is False:
-            calculated_values = ed_flights.var(numeric_only=numeric_only)
-            assert pd.isnull(calculated_values["timestamp"])
-            assert np.isnan(calculated_values["DestCountry"])
-            calculated_values = calculated_values.drop(["timestamp", "DestCountry"])
-            assert calculated_values.to_list() == [
-                70964.57023354847,
-                0.111987400797438,
-                3.7612787756607213,
-            ]
             assert isinstance(calculated_values["AvgTicketPrice"], np.float64)
             assert isinstance(calculated_values["dayOfWeek"], np.float64)
             assert isinstance(calculated_values["Cancelled"], np.float64)
-        elif numeric_only is None:
-            calculated_values = ed_flights.var(numeric_only=numeric_only)
-            assert calculated_values.to_list() == [
-                70964.57023354847,
-                0.111987400797438,
-                3.7612787756607213,
-            ]
-            dtype_list = [calculated_values[i].dtype for i in calculated_values.index]
-            assert dtype_list == [
-                np.dtype("float64"),
-                np.dtype("float64"),
-                np.dtype("float64"),
-            ]
-
-    # median
-    @pytest.mark.parametrize("numeric_only", [True, False, None])
-    def test_median_numeric_only(self, numeric_only):
-        ed_flights = self.ed_flights().filter(self.filter_data)
-        if numeric_only is True:
-            calculated_values = ed_flights.median(numeric_only=numeric_only)
-            dtype_list = [calculated_values[i].dtype for i in calculated_values.index]
-            assert (
-                (calculated_values.to_dict()["AvgTicketPrice"] * 0.9)
-                <= 640.3872852064159
-                <= (calculated_values.to_dict()["AvgTicketPrice"] * 1.1)
-            )
-            assert calculated_values["Cancelled"] == 0.0
-            assert calculated_values["dayOfWeek"] == 3.0
-            assert dtype_list == [
-                np.dtype("float64"),
-                np.dtype("float64"),
-                np.dtype("float64"),
-            ]
-        elif numeric_only is False:
-            expected_values = {
-                "AvgTicketPrice": 640.3222933002547,
-                "Cancelled": False,
-                "dayOfWeek": 3,
-                "timestamp": pd.Timestamp("2018-01-21 23:58:10.414120850"),
-            }
-            calculated_values = ed_flights.median(numeric_only=numeric_only)
-            assert isinstance(calculated_values["timestamp"], pd.Timestamp)
-            assert np.isnan(calculated_values["DestCountry"])
-            assert (
-                expected_values["Cancelled"] == calculated_values.to_dict()["Cancelled"]
-            )
-            assert (
-                (calculated_values.to_dict()["AvgTicketPrice"] * 0.9)
-                <= expected_values["AvgTicketPrice"]
-                <= (calculated_values.to_dict()["AvgTicketPrice"] * 1.1)
-            )
-            assert (
-                pd.to_datetime("2018-01-21 23:00:00.000")
-                <= expected_values["timestamp"]
-                <= pd.to_datetime("2018-01-21 23:59:59.000")
-            )
-            assert (
-                expected_values["dayOfWeek"] == calculated_values.to_dict()["dayOfWeek"]
-            )
-            assert isinstance(calculated_values["Cancelled"], np.bool_)
-            assert isinstance(calculated_values["dayOfWeek"], np.int64)
-        elif numeric_only is None:
-            expected_values = {
-                "AvgTicketPrice": 640.3872852064159,
-                "Cancelled": False,
-                "dayOfWeek": 3,
-                "timestamp": pd.Timestamp("2018-01-21 23:58:10.414120850"),
-            }
-            calculated_values = ed_flights.median(numeric_only=numeric_only)
-            assert isinstance(calculated_values["timestamp"], pd.Timestamp)
-            assert (
-                (calculated_values.to_dict()["AvgTicketPrice"] * 0.9)
-                <= expected_values["AvgTicketPrice"]
-                <= (calculated_values.to_dict()["AvgTicketPrice"] * 1.1)
-            )
-            assert (
-                pd.to_datetime("2018-01-21 23:00:00.000")
-                <= expected_values["timestamp"]
-                <= pd.to_datetime("2018-01-21 23:59:00.000")
-            )
-            assert isinstance(calculated_values["Cancelled"], np.bool_)
-            assert isinstance(calculated_values["dayOfWeek"], np.int64)
-
-    # mad
-    @pytest.mark.parametrize("numeric_only", [True, False, None])
-    def test_mad_numeric_only(self, numeric_only):
-        ed_flights = self.ed_flights().filter(self.filter_data)
-        if numeric_only is True:
-            expected_values = {"AvgTicketPrice": 213.47889841845912, "dayOfWeek": 2.0}
-            calculated_values = ed_flights.mad(numeric_only=numeric_only)
-            assert (
-                expected_values["dayOfWeek"] == calculated_values.to_dict()["dayOfWeek"]
-            )
-            assert (
-                (calculated_values["AvgTicketPrice"] * 0.9)
-                <= expected_values["AvgTicketPrice"]
-                <= (calculated_values["AvgTicketPrice"] * 1.1)
-            )
-            assert calculated_values["AvgTicketPrice"].dtype == np.dtype("float64")
-        elif numeric_only is False:
-            expected_values = {"AvgTicketPrice": 213.36870923117985, "dayOfWeek": 2.0}
-            calculated_values = ed_flights.mad(numeric_only=numeric_only)
             assert pd.isnull(calculated_values["timestamp"])
             assert np.isnan(calculated_values["DestCountry"])
-            assert np.isnan(calculated_values["Cancelled"])
-            calculated_values = calculated_values.drop(
-                ["timestamp", "DestCountry", "Cancelled"]
-            )
-            assert (
-                expected_values["dayOfWeek"] == calculated_values.to_dict()["dayOfWeek"]
-            )
-            assert (
-                (calculated_values["AvgTicketPrice"] * 0.9)
-                <= expected_values["AvgTicketPrice"]
-                <= (calculated_values["AvgTicketPrice"] * 1.1)
-            )
-            assert isinstance(calculated_values["AvgTicketPrice"], float)
-            assert isinstance(calculated_values["dayOfWeek"], float)
-
+            assert calculated_values.shape == (5,)
         elif numeric_only is None:
-            expected_values = {"AvgTicketPrice": 213.4408885767035, "dayOfWeek": 2.0}
-            calculated_values = ed_flights.mad(numeric_only=numeric_only)
-            assert (
-                (calculated_values["AvgTicketPrice"] * 0.9)
-                <= expected_values["AvgTicketPrice"]
-                <= (calculated_values["AvgTicketPrice"] * 1.1)
-            )
+            calculated_values = ed_flights.var(numeric_only=numeric_only)
+            assert isinstance(calculated_values["AvgTicketPrice"], float)
+            assert isinstance(calculated_values["Cancelled"], float)
+            assert isinstance(calculated_values["dayOfWeek"], float)
+            assert calculated_values.shape == (3,)
+
+    # check dtypes and shape for mean
+    @pytest.mark.parametrize("numeric_only", [False, None])
+    def test_mean_numeric_only(self, numeric_only):
+        ed_flights = self.ed_flights().filter(self.filter_data)
+        if numeric_only is False:
+            calculated_values = ed_flights.mean(numeric_only=numeric_only)
             assert isinstance(calculated_values["AvgTicketPrice"], float)
             assert isinstance(calculated_values["dayOfWeek"], float)
+            assert isinstance(calculated_values["Cancelled"], float)
+            assert isinstance(calculated_values["timestamp"], pd.Timestamp)
+            assert np.isnan(calculated_values["DestCountry"])
+            assert calculated_values.shape == (5,)
+        elif numeric_only is None:
+            calculated_values = ed_flights.mean(numeric_only=numeric_only)
+            assert isinstance(calculated_values["AvgTicketPrice"], float)
+            assert isinstance(calculated_values["Cancelled"], float)
+            assert isinstance(calculated_values["dayOfWeek"], float)
+            assert isinstance(calculated_values["timestamp"], pd.Timestamp)
+            assert calculated_values.shape == (4,)
+
+    # check dtypes and shape for mad
+    @pytest.mark.parametrize("numeric_only", [False, None])
+    def test_mad_numeric_only(self, numeric_only):
+        ed_flights = self.ed_flights().filter(self.filter_data)
+        if numeric_only is False:
+            calculated_values = ed_flights.mad(numeric_only=numeric_only)
+            assert isinstance(calculated_values["AvgTicketPrice"], float)
+            assert isinstance(calculated_values["Cancelled"], np.float64)
+            assert isinstance(calculated_values["dayOfWeek"], float)
+            assert pd.isnull(calculated_values["timestamp"])
+            assert np.isnan(calculated_values["DestCountry"])
+            assert calculated_values.shape == (5,)
+        elif numeric_only is None:
+            calculated_values = ed_flights.mad(numeric_only=numeric_only)
+            assert isinstance(calculated_values["AvgTicketPrice"], float)
+            assert isinstance(calculated_values["dayOfWeek"], float)
+            assert calculated_values.shape == (2,)

--- a/eland/tests/series/test_metrics_pytest.py
+++ b/eland/tests/series/test_metrics_pytest.py
@@ -72,7 +72,7 @@ class TestSeriesMetrics(TestData):
             if func == "nunique":  # nunique never returns 'NaN'
                 continue
 
-            ed_metric = getattr(ed_ecommerce, func)()
+            ed_metric = getattr(ed_ecommerce, func)(numeric_only=False)
             print(func, ed_metric)
             assert np.isnan(ed_metric)
 
@@ -86,7 +86,9 @@ class TestSeriesMetrics(TestData):
 
             for func in self.all_funcs:
                 pd_metric = getattr(pd_ecommerce, func)()
-                ed_metric = getattr(ed_ecommerce, func)()
+                ed_metric = getattr(ed_ecommerce, func)(
+                    **({"numeric_only": True} if (func != "nunique") else {})
+                )
                 self.assert_almost_equal_for_agg(func, pd_metric, ed_metric)
 
     @pytest.mark.parametrize("agg", ["mean", "min", "max"])


### PR DESCRIPTION
Closes #254 
- Added numeric_only = True | False | None for all agg and aggs (except nunique)
- Added logic where booleans are not supported by median_absolute_deviation
- Added tests, doctests for every change made, also modified existing tests to work with these changes.
- Nox and pytest sessions are successful.

