### PR TITLE
Drop support for Python 3.6, pandas<1.2

### DIFF
--- a/.ci/test-matrix.yml
+++ b/.ci/test-matrix.yml
@@ -3,17 +3,15 @@
 ELASTICSEARCH_VERSION:
   - 8.0.0-SNAPSHOT
   - 7.x-SNAPSHOT
-  - 7.10-SNAPSHOT
 
 PANDAS_VERSION:
-  - 1.2.0
-  - 1.3.0
+  - 1.2
+  - 1.3
 
 PYTHON_VERSION:
   - 3.9
   - 3.8
   - 3.7
-  - 3.6
 
 TEST_SUITE:
   - xpack

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,12 +12,12 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
-      - name: Set up Python 3.8
+      - name: Set up Python 3
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3
       - name: Install dependencies
-        run: python3.8 -m pip install nox
+        run: python3 -m pip install nox
       - name: Lint the code
         run: nox -s lint
 
@@ -26,13 +26,13 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
-      - name: Set up Python 3.8
+      - name: Set up Python 3
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3
       - name: Install dependencies
         run: |
             sudo apt-get install --yes pandoc
-            python3.8 -m pip install nox
+            python3 -m pip install nox
       - name: Build documentation
         run: nox -s docs

--- a/eland/common.py
+++ b/eland/common.py
@@ -310,7 +310,7 @@ def es_version(es_client: Elasticsearch) -> Tuple[int, int, int]:
                 f"Received: {version_info}"
             )
         eland_es_version = cast(
-            Tuple[int, int, int], tuple([int(x) for x in match.groups()])
+            Tuple[int, int, int], tuple(int(x) for x in match.groups())
         )
         es_client._eland_es_version = eland_es_version  # type: ignore
     else:

--- a/eland/operations.py
+++ b/eland/operations.py
@@ -219,7 +219,7 @@ class Operations:
         if is_dataframe:
             # If multiple values of mode is returned for a particular column
             # find the maximum length and use that to fill dataframe with NaN/NaT
-            rows_len = max([len(value) for value in results.values()])
+            rows_len = max(len(value) for value in results.values())
             for key, values in results.items():
                 row_diff = rows_len - len(values)
                 # Convert np.ndarray to list

--- a/noxfile.py
+++ b/noxfile.py
@@ -53,7 +53,7 @@ TYPED_FILES = (
 def format(session):
     session.install("black", "isort")
     session.run("python", "utils/license-headers.py", "fix", *SOURCE_FILES)
-    session.run("black", "--target-version=py36", *SOURCE_FILES)
+    session.run("black", "--target-version=py37", *SOURCE_FILES)
     session.run("isort", *SOURCE_FILES)
     lint(session)
 
@@ -63,7 +63,7 @@ def lint(session):
     session.install("black", "flake8", "mypy", "isort")
     session.install("--pre", "elasticsearch")
     session.run("python", "utils/license-headers.py", "check", *SOURCE_FILES)
-    session.run("black", "--check", "--target-version=py36", *SOURCE_FILES)
+    session.run("black", "--check", "--target-version=py37", *SOURCE_FILES)
     session.run("isort", "--check", *SOURCE_FILES)
     session.run("flake8", "--ignore=E501,W503,E402,E712,E203", *SOURCE_FILES)
 
@@ -89,20 +89,13 @@ def lint(session):
             session.error("\n" + "\n".join(sorted(set(errors))))
 
 
-@nox.session(python=["3.6", "3.7", "3.8", "3.9"])
-@nox.parametrize("pandas_version", ["1.2.0", "1.3.0"])
+@nox.session(python=["3.7", "3.8", "3.9"])
+@nox.parametrize("pandas_version", ["1.2", "1.3"])
 def test(session, pandas_version: str):
     session.install("-r", "requirements-dev.txt")
     session.install(".")
-    session.run("python", "-m", "pip", "install", f"pandas=={pandas_version}")
+    session.run("python", "-m", "pip", "install", f"pandas~={pandas_version}")
     session.run("python", "-m", "tests.setup_tests")
-
-    # Notebooks are only run on Python 3.7+ due to pandas 1.2.0
-    if session.python == "3.6":
-        nbval = ()
-    else:
-        nbval = ("--nbval",)
-
     session.run(
         "python",
         "-m",
@@ -111,7 +104,7 @@ def test(session, pandas_version: str):
         "term-missing",
         "--cov=eland/",
         "--doctest-modules",
-        *nbval,
+        "--nbval",
         *(session.posargs or ("eland/", "tests/")),
     )
 

--- a/setup.py
+++ b/setup.py
@@ -38,10 +38,10 @@ CLASSIFIERS = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
     "Topic :: Scientific/Engineering",
 ]
 
@@ -70,8 +70,8 @@ setup(
     classifiers=CLASSIFIERS,
     keywords="elastic eland pandas python",
     packages=find_packages(include=["eland", "eland.*"]),
-    install_requires=["elasticsearch>=7.7", "pandas>=1", "matplotlib", "numpy"],
-    python_requires=">=3.6",
+    install_requires=["elasticsearch>=7.13", "pandas>=1.2,<1.4", "matplotlib", "numpy"],
+    python_requires=">=3.7",
     package_data={"eland": ["py.typed"]},
     include_package_data=True,
     zip_safe=False,


### PR DESCRIPTION
Older versions are becoming harder to support, especially with pandas 1.2 dropping Python 3.6.