### PR TITLE
Add support for pd.set_option display.max_rows None

### DIFF
--- a/eland/dataframe.py
+++ b/eland/dataframe.py
@@ -482,7 +482,7 @@ class DataFrame(NDFrame):
         max_cols = pd.get_option("display.max_columns")
         min_rows = pd.get_option("display.min_rows")
 
-        if len(self) > max_rows:
+        if max_rows and len(self) > max_rows:
             max_rows = min_rows
 
         show_dimensions = pd.get_option("display.show_dimensions")
@@ -528,7 +528,7 @@ class DataFrame(NDFrame):
             min_rows = pd.get_option("display.min_rows")
             show_dimensions = pd.get_option("display.show_dimensions")
 
-            if len(self) > max_rows:
+            if max_rows and len(self) > max_rows:
                 max_rows = min_rows
 
             return self.to_html(

--- a/eland/series.py
+++ b/eland/series.py
@@ -320,7 +320,7 @@ class Series(NDFrame):
         max_rows = pd.get_option("display.max_rows")
         min_rows = pd.get_option("display.min_rows")
 
-        if len(self) > max_rows:
+        if max_rows and len(self) > max_rows:
             max_rows = min_rows
 
         show_dimensions = pd.get_option("display.show_dimensions")

--- a/eland/tests/common.py
+++ b/eland/tests/common.py
@@ -75,7 +75,7 @@ class TestData:
         return _ed_ecommerce
 
 
-def assert_pandas_eland_frame_equal(left, right):
+def assert_pandas_eland_frame_equal(left, right, **kwargs):
     if not isinstance(left, pd.DataFrame):
         raise AssertionError(f"Expected type pd.DataFrame, found {type(left)} instead")
 
@@ -83,10 +83,10 @@ def assert_pandas_eland_frame_equal(left, right):
         raise AssertionError(f"Expected type ed.DataFrame, found {type(right)} instead")
 
     # Use pandas tests to check similarity
-    assert_frame_equal(left, right.to_pandas())
+    assert_frame_equal(left, right.to_pandas(), **kwargs)
 
 
-def assert_eland_frame_equal(left, right):
+def assert_eland_frame_equal(left, right, **kwargs):
     if not isinstance(left, ed.DataFrame):
         raise AssertionError(f"Expected type ed.DataFrame, found {type(left)} instead")
 
@@ -94,10 +94,10 @@ def assert_eland_frame_equal(left, right):
         raise AssertionError(f"Expected type ed.DataFrame, found {type(right)} instead")
 
     # Use pandas tests to check similarity
-    assert_frame_equal(left.to_pandas(), right.to_pandas())
+    assert_frame_equal(left.to_pandas(), right.to_pandas(), **kwargs)
 
 
-def assert_pandas_eland_series_equal(left, right, check_less_precise=False):
+def assert_pandas_eland_series_equal(left, right, **kwargs):
     if not isinstance(left, pd.Series):
         raise AssertionError(f"Expected type pd.Series, found {type(left)} instead")
 
@@ -105,4 +105,4 @@ def assert_pandas_eland_series_equal(left, right, check_less_precise=False):
         raise AssertionError(f"Expected type ed.Series, found {type(right)} instead")
 
     # Use pandas tests to check similarity
-    assert_series_equal(left, right.to_pandas(), check_less_precise=check_less_precise)
+    assert_series_equal(left, right.to_pandas(), **kwargs)

--- a/eland/tests/dataframe/test_repr_pytest.py
+++ b/eland/tests/dataframe/test_repr_pytest.py
@@ -270,7 +270,7 @@ class TestDataFrameRepr(TestData):
 
         assert ed_ecom_rh == pd_ecom_rh
 
-    def test_dataframe_repr_pd_get_option_None(self):
+    def test_dataframe_repr_pd_get_option_none(self):
         show_dimensions = pd.get_option("display.show_dimensions")
         show_rows = pd.get_option("display.max_rows")
 

--- a/eland/tests/dataframe/test_repr_pytest.py
+++ b/eland/tests/dataframe/test_repr_pytest.py
@@ -72,7 +72,9 @@ class TestDataFrameRepr(TestData):
         pd_dest_location = self.pd_flights()["DestLocation"].head(1)
         ed_dest_location = self.ed_flights()["DestLocation"].head(1)
 
-        assert_pandas_eland_series_equal(pd_dest_location, ed_dest_location)
+        assert_pandas_eland_series_equal(
+            pd_dest_location, ed_dest_location, check_exact=False, rtol=2
+        )
 
     def test_num_rows_to_string(self):
         # check setup works
@@ -267,3 +269,27 @@ class TestDataFrameRepr(TestData):
         pd.set_option("display.show_dimensions", show_dimensions)
 
         assert ed_ecom_rh == pd_ecom_rh
+
+    def test_dataframe_repr_pd_get_option_None(self):
+        show_dimensions = pd.get_option("display.show_dimensions")
+        show_rows = pd.get_option("display.max_rows")
+
+        pd.set_option("display.show_dimensions", False)
+        pd.set_option("display.max_rows", None)
+
+        columns = [
+            "AvgTicketPrice",
+            "Cancelled",
+            "dayOfWeek",
+            "timestamp",
+            "DestCountry",
+        ]
+
+        ed_flights = self.ed_flights().filter(columns).head(40).__repr__()
+        pd_flights = self.pd_flights().filter(columns).head(40).__repr__()
+
+        assert ed_flights == pd_flights
+
+        # Restore default
+        pd.set_option("display.max_rows", show_rows)
+        pd.set_option("display.show_dimensions", show_dimensions)

--- a/eland/tests/dataframe/test_repr_pytest.py
+++ b/eland/tests/dataframe/test_repr_pytest.py
@@ -273,23 +273,23 @@ class TestDataFrameRepr(TestData):
     def test_dataframe_repr_pd_get_option_none(self):
         show_dimensions = pd.get_option("display.show_dimensions")
         show_rows = pd.get_option("display.max_rows")
+        try:
+            pd.set_option("display.show_dimensions", False)
+            pd.set_option("display.max_rows", None)
 
-        pd.set_option("display.show_dimensions", False)
-        pd.set_option("display.max_rows", None)
+            columns = [
+                "AvgTicketPrice",
+                "Cancelled",
+                "dayOfWeek",
+                "timestamp",
+                "DestCountry",
+            ]
 
-        columns = [
-            "AvgTicketPrice",
-            "Cancelled",
-            "dayOfWeek",
-            "timestamp",
-            "DestCountry",
-        ]
+            ed_flights = self.ed_flights().filter(columns).head(40).__repr__()
+            pd_flights = self.pd_flights().filter(columns).head(40).__repr__()
 
-        ed_flights = self.ed_flights().filter(columns).head(40).__repr__()
-        pd_flights = self.pd_flights().filter(columns).head(40).__repr__()
-
-        assert ed_flights == pd_flights
-
-        # Restore default
-        pd.set_option("display.max_rows", show_rows)
-        pd.set_option("display.show_dimensions", show_dimensions)
+            assert ed_flights == pd_flights
+        finally:
+            # Restore default
+            pd.set_option("display.max_rows", show_rows)
+            pd.set_option("display.show_dimensions", show_dimensions)

--- a/eland/tests/series/test_repr_pytest.py
+++ b/eland/tests/series/test_repr_pytest.py
@@ -47,7 +47,7 @@ class TestSeriesRepr(TestData):
         ed_s = ed.Series(ES_TEST_CLIENT, FLIGHTS_INDEX_NAME, "Carrier").head(0)
         assert repr(pd_s) == repr(ed_s)
 
-    def test_series_repr_pd_get_option_None(self):
+    def test_series_repr_pd_get_option_none(self):
         show_dimensions = pd.get_option("display.show_dimensions")
         show_rows = pd.get_option("display.max_rows")
 

--- a/eland/tests/series/test_repr_pytest.py
+++ b/eland/tests/series/test_repr_pytest.py
@@ -16,6 +16,8 @@
 #  under the License.
 
 # File called _pytest for PyCharm compatability
+import pandas as pd
+
 import eland as ed
 from eland.tests import ES_TEST_CLIENT, FLIGHTS_INDEX_NAME
 from eland.tests.common import TestData
@@ -44,3 +46,18 @@ class TestSeriesRepr(TestData):
         pd_s = self.pd_flights()["Carrier"].head(0)
         ed_s = ed.Series(ES_TEST_CLIENT, FLIGHTS_INDEX_NAME, "Carrier").head(0)
         assert repr(pd_s) == repr(ed_s)
+
+    def test_series_repr_pd_get_option_None(self):
+        show_dimensions = pd.get_option("display.show_dimensions")
+        show_rows = pd.get_option("display.max_rows")
+
+        pd.set_option("display.show_dimensions", False)
+        pd.set_option("display.max_rows", None)
+
+        ed_flights = self.ed_flights()["Cancelled"].head(40).__repr__()
+        pd_flights = self.pd_flights()["Cancelled"].head(40).__repr__()
+
+        assert ed_flights == pd_flights
+
+        pd.set_option("display.max_rows", show_rows)
+        pd.set_option("display.show_dimensions", show_dimensions)

--- a/eland/tests/series/test_repr_pytest.py
+++ b/eland/tests/series/test_repr_pytest.py
@@ -50,14 +50,14 @@ class TestSeriesRepr(TestData):
     def test_series_repr_pd_get_option_none(self):
         show_dimensions = pd.get_option("display.show_dimensions")
         show_rows = pd.get_option("display.max_rows")
+        try:
+            pd.set_option("display.show_dimensions", False)
+            pd.set_option("display.max_rows", None)
 
-        pd.set_option("display.show_dimensions", False)
-        pd.set_option("display.max_rows", None)
+            ed_flights = self.ed_flights()["Cancelled"].head(40).__repr__()
+            pd_flights = self.pd_flights()["Cancelled"].head(40).__repr__()
 
-        ed_flights = self.ed_flights()["Cancelled"].head(40).__repr__()
-        pd_flights = self.pd_flights()["Cancelled"].head(40).__repr__()
-
-        assert ed_flights == pd_flights
-
-        pd.set_option("display.max_rows", show_rows)
-        pd.set_option("display.show_dimensions", show_dimensions)
+            assert ed_flights == pd_flights
+        finally:
+            pd.set_option("display.max_rows", show_rows)
+            pd.set_option("display.show_dimensions", show_dimensions)


### PR DESCRIPTION
Closes #305 
- Added the support for both DataFrame and series
- Added tests.
- I also added `**kwargs` to our `assert_test_*` methods because `check_less_precise` is now deprecated, we have to use `check_exact=False`

@sethmlarson Please review 😄 