### PR TITLE
Add support for MultiIndex

### DIFF
--- a/docs/source/reference/api/eland.MultiIndex.rst
+++ b/docs/source/reference/api/eland.MultiIndex.rst
@@ -1,0 +1,6 @@
+eland.MultiIndex
+================
+
+.. currentmodule:: eland
+
+.. autoclass:: MultiIndex

--- a/docs/source/reference/indexing.rst
+++ b/docs/source/reference/indexing.rst
@@ -15,3 +15,4 @@ Constructor
    :toctree: api/
 
    Index
+   MultiIndex

--- a/eland/__init__.py
+++ b/eland/__init__.py
@@ -26,7 +26,7 @@ from eland._version import (  # noqa: F401
     __maintainer_email__,
 )
 from eland.common import SortOrder
-from eland.index import Index
+from eland.index import Index, MultiIndex
 from eland.ndframe import NDFrame
 from eland.series import Series
 from eland.dataframe import DataFrame
@@ -37,6 +37,7 @@ __all__ = [
     "Series",
     "NDFrame",
     "Index",
+    "MultiIndex",
     "pandas_to_eland",
     "eland_to_pandas",
     "csv_to_eland",

--- a/eland/actions.py
+++ b/eland/actions.py
@@ -16,7 +16,7 @@
 #  under the License.
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
 from eland import SortOrder
 
 
@@ -50,14 +50,19 @@ class PostProcessingAction(ABC):
 
 
 class SortIndexAction(PostProcessingAction):
-    def __init__(self) -> None:
+    def __init__(self, sort_orders: Optional[List[SortOrder]] = None) -> None:
         super().__init__("sort_index")
+        self._sort_orders = sort_orders
 
     def resolve_action(self, df: "pd.DataFrame") -> "pd.DataFrame":
-        return df.sort_index()
+        if self._sort_orders is None:
+            return df.sort_index()
+        for i, sort_order in list(enumerate(self._sort_orders))[::-1]:
+            df = df.sort_index(level=i, ascending=sort_order == SortOrder.ASC)
+        return df
 
     def __repr__(self) -> str:
-        return f"('{self.type}')"
+        return f"('{self.type}': ('sort_orders': {self._sort_orders})"
 
 
 class HeadAction(PostProcessingAction):
@@ -87,24 +92,36 @@ class TailAction(PostProcessingAction):
 
 
 class SortFieldAction(PostProcessingAction):
-    def __init__(self, sort_params_string: str) -> None:
+    def __init__(
+        self,
+        sort_params: List[Dict[str, Dict[str, str]]],
+        es_index_fields: Tuple[str, ...],
+    ) -> None:
         super().__init__("sort_field")
 
-        if sort_params_string is None:
-            raise ValueError("Expected valid string")
-
-        # Split string
-        sort_field, _, sort_order = sort_params_string.partition(":")
-        if not sort_field or sort_order not in ("asc", "desc"):
-            raise ValueError(
-                f"Expected ES sort params string (e.g. _doc:desc). Got '{sort_params_string}'"
-            )
-
-        self._sort_field = sort_field
-        self._sort_order = SortOrder.from_string(sort_order)
+        self._sort_params = []
+        for sort_param in sort_params:
+            sort_field, order = sort_param.popitem()
+            if sort_field == "_doc":
+                sort_field = "_id"
+            _, sort_order = order.popitem()
+            self._sort_params.append((sort_field, SortOrder.from_string(sort_order)))
+        self._es_index_fields = es_index_fields
 
     def resolve_action(self, df: "pd.DataFrame") -> "pd.DataFrame":
-        return df.sort_values(self._sort_field, self._sort_order == SortOrder.ASC)
+        # Need to detect if a column is also in an index
+        # and call sort_index() if that is the case to avoid the
+        # ambiguity error raised from sort_values() when there
+        # are matches between df.index and df.columns.
+        for sort_field, sort_order in self._sort_params[::-1]:
+            if sort_field in self._es_index_fields:
+                df = df.sort_index(
+                    level=self._es_index_fields.index(sort_field),
+                    ascending=sort_order == SortOrder.ASC,
+                )
+            else:
+                df = df.sort_values(sort_field, ascending=sort_order == SortOrder.ASC)
+        return df
 
     def __repr__(self) -> str:
-        return f"('{self.type}': ('sort_field': '{self._sort_field}', 'sort_order': {self._sort_order}))"
+        return f"('{self.type}': ('sort_params': '{self._sort_params}'))"

--- a/eland/index.py
+++ b/eland/index.py
@@ -15,11 +15,25 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
-from typing import Optional, TextIO, TYPE_CHECKING
+from typing import Optional, TextIO, TYPE_CHECKING, Union, Sequence, Tuple, List
 from eland.utils import deprecated_api
 
 if TYPE_CHECKING:
     from .query_compiler import QueryCompiler
+
+
+def make_index(
+    query_compiler: "QueryCompiler",
+    es_index_fields: Optional[Union[str, Sequence[str]]],
+) -> "Index":
+    if es_index_fields is None:
+        es_index_fields = (Index.ID_INDEX_FIELD,)
+    elif isinstance(es_index_fields, str):
+        es_index_fields = (es_index_fields,)
+    if len(es_index_fields) == 1:
+        return Index(query_compiler, es_index_fields=es_index_fields[0])
+    else:
+        return MultiIndex(query_compiler, es_index_fields=es_index_fields)
 
 
 class Index:
@@ -32,7 +46,8 @@ class Index:
     For slicing and sorting operations it must be a docvalues field. By default _id is used,
     which can't be used for range queries and is inefficient for sorting:
 
-    https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-id-field.html
+    `<https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-id-field.html>`_
+
     (The value of the _id field is also accessible in aggregations or for sorting,
     but doing so is discouraged as it requires to load a lot of data in memory.
     In case sorting or aggregating on the _id field is required, it is advised to duplicate
@@ -43,7 +58,9 @@ class Index:
     ID_SORT_FIELD = "_doc"  # if index field is _id, sort by _doc
 
     def __init__(
-        self, query_compiler: "QueryCompiler", es_index_field: Optional[str] = None
+        self,
+        query_compiler: "QueryCompiler",
+        es_index_fields: Optional[Union[str, Sequence[str]]] = None,
     ):
         self._query_compiler = query_compiler
 
@@ -54,30 +71,7 @@ class Index:
         # The type:ignore is due to mypy not being smart enough
         # to recognize the property.setter has a different type
         # than the property.getter.
-        self.es_index_field = es_index_field  # type: ignore
-
-    @property
-    def sort_field(self) -> str:
-        if self._index_field == self.ID_INDEX_FIELD:
-            return self.ID_SORT_FIELD
-        return self._index_field
-
-    @property
-    def is_source_field(self) -> bool:
-        return self._is_source_field
-
-    @property
-    def es_index_field(self) -> str:
-        return self._index_field
-
-    @es_index_field.setter
-    def es_index_field(self, index_field: Optional[str]) -> None:
-        if index_field is None or index_field == Index.ID_INDEX_FIELD:
-            self._index_field = Index.ID_INDEX_FIELD
-            self._is_source_field = False
-        else:
-            self._index_field = index_field
-            self._is_source_field = True
+        self.es_index_fields = es_index_fields  # type: ignore
 
     def __len__(self) -> int:
         return self._query_compiler._index_count()
@@ -90,11 +84,98 @@ class Index:
     def __iter__(self) -> "Index":
         return self
 
+    @property
+    def shape(self) -> Tuple[int]:
+        """Return a tuple of the shape of the underlying data."""
+        return (len(self),)
+
+    @property
+    def size(self) -> int:
+        """Return the number of elements in the underlying data."""
+        return len(self)
+
     def es_info(self, buf: TextIO) -> None:
-        buf.write("Index:\n")
-        buf.write(f" es_index_field: {self.es_index_field}\n")
-        buf.write(f" is_source_field: {self.is_source_field}\n")
+        buf.write(f"{type(self).__name__}:\n")
+        buf.write(f" es_index_fields: {self.es_index_fields}\n")
+        buf.write(f" is_source_fields: {self.is_source_fields}\n")
 
     @deprecated_api("eland.Index.es_info()")
     def info_es(self, buf: TextIO) -> None:
         self.es_info(buf)
+
+    @property
+    def es_index_fields(self) -> Tuple[str, ...]:
+        return self._es_index_fields
+
+    @es_index_fields.setter
+    def es_index_fields(self, value: Optional[Union[str, Sequence[str]]]) -> None:
+        if value is None:
+            value = (Index.ID_INDEX_FIELD,)
+        elif isinstance(value, str):
+            value = (value,)
+        self._es_index_fields = tuple(value)
+
+    @property
+    def sort_fields(self) -> Tuple[str, ...]:
+        return tuple(
+            [
+                es_field if es_field != Index.ID_INDEX_FIELD else Index.ID_SORT_FIELD
+                for es_field in self.es_index_fields
+            ]
+        )
+
+    @property
+    def is_source_fields(self) -> Tuple[Tuple[str, bool], ...]:
+        return tuple(
+            [
+                (es_field, es_field != Index.ID_INDEX_FIELD)
+                for es_field in self.es_index_fields
+            ]
+        )
+
+    @property
+    def names(self) -> List[Optional[str]]:
+        """Names of levels in MultiIndex."""
+        return [None]
+
+    @property
+    def name(self) -> Optional[str]:
+        """Return Index or MultiIndex name."""
+        return None
+
+
+class MultiIndex(Index):
+    """A multi-level index of an eland.DataFrame. As is the case for
+    a single-level eland.Index this index has different behavior than
+    a pandas.Index.
+
+    To use a MultiIndex you can construct your DataFrame by
+    setting the ``es_index_field`` argument to a list or tuple
+    of strings:
+
+        >>> df = ed.DataFrame(
+        ...     es_client='localhost',
+        ...     es_index_pattern='flights',
+        ...     es_index_field=["OriginCountry", "DestCountry"],
+        ... )
+                                   AvgTicketPrice  ...           timestamp
+        OriginCountry DestCountry                  ...
+        AE            AE               441.242460  ... 2018-01-06 13:03:25
+                      AE               190.500200  ... 2018-01-08 05:25:09
+                      AE               110.799908  ... 2018-01-09 10:03:42
+                      AE               185.232228  ... 2018-01-30 22:16:18
+                      AE               212.574590  ... 2018-02-05 16:48:34
+        ...                                   ...  ...                 ...
+                      AE               441.242460  ... 2018-01-06 13:03:25
+                      AE               190.500200  ... 2018-01-08 05:25:09
+                      AE               110.799908  ... 2018-01-09 10:03:42
+                      AE               185.232228  ... 2018-01-30 22:16:18
+                      AE               212.574590  ... 2018-02-05 16:48:34
+        <BLANKLINE>
+        [13059 rows x 27 columns]
+    """
+
+    @property
+    def names(self) -> List[Optional[str]]:
+        """Names of levels in MultiIndex."""
+        return list(self.es_index_fields)

--- a/eland/ndframe.py
+++ b/eland/ndframe.py
@@ -73,7 +73,7 @@ class NDFrame(ABC):
                 client=es_client,
                 index_pattern=es_index_pattern,
                 display_names=columns,
-                index_field=es_index_field,
+                index_fields=es_index_field,
             )
         self._query_compiler = _query_compiler
 

--- a/eland/query.py
+++ b/eland/query.py
@@ -25,6 +25,7 @@ from eland.filter import (
     NotNull,
     IsNull,
     IsIn,
+    Like,
     Rlike,
 )
 
@@ -94,6 +95,16 @@ class Query:
                 self._query = ~(IsIn(field, items))
             else:
                 self._query = self._query & ~(IsIn(field, items))
+
+    def wildcard(self, field: str, value: str) -> None:
+        """
+        Add wildcard query
+        https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-wildcard-query.html
+        """
+        if self._query.empty():
+            self._query = Like(field, value)
+        else:
+            self._query = self._query & Like(field, value)
 
     def regexp(self, field: str, value: str) -> None:
         """

--- a/eland/tests/index/test_index.py
+++ b/eland/tests/index/test_index.py
@@ -1,0 +1,76 @@
+#  Licensed to Elasticsearch B.V. under one or more contributor
+#  license agreements. See the NOTICE file distributed with
+#  this work for additional information regarding copyright
+#  ownership. Elasticsearch B.V. licenses this file to you under
+#  the Apache License, Version 2.0 (the "License"); you may
+#  not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+# 	http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+
+import pytest
+import pandas as pd
+from eland import DataFrame, Index
+from eland.tests.common import (
+    ES_TEST_CLIENT,
+    ECOMMERCE_INDEX_NAME,
+    FLIGHTS_SMALL_INDEX_NAME,
+)
+
+
+def test_default_index():
+    ed_df = DataFrame(
+        ES_TEST_CLIENT,
+        FLIGHTS_SMALL_INDEX_NAME,
+    )
+    assert isinstance(ed_df.index, Index)
+    assert ed_df.index.es_index_fields == ("_id",)
+    assert ed_df.index.sort_fields == ("_doc",)
+    assert ed_df.index.is_source_fields == (("_id", False),)
+
+
+def test_column_index():
+    ed_df = DataFrame(
+        ES_TEST_CLIENT,
+        FLIGHTS_SMALL_INDEX_NAME,
+        es_index_field="Carrier",
+    )
+    assert isinstance(ed_df.index, Index)
+    assert ed_df.index.sort_fields == ("Carrier",)
+    assert ed_df.index.is_source_fields == (("Carrier", True),)
+
+    pd_df = ed_df.to_pandas()
+    assert isinstance(pd_df.index, pd.Index)
+
+
+def test_shape_and_size(df):
+    assert df.index.shape == (48,)
+    assert df.index.size == 48
+
+
+def test_drop_and_filter(df):
+    ed_df = DataFrame(
+        ES_TEST_CLIENT,
+        ECOMMERCE_INDEX_NAME,
+        es_index_field="order_id",
+    )
+    pd_df = ed_df.to_pandas()
+    df = df.set_objects(ed_df, pd_df)
+
+    assert df.shape == (4675, 45)
+    df = df.drop(index=[550375])
+    assert df.shape == (4674, 45)
+
+    with pytest.raises(KeyError) as e:
+        df.drop(index=[550375, 550412])
+    assert e.value.args[0] == "[550375] not found in axis"
+
+    df = df.filter(axis="index", items=[550412, 550425, 550426])
+    assert df.shape == (2, 45)

--- a/eland/tests/index/test_multi_index.py
+++ b/eland/tests/index/test_multi_index.py
@@ -1,0 +1,381 @@
+#  Licensed to Elasticsearch B.V. under one or more contributor
+#  license agreements. See the NOTICE file distributed with
+#  this work for additional information regarding copyright
+#  ownership. Elasticsearch B.V. licenses this file to you under
+#  the Apache License, Version 2.0 (the "License"); you may
+#  not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+# 	http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+
+import pytest
+import pandas as pd
+from eland import DataFrame, MultiIndex
+from eland.tests.common import ES_TEST_CLIENT, FLIGHTS_SMALL_INDEX_NAME
+
+
+def test_multi_index_type():
+    ed_df = DataFrame(
+        ES_TEST_CLIENT,
+        FLIGHTS_SMALL_INDEX_NAME,
+        es_index_field=("Carrier", "DestCountry"),
+    )
+    assert isinstance(ed_df.index, MultiIndex)
+    assert ed_df.index.es_index_fields == ("Carrier", "DestCountry")
+    assert ed_df.index.sort_fields == ("Carrier", "DestCountry")
+    assert ed_df.index.is_source_fields == (("Carrier", True), ("DestCountry", True))
+
+    pd_df = ed_df.to_pandas()
+    assert isinstance(pd_df.index, pd.MultiIndex)
+
+
+def test_multi_index_repr(df):
+    ed_df = DataFrame(
+        ES_TEST_CLIENT,
+        FLIGHTS_SMALL_INDEX_NAME,
+        es_index_field=("Carrier", "DestCountry"),
+    )
+    ed_df.drop(labels=["AvgTicketPrice"], axis="columns", inplace=True)
+    print(ed_df._repr_html_())
+    assert repr(ed_df) == (
+        """                     Cancelled Carrier  ... dayOfWeek           timestamp
+Carrier DestCountry                     ...                              
+ES-Air  AR               False  ES-Air  ...         0 2018-01-01 01:30:47
+        AR               False  ES-Air  ...         0 2018-01-01 23:43:02
+        CA               False  ES-Air  ...         0 2018-01-01 01:08:20
+        CN               False  ES-Air  ...         0 2018-01-01 07:58:17
+        CN               False  ES-Air  ...         0 2018-01-01 21:30:40
+...                        ...     ...  ...       ...                 ...
+        AR               False  ES-Air  ...         0 2018-01-01 01:30:47
+        AR               False  ES-Air  ...         0 2018-01-01 23:43:02
+        CA               False  ES-Air  ...         0 2018-01-01 01:08:20
+        CN               False  ES-Air  ...         0 2018-01-01 07:58:17
+        CN               False  ES-Air  ...         0 2018-01-01 21:30:40
+
+[48 rows x 26 columns]"""
+    )
+    assert ed_df._repr_html_() == (
+        """<div>
+<style scoped>
+    .dataframe tbody tr th:only-of-type {
+        vertical-align: middle;
+    }
+
+    .dataframe tbody tr th {
+        vertical-align: top;
+    }
+
+    .dataframe thead th {
+        text-align: right;
+    }
+</style>
+<table border="1" class="dataframe">
+  <thead>
+    <tr style="text-align: right;">
+      <th></th>
+      <th></th>
+      <th>Cancelled</th>
+      <th>Carrier</th>
+      <th>...</th>
+      <th>dayOfWeek</th>
+      <th>timestamp</th>
+    </tr>
+    <tr>
+      <th>Carrier</th>
+      <th>DestCountry</th>
+      <th></th>
+      <th></th>
+      <th></th>
+      <th></th>
+      <th></th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th rowspan="11" valign="top">ES-Air</th>
+      <th>AR</th>
+      <td>False</td>
+      <td>ES-Air</td>
+      <td>...</td>
+      <td>0</td>
+      <td>2018-01-01 01:30:47</td>
+    </tr>
+    <tr>
+      <th>AR</th>
+      <td>False</td>
+      <td>ES-Air</td>
+      <td>...</td>
+      <td>0</td>
+      <td>2018-01-01 23:43:02</td>
+    </tr>
+    <tr>
+      <th>CA</th>
+      <td>False</td>
+      <td>ES-Air</td>
+      <td>...</td>
+      <td>0</td>
+      <td>2018-01-01 01:08:20</td>
+    </tr>
+    <tr>
+      <th>CN</th>
+      <td>False</td>
+      <td>ES-Air</td>
+      <td>...</td>
+      <td>0</td>
+      <td>2018-01-01 07:58:17</td>
+    </tr>
+    <tr>
+      <th>CN</th>
+      <td>False</td>
+      <td>ES-Air</td>
+      <td>...</td>
+      <td>0</td>
+      <td>2018-01-01 21:30:40</td>
+    </tr>
+    <tr>
+      <th>...</th>
+      <td>...</td>
+      <td>...</td>
+      <td>...</td>
+      <td>...</td>
+      <td>...</td>
+    </tr>
+    <tr>
+      <th>AR</th>
+      <td>False</td>
+      <td>ES-Air</td>
+      <td>...</td>
+      <td>0</td>
+      <td>2018-01-01 01:30:47</td>
+    </tr>
+    <tr>
+      <th>AR</th>
+      <td>False</td>
+      <td>ES-Air</td>
+      <td>...</td>
+      <td>0</td>
+      <td>2018-01-01 23:43:02</td>
+    </tr>
+    <tr>
+      <th>CA</th>
+      <td>False</td>
+      <td>ES-Air</td>
+      <td>...</td>
+      <td>0</td>
+      <td>2018-01-01 01:08:20</td>
+    </tr>
+    <tr>
+      <th>CN</th>
+      <td>False</td>
+      <td>ES-Air</td>
+      <td>...</td>
+      <td>0</td>
+      <td>2018-01-01 07:58:17</td>
+    </tr>
+    <tr>
+      <th>CN</th>
+      <td>False</td>
+      <td>ES-Air</td>
+      <td>...</td>
+      <td>0</td>
+      <td>2018-01-01 21:30:40</td>
+    </tr>
+  </tbody>
+</table>
+</div>
+<p>48 rows × 26 columns</p>"""
+    )
+
+
+def test_multi_index_drop_filter_agg(df):
+    ed_df = DataFrame(
+        ES_TEST_CLIENT,
+        FLIGHTS_SMALL_INDEX_NAME,
+        es_index_field=("Carrier", "DestCountry"),
+    )
+    pd_df = ed_df.to_pandas()
+    assert isinstance(pd_df.index, pd.MultiIndex)
+    assert isinstance(ed_df.index, MultiIndex)
+    assert list(pd_df.index) == [
+        ("ES-Air", "AR"),
+        ("ES-Air", "AR"),
+        ("ES-Air", "CA"),
+        ("ES-Air", "CN"),
+        ("ES-Air", "CN"),
+        ("ES-Air", "CO"),
+        ("ES-Air", "JP"),
+        ("ES-Air", "JP"),
+        ("ES-Air", "US"),
+        ("JetBeats", "AT"),
+        ("JetBeats", "CH"),
+        ("JetBeats", "FI"),
+        ("JetBeats", "IN"),
+        ("JetBeats", "IT"),
+        ("JetBeats", "IT"),
+        ("JetBeats", "JP"),
+        ("JetBeats", "US"),
+        ("JetBeats", "US"),
+        ("JetBeats", "US"),
+        ("JetBeats", "US"),
+        ("Kibana Airlines", "AU"),
+        ("Kibana Airlines", "CA"),
+        ("Kibana Airlines", "CA"),
+        ("Kibana Airlines", "CA"),
+        ("Kibana Airlines", "CH"),
+        ("Kibana Airlines", "CN"),
+        ("Kibana Airlines", "CN"),
+        ("Kibana Airlines", "CN"),
+        ("Kibana Airlines", "DE"),
+        ("Kibana Airlines", "GB"),
+        ("Kibana Airlines", "IN"),
+        ("Kibana Airlines", "IT"),
+        ("Kibana Airlines", "IT"),
+        ("Kibana Airlines", "JP"),
+        ("Kibana Airlines", "JP"),
+        ("Logstash Airways", "AT"),
+        ("Logstash Airways", "AT"),
+        ("Logstash Airways", "CA"),
+        ("Logstash Airways", "CA"),
+        ("Logstash Airways", "CH"),
+        ("Logstash Airways", "CN"),
+        ("Logstash Airways", "FR"),
+        ("Logstash Airways", "IT"),
+        ("Logstash Airways", "IT"),
+        ("Logstash Airways", "IT"),
+        ("Logstash Airways", "IT"),
+        ("Logstash Airways", "PR"),
+        ("Logstash Airways", "RU"),
+    ]
+    df = df.set_objects(ed_df, pd_df)
+    assert df.shape == (48, 27)
+    assert df.index.shape == (48,)
+    assert df.index.size == 48
+
+    df = df.drop(index=[("ES-Air", "AR")])
+    df = df.drop(columns=["DestLocation", "OriginLocation"])
+    assert df.size == 1150
+    assert df.shape == (46, 25)
+    assert df.mean(numeric_only=True).shape == (9,)
+
+    # TODO: Uncomment when numeric_only=True works properly for types
+    # df.max(numeric_only=True)
+    # df.min(numeric_only=True)
+
+    df = df.filter(
+        axis="columns", items=["Carrier", "DestCountry", "AvgTicketPrice", "Cancelled"]
+    )
+
+    # TODO: Remove the get_objects() once min and max work for text fields.
+    ed_df, pd_df = df.get_objects()
+    ed_agg = ed_df.agg(["min", "max", "mean"])[["AvgTicketPrice", "Cancelled"]]
+    pd_agg = pd_df.agg(["min", "max", "mean"])[["AvgTicketPrice", "Cancelled"]]
+    df_agg = df.set_objects(ed_agg, pd_agg)
+    assert df_agg.shape == (3, 2)
+
+
+def test_multi_index_drop_in_index(df):
+    ed_df = DataFrame(
+        ES_TEST_CLIENT,
+        FLIGHTS_SMALL_INDEX_NAME,
+        es_index_field=("Carrier", "DestCountry"),
+    )
+    pd_df = ed_df.to_pandas()
+    df = df.set_objects(ed_df, pd_df)
+    assert df.index.size == 48
+
+    df2 = df.drop([("ES-Air", "AR")])
+    assert df2.index.size == 46
+
+    df3 = df.drop([("ES-Air", "AR"), ("ES-Air", "CA"), ("Logstash Airways", "CN")])
+    assert df3.index.size == 44
+
+    # Dropping an item that eixsts and one that doesn't
+    # shows both items in the error.
+    with pytest.raises(KeyError) as e:
+        df3.drop(index=[("ES-Air", "CA"), ("Logstash Airways", "RU")])
+    assert (
+        e.value.args[0]
+        == "[('ES-Air', 'CA') ('Logstash Airways', 'RU')] not found in axis"
+    )
+
+    with pytest.raises(ValueError) as e:
+        df.drop([("ES-Air", "CA", 1)])
+    assert str(e.value) == "Length of names must match number of levels in MultiIndex."
+
+
+def test_multiindex_drop_filter__id(df):
+    ed_df = DataFrame(
+        ES_TEST_CLIENT,
+        FLIGHTS_SMALL_INDEX_NAME,
+        es_index_field=("_id", "Carrier"),
+    )
+    pd_df = ed_df.to_pandas()
+    assert list(pd_df.index) == [
+        ("0", "Kibana Airlines"),
+        ("1", "Logstash Airways"),
+        ("10", "JetBeats"),
+        ("11", "Logstash Airways"),
+        ("12", "Logstash Airways"),
+        ("13", "Logstash Airways"),
+        ("14", "Logstash Airways"),
+        ("15", "Kibana Airlines"),
+        ("16", "Logstash Airways"),
+        ("17", "ES-Air"),
+        ("18", "ES-Air"),
+        ("19", "JetBeats"),
+        ("2", "Logstash Airways"),
+        ("20", "JetBeats"),
+        ("21", "ES-Air"),
+        ("22", "JetBeats"),
+        ("23", "Logstash Airways"),
+        ("24", "Logstash Airways"),
+        ("25", "ES-Air"),
+        ("26", "Kibana Airlines"),
+        ("27", "JetBeats"),
+        ("28", "Kibana Airlines"),
+        ("29", "Logstash Airways"),
+        ("3", "Kibana Airlines"),
+        ("30", "Kibana Airlines"),
+        ("31", "ES-Air"),
+        ("32", "Kibana Airlines"),
+        ("33", "JetBeats"),
+        ("34", "Logstash Airways"),
+        ("35", "ES-Air"),
+        ("36", "JetBeats"),
+        ("37", "Kibana Airlines"),
+        ("38", "ES-Air"),
+        ("39", "JetBeats"),
+        ("4", "Kibana Airlines"),
+        ("40", "ES-Air"),
+        ("41", "JetBeats"),
+        ("42", "ES-Air"),
+        ("43", "Logstash Airways"),
+        ("44", "Kibana Airlines"),
+        ("45", "Kibana Airlines"),
+        ("46", "Kibana Airlines"),
+        ("47", "Kibana Airlines"),
+        ("5", "JetBeats"),
+        ("6", "JetBeats"),
+        ("7", "Kibana Airlines"),
+        ("8", "Kibana Airlines"),
+        ("9", "Logstash Airways"),
+    ]
+
+    df = df.set_objects(ed_df, pd_df)
+    assert df.shape == (48, 27)
+
+    df = df.drop(index=[("12", "Logstash Airways")])
+    assert df.shape == (47, 27)
+
+    df = df.filter(
+        items=[("47", "Kibana Airlines"), ("6", "JetBeats"), ("7", "Kibana Airlines")],
+        axis="index",
+    )
+    assert df.shape == (3, 27)

--- a/eland/utils.py
+++ b/eland/utils.py
@@ -17,8 +17,20 @@
 
 import re
 import functools
+from itertools import zip_longest
+
 import warnings
-from typing import Callable, TypeVar, Any, Union, List, cast, Collection, Iterable
+from typing import (
+    Callable,
+    TypeVar,
+    Any,
+    Union,
+    List,
+    cast,
+    Collection,
+    Iterable,
+    Tuple,
+)
 from collections.abc import Collection as ABCCollection
 import pandas as pd  # type: ignore
 
@@ -54,12 +66,20 @@ def is_valid_attr_name(s: str) -> bool:
     )
 
 
-def to_list(x: Union[Collection[Any], pd.Series]) -> List[Any]:
+def to_list(x: Union[Collection[Item], pd.Series]) -> List[Item]:
     if isinstance(x, ABCCollection):
         return list(x)
     elif isinstance(x, pd.Series):
-        return cast(List[Any], x.to_list())
+        return cast(List[Item], x.to_list())
     raise NotImplementedError(f"Could not convert {type(x).__name__} into a list")
+
+
+def zip_equal(*iterables: Iterable[RT]) -> Iterable[Tuple[RT, ...]]:
+    notequal = object()
+    for row in zip_longest(*iterables, fillvalue=notequal):
+        if any(i is notequal for i in row):
+            raise ValueError("Iterables of unequal length passed to zip_equal()")
+        yield row
 
 
 def try_sort(iterable: Iterable[Item]) -> Iterable[Item]:

--- a/noxfile.py
+++ b/noxfile.py
@@ -68,7 +68,7 @@ def lint(session):
     session.install("black", "flake8", "mypy")
     session.run("python", "utils/license-headers.py", "check", *SOURCE_FILES)
     session.run("black", "--check", "--target-version=py36", *SOURCE_FILES)
-    session.run("flake8", "--ignore=E501,W503,E402,E712,E203", *SOURCE_FILES)
+    session.run("flake8", "--ignore=E501,W503,W291,E402,E712,E203", *SOURCE_FILES)
 
     # TODO: When all files are typed we can change this to .run("mypy", "--strict", "eland/")
     session.log("mypy --strict eland/")


### PR DESCRIPTION
- Adds `eland.MultiIndex`
  - Changes most attributes on `Index` to be plural to account for `MultiIndex`
- Adds support for defining a DataFrame with multiple index fields
- Adds multiindex support to `DataFrame.drop()`, `DataFrame.filter()`
- Changes `index_matches_count()` function to use `msearch()` for individual counts of boolean conditions since multiindex (and regular indices that contain duplicates) aren't guaranteed to have just one of each entry. So now we check that there's 1 or more entry.
- Adds `QueryRegexpTask` for `regex` filtering