### PR TITLE
Fix build errors on 8.0 snapshot

### DIFF
--- a/eland/tests/dataframe/test_datetime_pytest.py
+++ b/eland/tests/dataframe/test_datetime_pytest.py
@@ -222,7 +222,7 @@ class TestDataFrameDateTime(TestData):
             "strict_week_date_time_no_millis": dt.strftime("%G-W%V-%uT%H:%M:%S%z"),
             "week_date_time_no_millis": dt.strftime("%G-W%V-%uT%H:%M:%S%z"),
             "strict_weekyear": dt.strftime("%G"),
-            "weekyear": dt.strftime("%G"),
+            "week_year": dt.strftime("%G"),
             "strict_weekyear_week": dt.strftime("%G-W%V"),
             "weekyear_week": dt.strftime("%G-W%V"),
             "strict_weekyear_week_day": dt.strftime("%G-W%V-%u"),

--- a/eland/tests/field_mappings/test_datetime_pytest.py
+++ b/eland/tests/field_mappings/test_datetime_pytest.py
@@ -162,7 +162,7 @@ class TestDateTime(TestData):
             "strict_week_date_time_no_millis": dt.strftime("%G-W%V-%uT%H:%M:%S%z"),
             "week_date_time_no_millis": dt.strftime("%G-W%V-%uT%H:%M:%S%z"),
             "strict_weekyear": dt.strftime("%G"),
-            "weekyear": dt.strftime("%G"),
+            "week_year": dt.strftime("%G"),
             "strict_weekyear_week": dt.strftime("%G-W%V"),
             "weekyear_week": dt.strftime("%G-W%V"),
             "strict_weekyear_week_day": dt.strftime("%G-W%V-%u"),


### PR DESCRIPTION
- There was a deprecation warning which says **weekyear** should be in snake case in future versions.
- Tested this on 7.x-SNAPSHOT and 8.0.0-SNAPSHOT
This resolves current build error on 8.0.0-SNAPSHOT and makes build successful. 😃 

@sethmlarson . Please review this.