### PR TITLE
Add Elasticsearch storage usage to df.info()

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Data columns (total 27 columns):
  26  timestamp           13059 non-null  datetime64[ns]
 dtypes: bool(2), datetime64[ns](1), float64(5), int64(2), object(17)
 memory usage: 80.0 bytes
+Elasticsearch storage usage: 5.043 MB
 
 # Filtering of rows using comparisons
 >>> df[(df.Carrier=="Kibana Airlines") & (df.AvgTicketPrice > 900.0) & (df.Cancelled == True)].head()

--- a/docs/sphinx/examples/demo_notebook.ipynb
+++ b/docs/sphinx/examples/demo_notebook.ipynb
@@ -88,7 +88,7 @@
        "eland.dataframe.DataFrame"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3122,7 +3122,8 @@
       " 25  dayOfWeek           13059 non-null  int64         \n",
       " 26  timestamp           13059 non-null  datetime64[ns]\n",
       "dtypes: bool(2), datetime64[ns](1), float64(5), int64(2), object(17)\n",
-      "memory usage: 64.0 bytes\n"
+      "memory usage: 64.000 bytes\n",
+      "Elasticsearch storage usage: 5.043 MB\n"
      ]
     }
    ],
@@ -4065,7 +4066,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.6"
+   "version": "3.8.5"
   },
   "pycharm": {
    "stem_cell": {

--- a/eland/tests/tests_notebook/test_demo_notebook.ipynb
+++ b/eland/tests/tests_notebook/test_demo_notebook.ipynb
@@ -2870,7 +2870,8 @@
       " 25  dayOfWeek           13059 non-null  int64         \n",
       " 26  timestamp           13059 non-null  datetime64[ns]\n",
       "dtypes: bool(2), datetime64[ns](1), float64(5), int64(2), object(17)\n",
-      "memory usage: 64.0 bytes\n"
+      "memory usage: 64.000 bytes\n",
+      "Elasticsearch storage usage: 5.043 MB\n"
      ]
     }
    ],


### PR DESCRIPTION
- Added the Elasticsearch Storage Usage to `df.info()`

Example:
```python
>>> ed_df = ed.DataFrame('localhost', 'flights')
>>> ed_df.info()
<class 'eland.dataframe.DataFrame'>
Index: 13059 entries, 0 to 13058
Data columns (total 27 columns):
 #   Column              Non-Null Count  Dtype         
---  ------              --------------  -----         
 0   AvgTicketPrice      13059 non-null  float64       
 1   Cancelled           13059 non-null  bool          
 2   Carrier             13059 non-null  object        
 3   Dest                13059 non-null  object        
 4   DestAirportID       13059 non-null  object        
 5   DestCityName        13059 non-null  object        
 6   DestCountry         13059 non-null  object        
 7   DestLocation        13059 non-null  object        
 8   DestRegion          13059 non-null  object        
 9   DestWeather         13059 non-null  object        
 10  DistanceKilometers  13059 non-null  float64       
 11  DistanceMiles       13059 non-null  float64       
 12  FlightDelay         13059 non-null  bool          
 13  FlightDelayMin      13059 non-null  int64         
 14  FlightDelayType     13059 non-null  object        
 15  FlightNum           13059 non-null  object        
 16  FlightTimeHour      13059 non-null  float64       
 17  FlightTimeMin       13059 non-null  float64       
 18  Origin              13059 non-null  object        
 19  OriginAirportID     13059 non-null  object        
 20  OriginCityName      13059 non-null  object        
 21  OriginCountry       13059 non-null  object        
 22  OriginLocation      13059 non-null  object        
 23  OriginRegion        13059 non-null  object        
 24  OriginWeather       13059 non-null  object        
 25  dayOfWeek           13059 non-null  int64         
 26  timestamp           13059 non-null  datetime64[ns]
dtypes: bool(2), datetime64[ns](1), float64(5), int64(2), object(17)
memory usage: 64.000 bytes
Elasticsearch storage usage: 5.043 MB
```
@sethmlarson Please review 😃 