### PR TITLE
Implement `DataFrameGroupBy.count()`

### DIFF
--- a/eland/dataframe.py
+++ b/eland/dataframe.py
@@ -1474,6 +1474,7 @@ class DataFrame(NDFrame):
                     True          121.280296  1175.709961       0.0  6.0
         <BLANKLINE>
         [63 rows x 4 columns]
+
         >>> ed_flights.groupby(["DestCountry", "Cancelled"]).mean(numeric_only=True) # doctest: +NORMALIZE_WHITESPACE
                                AvgTicketPrice  dayOfWeek
         DestCountry Cancelled
@@ -1490,6 +1491,23 @@ class DataFrame(NDFrame):
                     True           677.794078   2.928571
         <BLANKLINE>
         [63 rows x 2 columns]
+
+        >>> ed_flights.groupby(["DestCountry", "Cancelled"]).min(numeric_only=False) # doctest: +NORMALIZE_WHITESPACE
+                               AvgTicketPrice  dayOfWeek           timestamp
+        DestCountry Cancelled
+        AE          False          110.799911          0 2018-01-01 19:31:30
+                    True           132.443756          0 2018-01-06 13:03:25
+        AR          False          125.589394          0 2018-01-01 01:30:47
+                    True           251.389603          0 2018-01-01 02:13:17
+        AT          False          100.020531          0 2018-01-01 05:24:19
+        ...                               ...        ...                 ...
+        TR          True           307.915649          0 2018-01-08 04:35:10
+        US          False          100.145966          0 2018-01-01 00:06:27
+                    True           102.153069          0 2018-01-01 09:02:36
+        ZA          False          102.002663          0 2018-01-01 06:44:44
+                    True           121.280296          0 2018-01-04 00:37:01
+        <BLANKLINE>
+        [63 rows x 3 columns]
         """
         if by is None:
             raise ValueError("by parameter should be specified to groupby")

--- a/eland/field_mappings.py
+++ b/eland/field_mappings.py
@@ -100,14 +100,12 @@ class Field(NamedTuple):
             elif es_agg[0] == "percentiles":
                 es_agg = "percentiles"
 
-        if es_agg == "value_count":
-            return True
-        # Cardinality works for all types
-        # Numerics and bools work for all aggs
         # Except "median_absolute_deviation" which doesn't support bool
         if es_agg == "median_absolute_deviation" and self.is_bool:
             return False
-        if es_agg == "cardinality" or self.is_numeric or self.is_bool:
+        # Cardinality and Count work for all types
+        # Numerics and bools work for all aggs
+        if es_agg in ("cardinality", "value_count") or self.is_numeric or self.is_bool:
             return True
         # Timestamps also work for 'min', 'max' and 'avg'
         if es_agg in {"min", "max", "avg", "percentiles"} and self.is_timestamp:

--- a/eland/field_mappings.py
+++ b/eland/field_mappings.py
@@ -100,6 +100,8 @@ class Field(NamedTuple):
             elif es_agg[0] == "percentiles":
                 es_agg = "percentiles"
 
+        if es_agg == "value_count":
+            return True
         # Cardinality works for all types
         # Numerics and bools work for all aggs
         # Except "median_absolute_deviation" which doesn't support bool
@@ -730,7 +732,6 @@ class FieldMappings:
 
         """
         groupby_fields: Dict[str, Field] = {}
-        # groupby_fields: Union[List[Field], List[None]] = [None] * len(by)
         aggregatable_fields: List[Field] = []
         for column, row in self._mappings_capabilities.iterrows():
             row = row.to_dict()

