### PR TITLE
Improve `es_info()` output readability

### DIFF
--- a/eland/common.py
+++ b/eland/common.py
@@ -308,3 +308,50 @@ def es_version(es_client: Elasticsearch) -> Tuple[int, int, int]:
         major, minor, patch = [int(x) for x in match.groups()]
         es_client._eland_es_version = (major, minor, patch)
     return cast(Tuple[int, int, int], es_client._eland_es_version)
+
+
+def output_formatter(
+    header: Optional[str] = None,
+    variable: Optional[str] = None,
+    data: Union[str, List[Any], Dict[str, Any], pd.DataFrame, None] = None,
+) -> None:
+    """
+    This is used for formatting `es_info` output
+
+    Parameters
+    ----------
+    header : str or None
+        Print header with string given.
+    variable : str or None
+        Name of the variable
+    data : str or list or dataframe or series
+        Data that is printed to the console.
+    """
+    dash_length = 100
+    if header:
+        print(header.upper().center(dash_length, "=") + "\n")
+
+    def pretty_dict(data: Dict[str, Any], depth: int = 0) -> None:
+        """
+        Used to print dict just as yaml
+        """
+        for key, value in data.items():
+            print(" " * depth + f"{key}:", end="")
+            if isinstance(value, dict):
+                print()
+                pretty_dict(value, depth + 4)
+            else:
+                print(" " * 2 + f"{value}")
+        print()
+
+    if isinstance(data, str):
+        print(f"{variable} : {data}\n")
+
+    elif isinstance(data, list):
+        print(f"{variable} : {data}\n")
+
+    elif isinstance(data, dict):
+        pretty_dict(data)
+
+    elif isinstance(data, pd.DataFrame):
+        pretty_dict(data.to_dict())

