### PR TITLE
Refactor manifest.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include LICENSE.txt
 include README.md
-recursive-include eland py.typed
+recursive-include eland 
+include eland/py.typed

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,3 @@
 include LICENSE.txt
 include README.md
-recursive-include eland 
 include eland/py.typed


### PR DESCRIPTION
Since we don't have `py.typed` in root directory
In `Manifest.in`
Either it should be included as part of `recursive-include eland`
or make it `include eland/py.typed`

I chose the second.

@sethmlarson Need thoughts on this.