--- a/eland/groupby.py
+++ b/eland/groupby.py
@@ -158,14 +158,19 @@ class GroupByDataFrame(GroupBy):
             A Pandas DataFrame
 
         """
+        # Controls whether a MultiIndex is used for the
+        # columns of the result DataFrame.
+        is_dataframe_agg = True
         if isinstance(func, str):
             func = [func]
+            is_dataframe_agg = False
+
         return self._query_compiler.aggs_groupby(
             by=self._by,
             pd_aggs=func,
             dropna=self._dropna,
             numeric_only=numeric_only,
-            is_dataframe_agg=True,
+            is_dataframe_agg=is_dataframe_agg,
         )
 
     agg = aggregate

--- a/eland/groupby.py
+++ b/eland/groupby.py
@@ -152,6 +152,11 @@ class GroupByDataFrame(GroupBy):
             - True: returns all values with float64, NaN/NaT are ignored.
             - False: returns all values with float64.
             - None: returns all values with default datatype.
+
+        Returns
+        -------
+            A Pandas DataFrame
+
         """
         if isinstance(func, str):
             func = [func]
@@ -164,3 +169,14 @@ class GroupByDataFrame(GroupBy):
         )
 
     agg = aggregate
+
+    def count(self) -> "pd.DataFrame":
+        """
+        Used to groupby and count
+
+        Returns
+        -------
+            A Pandas DataFrame
+
+        """
+        return self._query_compiler.count_groupby(by=self._by, is_dataframe_agg=False)

--- a/eland/groupby.py
+++ b/eland/groupby.py
@@ -179,4 +179,10 @@ class GroupByDataFrame(GroupBy):
             A Pandas DataFrame
 
         """
-        return self._query_compiler.count_groupby(by=self._by, is_dataframe_agg=False)
+        return self._query_compiler.aggs_groupby(
+            by=self._by,
+            pd_aggs=["count"],
+            dropna=self._dropna,
+            numeric_only=False,
+            is_dataframe_agg=False,
+        )

--- a/eland/operations.py
+++ b/eland/operations.py
@@ -512,11 +512,11 @@ class Operations:
                         agg_value = np.NaN
 
                 # Cardinality is always either NaN or integer.
-                elif pd_agg == "nunique":
+                elif pd_agg in ("nunique", "count"):
                     agg_value = int(agg_value)
 
                 # If this is a non-null timestamp field convert to a pd.Timestamp()
-                elif field.is_timestamp and pd_agg != "count":
+                elif field.is_timestamp:
                     agg_value = elasticsearch_date_to_pandas_date(
                         agg_value, field.es_date_format
                     )

--- a/eland/query.py
+++ b/eland/query.py
@@ -167,7 +167,7 @@ class Query:
     def composite_agg_start(
         self,
         name: str,
-        size: int,
+        size: Optional[int] = None,
         dropna: bool = True,
     ) -> None:
         """
@@ -195,8 +195,8 @@ class Query:
 
         Parameters
         ----------
-        size: int
-            Pagination size.
+        size: int or None
+            Use composite aggregation with pagination if size is Not None
         name: str
             Name of the buckets
         dropna: bool
@@ -215,10 +215,14 @@ class Query:
             sources.append({bucket_agg_name: bucket_agg})
         self._composite_aggs.clear()
 
-        aggs = {
-            "composite": {"size": size, "sources": sources},
-            "aggregations": self._aggs.copy(),
-        }
+        aggs: Dict[str, Dict[str, Any]] = {"composite": {"sources": sources}}
+
+        if size is not None:
+            aggs["composite"]["size"] = size
+
+        if self._aggs:
+            aggs["aggregations"] = self._aggs.copy()
+
         self._aggs.clear()
         self._aggs[name] = aggs
 