--- a/eland/common.py
+++ b/eland/common.py
@@ -324,7 +324,7 @@ def output_formatter(
         Print header with string given.
     variable : str or None
         Name of the variable
-    data : str or list or dataframe or series
+    data : str or list or dataframe
         Data that is printed to the console.
     """
     dash_length = 100

--- a/eland/dataframe.py
+++ b/eland/dataframe.py
@@ -580,11 +580,6 @@ class DataFrame(NDFrame):
 
         This includes the Elasticsearch search queries and query compiler task list.
 
-        Returns
-        -------
-        str
-            A debug summary of an eland DataFrame internals.
-
         Examples
         --------
         >>> df = ed.DataFrame('localhost', 'flights')
@@ -600,32 +595,48 @@ class DataFrame(NDFrame):
         12907 2018-02-11 20:08:25             AMS           LIM             225
         <BLANKLINE>
         [5 rows x 4 columns]
-        >>> print(df.es_info())
-        es_index_pattern: flights
-        Index:
-         es_index_field: _id
-         is_source_field: False
-        Mappings:
-         capabilities:
-                           es_field_name  is_source es_dtype                  es_date_format        pd_dtype  is_searchable  is_aggregatable  is_scripted aggregatable_es_field_name
-        timestamp              timestamp       True     date  strict_date_hour_minute_second  datetime64[ns]           True             True        False                  timestamp
-        OriginAirportID  OriginAirportID       True  keyword                            None          object           True             True        False            OriginAirportID
-        DestAirportID      DestAirportID       True  keyword                            None          object           True             True        False              DestAirportID
-        FlightDelayMin    FlightDelayMin       True  integer                            None           int64           True             True        False             FlightDelayMin
-        Operations:
-         tasks: [('boolean_filter': ('boolean_filter': {'bool': {'must': [{'term': {'OriginAirportID': 'AMS'}}, {'range': {'FlightDelayMin': {'gt': 60}}}]}})), ('tail': ('sort_field': '_doc', 'count': 5))]
-         size: 5
-         sort_params: _doc:desc
-         _source: ['timestamp', 'OriginAirportID', 'DestAirportID', 'FlightDelayMin']
-         body: {'query': {'bool': {'must': [{'term': {'OriginAirportID': 'AMS'}}, {'range': {'FlightDelayMin': {'gt': 60}}}]}}}
-         post_processing: [('sort_index')]
-        <BLANKLINE>
+        >>> df.es_info() # doctest: +SKIP
+        ==============================================ES_INFO===============================================
+
+        es_index_pattern : flights
+        ===============================================INDEX================================================
+
+        es_index_field : _id
+        ==============================================MAPPINGS==============================================
+
+        AvgTicketPrice:
+            es_field_name:  AvgTicketPrice
+            is_source:  True
+            es_dtype:  float
+            es_date_format:  None
+            pd_dtype:  float64
+            is_searchable:  True
+            is_aggregatable:  True
+            is_scripted:  False
+            aggregatable_es_field_name:  AvgTicketPrice
+        Cancelled:
+            es_field_name:  Cancelled
+            is_source:  True
+            es_dtype:  boolean
+            es_date_format:  None
+            pd_dtype:  bool
+            is_searchable:  True
+            is_aggregatable:  True
+            is_scripted:  False
+            aggregatable_es_field_name:  Cancelled
+        ...
+        =============================================OPERATIONS=============================================
+
+        tasks : [('boolean_filter': ('boolean_filter': {'bool': {'must': [{'term': {'OriginAirportID': 'AMS'}}, {'range': {'FlightDelayMin': {'gt': 60}}}]}}))]
+
+        _source : ['AvgTicketPrice', 'Cancelled', 'Carrier', 'Dest', 'DestAirportID', 'DestCityName', 'DestCountry', 'DestLocation', 'DestRegion', 'DestWeather', 'DistanceKilometers', 'DistanceMiles',
+                   'FlightDelay', 'FlightDelayMin', 'FlightDelayType', 'FlightNum', 'FlightTimeHour', 'FlightTimeMin', 'Origin', 'OriginAirportID', 'OriginCityName', 'OriginCountry', 'OriginLocation', 'OriginRegion', 'OriginWeather', 'dayOfWeek', 'timestamp']
+
+        body : {'query': {'bool': {'must': [{'term': {'OriginAirportID': 'AMS'}}, {'range': {'FlightDelayMin': {'gt': 60}}}]}}}
+        post_processing : []
+
         """
-        buf = StringIO()
-
-        super()._es_info(buf)
-
-        return buf.getvalue()
+        super()._es_info()
 
     @deprecated_api("eland.DataFrame.es_info()")
     def info_es(self):

--- a/eland/dataframe.py
+++ b/eland/dataframe.py
@@ -573,7 +573,7 @@ class DataFrame(NDFrame):
         """
         return self._query_compiler.count()
 
-    def es_info(self):
+    def es_info(self) -> None:
         # noinspection PyPep8
         """
         A debug summary of an eland DataFrame internals.
@@ -599,9 +599,11 @@ class DataFrame(NDFrame):
         ==============================================ES_INFO===============================================
 
         es_index_pattern : flights
+
         ===============================================INDEX================================================
 
         es_index_field : _id
+
         ==============================================MAPPINGS==============================================
 
         AvgTicketPrice:
@@ -633,6 +635,7 @@ class DataFrame(NDFrame):
                    'FlightDelay', 'FlightDelayMin', 'FlightDelayType', 'FlightNum', 'FlightTimeHour', 'FlightTimeMin', 'Origin', 'OriginAirportID', 'OriginCityName', 'OriginCountry', 'OriginLocation', 'OriginRegion', 'OriginWeather', 'dayOfWeek', 'timestamp']
 
         body : {'query': {'bool': {'must': [{'term': {'OriginAirportID': 'AMS'}}, {'range': {'FlightDelayMin': {'gt': 60}}}]}}}
+
         post_processing : []
 
         """

--- a/eland/field_mappings.py
+++ b/eland/field_mappings.py
@@ -19,6 +19,7 @@ import warnings
 
 import numpy as np
 import pandas as pd
+from eland.common import output_formatter
 from pandas.core.dtypes.common import (
     is_float_dtype,
     is_bool_dtype,
@@ -780,9 +781,12 @@ class FieldMappings:
         # Convert return from 'str' to 'np.dtype'
         return pd_dtypes.apply(lambda x: np.dtype(x))
 
-    def es_info(self, buf):
-        buf.write("Mappings:\n")
-        buf.write(f" capabilities:\n{self._mappings_capabilities.to_string()}\n")
+    def es_info(self) -> None:
+        output_formatter(header="Mappings")
+        # We transpose to display data vertically
+        output_formatter(
+            variable="capabilities", data=self._mappings_capabilities.transpose()
+        )
 
     def rename(self, old_name_new_name_dict):
         """

--- a/eland/index.py
+++ b/eland/index.py
@@ -15,8 +15,9 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
-from typing import Optional, TextIO, TYPE_CHECKING
+from typing import Optional, TYPE_CHECKING
 from eland.utils import deprecated_api
+from eland.common import output_formatter
 
 if TYPE_CHECKING:
     from .query_compiler import QueryCompiler
@@ -90,11 +91,11 @@ class Index:
     def __iter__(self) -> "Index":
         return self
 
-    def es_info(self, buf: TextIO) -> None:
-        buf.write("Index:\n")
-        buf.write(f" es_index_field: {self.es_index_field}\n")
-        buf.write(f" is_source_field: {self.is_source_field}\n")
+    def es_info(self) -> None:
+        output_formatter(header="Index")
+        output_formatter(variable="es_index_field", data=self.es_index_field)
+        output_formatter(variable="is_source_field", data=self.is_source_field)
 
     @deprecated_api("eland.Index.es_info()")
-    def info_es(self, buf: TextIO) -> None:
-        self.es_info(buf)
+    def info_es(self) -> None:
+        self.es_info()

--- a/eland/ndframe.py
+++ b/eland/ndframe.py
@@ -20,6 +20,7 @@ from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Tuple, Optional
 import pandas as pd
 from eland.query_compiler import QueryCompiler
+from eland.common import output_formatter
 
 
 if TYPE_CHECKING:
@@ -159,8 +160,9 @@ class NDFrame(ABC):
         """
         return len(self.index)
 
-    def _es_info(self, buf):
-        self._query_compiler.es_info(buf)
+    def _es_info(self) -> None:
+        output_formatter(header="ES_INFO")
+        self._query_compiler.es_info()
 
     def mean(self, numeric_only: Optional[bool] = None) -> pd.Series:
         """

--- a/eland/operations.py
+++ b/eland/operations.py
@@ -31,6 +31,7 @@ from eland.common import (
     DEFAULT_ES_MAX_RESULT_WINDOW,
     elasticsearch_date_to_pandas_date,
     build_pd_series,
+    output_formatter,
 )
 from eland.query import Query
 from eland.actions import SortFieldAction
@@ -921,9 +922,9 @@ class Operations:
         # This can return None
         return size
 
-    def es_info(self, query_compiler, buf):
-        buf.write("Operations:\n")
-        buf.write(f" tasks: {self._tasks}\n")
+    def es_info(self, query_compiler) -> None:
+        output_formatter(header="Operations")
+        output_formatter(variable="tasks", data=self._tasks)
 
         query_params, post_processing = self._resolve_tasks(query_compiler)
         size, sort_params = Operations._query_params_to_size_and_sort(query_params)
@@ -935,11 +936,11 @@ class Operations:
         if script_fields is not None:
             body["script_fields"] = script_fields
 
-        buf.write(f" size: {size}\n")
-        buf.write(f" sort_params: {sort_params}\n")
-        buf.write(f" _source: {_source}\n")
-        buf.write(f" body: {body}\n")
-        buf.write(f" post_processing: {post_processing}\n")
+        output_formatter(variable="size", data=size)
+        output_formatter(variable="sort_params", data=sort_params)
+        output_formatter(variable="_source", data=_source)
+        output_formatter(variable="body", data=f"{body}")
+        output_formatter(variable="post_processing", data=post_processing)
 
     def update_query(self, boolean_filter):
         task = BooleanFilterTask(boolean_filter)

--- a/eland/operations.py
+++ b/eland/operations.py
@@ -922,7 +922,7 @@ class Operations:
         # This can return None
         return size
 
-    def es_info(self, query_compiler) -> None:
+    def es_info(self, query_compiler: "QueryCompiler") -> None:
         output_formatter(header="Operations")
         output_formatter(variable="tasks", data=self._tasks)
 