--- a/eland/query.py
+++ b/eland/query.py
@@ -167,7 +167,7 @@ class Query:
     def composite_agg_start(
         self,
         name: str,
-        size: Optional[int] = None,
+        size: int,
         dropna: bool = True,
     ) -> None:
         """
@@ -196,7 +196,7 @@ class Query:
         Parameters
         ----------
         size: int or None
-            Use composite aggregation with pagination if size is Not None
+            Use composite aggregation with pagination if size is not None
         name: str
             Name of the buckets
         dropna: bool
@@ -215,10 +215,9 @@ class Query:
             sources.append({bucket_agg_name: bucket_agg})
         self._composite_aggs.clear()
 
-        aggs: Dict[str, Dict[str, Any]] = {"composite": {"sources": sources}}
-
-        if size is not None:
-            aggs["composite"]["size"] = size
+        aggs: Dict[str, Dict[str, Any]] = {
+            "composite": {"size": size, "sources": sources}
+        }
 
         if self._aggs:
             aggs["aggregations"] = self._aggs.copy()

--- a/eland/query_compiler.py
+++ b/eland/query_compiler.py
@@ -567,6 +567,17 @@ class QueryCompiler:
             numeric_only=numeric_only,
         )
 
+    def count_groupby(
+        self, by: List[str], is_dataframe_agg: bool = False
+    ) -> pd.DataFrame:
+        return self._operations.aggs_groupby(
+            self,
+            by=by,
+            pd_aggs=["count"],
+            is_dataframe_agg=is_dataframe_agg,
+            numeric_only=False,
+        )
+
     def value_counts(self, es_size):
         return self._operations.value_counts(self, es_size)
 

--- a/eland/query_compiler.py
+++ b/eland/query_compiler.py
@@ -567,17 +567,6 @@ class QueryCompiler:
             numeric_only=numeric_only,
         )
 
-    def count_groupby(
-        self, by: List[str], is_dataframe_agg: bool = False
-    ) -> pd.DataFrame:
-        return self._operations.aggs_groupby(
-            self,
-            by=by,
-            pd_aggs=["count"],
-            is_dataframe_agg=is_dataframe_agg,
-            numeric_only=False,
-        )
-
     def value_counts(self, es_size):
         return self._operations.value_counts(self, es_size)
 

--- a/eland/tests/dataframe/test_count_pytest.py
+++ b/eland/tests/dataframe/test_count_pytest.py
@@ -16,9 +16,30 @@
 #  under the License.
 
 # File called _pytest for PyCharm compatability
+from pandas.testing import assert_series_equal
+
+from eland.tests.common import TestData
 
 
-class TestDataFrameCount:
+class TestDataFrameCount(TestData):
+    filter_data = [
+        "AvgTicketPrice",
+        "Cancelled",
+        "dayOfWeek",
+        "timestamp",
+        "DestCountry",
+    ]
+
     def test_count(self, df):
         df.load_dataset("ecommerce")
         df.count()
+
+    def test_count_flights(self):
+
+        pd_flights = self.pd_flights().filter(self.filter_data)
+        ed_flights = self.ed_flights().filter(self.filter_data)
+
+        pd_count = pd_flights.count()
+        ed_count = ed_flights.count()
+
+        assert_series_equal(pd_count, ed_count)

--- a/eland/tests/dataframe/test_groupby_pytest.py
+++ b/eland/tests/dataframe/test_groupby_pytest.py
@@ -154,3 +154,17 @@ class TestGroupbyDataFrame(TestData):
     def test_groupby_dropna(self):
         # TODO Add tests once dropna is implemeted
         pass
+
+    def test_groupByDataFrame_count(self):
+        pd_flights = self.pd_flights().filter(self.filter_data)
+        ed_flights = self.ed_flights().filter(self.filter_data)
+
+        pd_count = pd_flights.groupby("dayOfWeek").count()
+        ed_count = ed_flights.groupby("dayOfWeek").count()
+
+        assert_frame_equal(pd_count, ed_count)
+
+        pd_agg_count = pd_flights.groupby("Cancelled").agg(["count"])
+        ed_agg_count = ed_flights.groupby("Cancelled").agg(["count"])
+
+        assert_frame_equal(pd_agg_count, ed_agg_count)

--- a/eland/tests/dataframe/test_groupby_pytest.py
+++ b/eland/tests/dataframe/test_groupby_pytest.py
@@ -19,7 +19,7 @@
 
 import pandas as pd
 import pytest
-from pandas.testing import assert_frame_equal, assert_series_equal
+from pandas.testing import assert_frame_equal, assert_index_equal, assert_series_equal
 
 from eland.tests.common import TestData
 
@@ -155,16 +155,20 @@ class TestGroupbyDataFrame(TestData):
         # TODO Add tests once dropna is implemeted
         pass
 
-    def test_groupByDataFrame_count(self):
+    def test_groupby_dataframe_count(self):
         pd_flights = self.pd_flights().filter(self.filter_data)
         ed_flights = self.ed_flights().filter(self.filter_data)
 
         pd_count = pd_flights.groupby("dayOfWeek").count()
         ed_count = ed_flights.groupby("dayOfWeek").count()
 
+        assert_index_equal(pd_count.columns, ed_count.columns)
+        assert_index_equal(pd_count.index, ed_count.index)
         assert_frame_equal(pd_count, ed_count)
 
         pd_agg_count = pd_flights.groupby("Cancelled").agg(["count"])
         ed_agg_count = ed_flights.groupby("Cancelled").agg(["count"])
 
+        assert_index_equal(pd_agg_count.columns, ed_agg_count.columns)
+        assert_index_equal(pd_agg_count.index, ed_agg_count.index)
         assert_frame_equal(pd_agg_count, ed_agg_count)

--- a/eland/tests/dataframe/test_metrics_pytest.py
+++ b/eland/tests/dataframe/test_metrics_pytest.py
@@ -20,7 +20,7 @@ import pandas as pd
 
 # File called _pytest for PyCharm compatibility
 import pytest
-from pandas.testing import assert_series_equal
+from pandas.testing import assert_frame_equal, assert_series_equal
 
 from eland.tests.common import TestData
 
@@ -414,3 +414,13 @@ class TestDataFrameMetrics(TestData):
             assert isinstance(calculated_values["AvgTicketPrice"], float)
             assert isinstance(calculated_values["dayOfWeek"], float)
             assert calculated_values.shape == (2,)
+
+    def test_aggs_count(self):
+
+        pd_flights = self.pd_flights().filter(self.filter_data)
+        ed_flights = self.ed_flights().filter(self.filter_data)
+
+        pd_count = pd_flights.agg(["count"])
+        ed_count = ed_flights.agg(["count"])
+
+        assert_frame_equal(pd_count, ed_count)

--- a/eland/tests/operations/test_map_pd_aggs_to_es_aggs_pytest.py
+++ b/eland/tests/operations/test_map_pd_aggs_to_es_aggs_pytest.py
@@ -30,7 +30,7 @@ def test_all_aggs():
         ("extended_stats", "std_deviation"),
         ("extended_stats", "variance"),
         "median_absolute_deviation",
-        ("extended_stats", "count"),
+        "value_count",
         "cardinality",
         ("percentiles", "50.0"),
     ]
@@ -40,7 +40,7 @@ def test_extended_stats_optimization():
     # Tests that when '<agg>' and an 'extended_stats' agg are used together
     # that ('extended_stats', '<agg>') is used instead of '<agg>'.
     es_aggs = Operations._map_pd_aggs_to_es_aggs(["count", "nunique"])
-    assert es_aggs == ["count", "cardinality"]
+    assert es_aggs == ["value_count", "cardinality"]
 
     for pd_agg in ["var", "std"]:
         extended_es_agg = Operations._map_pd_aggs_to_es_aggs([pd_agg])[0]
@@ -49,4 +49,4 @@ def test_extended_stats_optimization():
         assert es_aggs == [extended_es_agg, "cardinality"]
 
         es_aggs = Operations._map_pd_aggs_to_es_aggs(["count", pd_agg, "nunique"])
-        assert es_aggs == [("extended_stats", "count"), extended_es_agg, "cardinality"]
+        assert es_aggs == ["value_count", extended_es_agg, "cardinality"]


### PR DESCRIPTION
Closes #289 

Implemented
- `ed_df.groupby([...]).count()`
- `ed_df.groupby([...]).agg(['count'])`
- `ed_df.groupby([...]).agg(['max', 'min', 'count', 'mean'])` maintains order
- Fixed bug where following raises exception `ed_df.agg['count']`
- Added tests for all the above functionality
- Add `hacktoberfest-accepted` label

@sethmlarson Please Review :)