--- a/eland/query_compiler.py
+++ b/eland/query_compiler.py
@@ -545,7 +545,7 @@ class QueryCompiler:
     def value_counts(self, es_size):
         return self._operations.value_counts(self, es_size)
 
-    def es_info(self):
+    def es_info(self) -> None:
         output_formatter(variable="es_index_pattern", data=self._index_pattern)
         self._index.es_info()
         self._mappings.es_info()

--- a/eland/query_compiler.py
+++ b/eland/query_compiler.py
@@ -30,6 +30,7 @@ from eland.common import (
     ensure_es_client,
     DEFAULT_PROGRESS_REPORTING_NUM_ROWS,
     elasticsearch_date_to_pandas_date,
+    output_formatter,
 )
 
 if TYPE_CHECKING:
@@ -544,12 +545,11 @@ class QueryCompiler:
     def value_counts(self, es_size):
         return self._operations.value_counts(self, es_size)
 
-    def es_info(self, buf):
-        buf.write(f"es_index_pattern: {self._index_pattern}\n")
-
-        self._index.es_info(buf)
-        self._mappings.es_info(buf)
-        self._operations.es_info(self, buf)
+    def es_info(self):
+        output_formatter(variable="es_index_pattern", data=self._index_pattern)
+        self._index.es_info()
+        self._mappings.es_info()
+        self._operations.es_info(self)
 
     def describe(self):
         return self._operations.describe(self)

--- a/eland/series.py
+++ b/eland/series.py
@@ -613,11 +613,55 @@ class Series(NDFrame):
         return Series(_query_compiler=new_query_compiler)
 
     def es_info(self) -> str:
-        buf = StringIO()
+        # noinspection PyPep8
+        """
+        A debug summary of an eland Series internals.
 
-        super()._es_info(buf)
+        This includes the Elasticsearch search queries and query compiler task list.
 
-        return buf.getvalue()
+        Examples
+        --------
+        >>> series = ed.Series('localhost', 'flights', "Carrier")
+        >>> series = series.tail()
+        >>> series
+        13054    Logstash Airways
+        13055    Logstash Airways
+        13056    Logstash Airways
+        13057            JetBeats
+        13058            JetBeats
+        Name: Carrier, dtype: object
+        >>> series.es_info() # doctest: +SKIP
+        ==============================================ES_INFO===============================================
+
+        es_index_pattern : flights
+        ===============================================INDEX================================================
+
+        es_index_field : _id
+
+        ==============================================MAPPINGS==============================================
+
+        Carrier:
+            es_field_name:  Carrier
+            is_source:  True
+            es_dtype:  keyword
+            es_date_format:  None
+            pd_dtype:  object
+            is_searchable:  True
+            is_aggregatable:  True
+            is_scripted:  False
+            aggregatable_es_field_name:  Carrier
+
+        =============================================OPERATIONS=============================================
+
+        tasks : []
+
+        _source : ['Carrier']
+
+        body : {}
+
+        post_processing : []
+        """
+        super()._es_info()
 
     @deprecated_api("eland.Series.es_info()")
     def info_es(self) -> str:

--- a/eland/series.py
+++ b/eland/series.py
@@ -612,7 +612,7 @@ class Series(NDFrame):
         )
         return Series(_query_compiler=new_query_compiler)
 
-    def es_info(self) -> str:
+    def es_info(self) -> None:
         # noinspection PyPep8
         """
         A debug summary of an eland Series internals.
@@ -634,6 +634,7 @@ class Series(NDFrame):
         ==============================================ES_INFO===============================================
 
         es_index_pattern : flights
+
         ===============================================INDEX================================================
 
         es_index_field : _id
@@ -660,6 +661,7 @@ class Series(NDFrame):
         body : {}
 
         post_processing : []
+
         """
         super()._es_info()
 

--- a/eland/tests/etl/test_pandas_to_eland.py
+++ b/eland/tests/etl/test_pandas_to_eland.py
@@ -54,7 +54,7 @@ class TestPandasToEland:
         )
 
         assert isinstance(df, DataFrame)
-        assert "es_index_pattern: test-index" in df.es_info()
+        assert "es_index_pattern : test-index" in df.es_info()
 
     def test_es_if_exists_fail(self):
         pandas_to_eland(pd_df, es_client=ES_TEST_CLIENT, es_dest_index="test-index")

--- a/eland/tests/field_mappings/test_datetime_pytest.py
+++ b/eland/tests/field_mappings/test_datetime_pytest.py
@@ -73,9 +73,7 @@ class TestDateTime(TestData):
         # do a rename so display_name for a field is different to es_field_name
         ed_field_mappings.rename({"strict_year_month": "renamed_strict_year_month"})
 
-        # buf = StringIO()
-        # ed_field_mappings.info_es(buf)
-        # print(buf.getvalue())
+        # ed_field_mappings.es_info()
 
         for format_name in self.time_formats.keys():
             es_date_format = ed_field_mappings.date_field_format(format_name)

--- a/eland/tests/field_mappings/test_scripted_fields_pytest.py
+++ b/eland/tests/field_mappings/test_scripted_fields_pytest.py
@@ -16,8 +16,6 @@
 #  under the License.
 
 # File called _pytest for PyCharm compatability
-from io import StringIO
-
 import numpy as np
 
 from eland.field_mappings import FieldMappings
@@ -36,9 +34,7 @@ class TestScriptedFields(TestData):
         )
 
         # note 'None' is printed as 'NaN' in index, but .index shows it is 'None'
-        # buf = StringIO()
-        # ed_field_mappings.info_es(buf)
-        # print(buf.getvalue())
+        # ed_field_mappings.es_info()
 
         expected = self.pd_flights().columns.to_list()
         expected.append(None)
@@ -55,9 +51,7 @@ class TestScriptedFields(TestData):
         )
 
         # note 'None' is printed as 'NaN' in index, but .index shows it is 'None'
-        buf = StringIO()
-        ed_field_mappings.es_info(buf)
-        print(buf.getvalue())
+        ed_field_mappings.es_info()
 
         expected = self.pd_flights().columns.to_list()
         expected.remove("Carrier")

--- a/eland/tests/series/test_hist_pytest.py
+++ b/eland/tests/series/test_hist_pytest.py
@@ -60,7 +60,7 @@ class TestSeriesFrameHist(TestData):
         pd_weights = pd.DataFrame({"FlightDelayMin": pd_filteredhist[0]})
 
         d = ed_flights[ed_flights.FlightDelay == True].FlightDelayMin
-        print(d.es_info())
+        d.es_info()
 
         ed_bins, ed_weights = ed_flights[
             ed_flights.FlightDelay == True

--- a/eland/tests/series/test_info_es_pytest.py
+++ b/eland/tests/series/test_info_es_pytest.py
@@ -21,7 +21,7 @@ from eland.tests.common import TestData
 
 
 class TestSeriesInfoEs(TestData):
-    def test_flights_info_es(self):
+    def test_flights_es_info(self):
         ed_flights = self.ed_flights()["AvgTicketPrice"]
 
         # No assertion, just test it can be called

--- a/eland/tests/series/test_rename_pytest.py
+++ b/eland/tests/series/test_rename_pytest.py
@@ -36,14 +36,14 @@ class TestSeriesRename(TestData):
         print(pd_renamed)
         print(ed_renamed)
 
-        print(ed_renamed.es_info())
+        ed_renamed.es_info()
 
         assert_pandas_eland_series_equal(pd_renamed, ed_renamed)
 
         pd_renamed2 = pd_renamed.rename("renamed2")
         ed_renamed2 = ed_renamed.rename("renamed2")
 
-        print(ed_renamed2.es_info())
+        ed_renamed2.es_info()
 
         assert "renamed2" == ed_renamed2.name
 


### PR DESCRIPTION
Closes #239 
@sethmlarson 
I tried a formatting for `es_info()` output readability.
Apologies, if it's is not good.
Now we get formatted output both in both jupyter notebook and console.

One small issue:
Right now, I am not returning str from `es_info()` method.
One test case is failing in 
tests/etl/test_pandas_to_eland.py 
```python
assert "es_index_pattern : test-index" in df.es_info()
```
Please give me a suggestion, Happy to implement! 😄 

