### PR TITLE
Add pseudohubererror in tests

### DIFF
--- a/tests/ml/test_ml_model_pytest.py
+++ b/tests/ml/test_ml_model_pytest.py
@@ -336,7 +336,13 @@ class TestMLModel:
     @pytest.mark.parametrize("compress_model_definition", [True, False])
     @pytest.mark.parametrize(
         "objective",
-        ["reg:squarederror", "reg:squaredlogerror", "reg:linear", "reg:logistic"],
+        [
+            "reg:squarederror",
+            "reg:squaredlogerror",
+            "reg:linear",
+            "reg:logistic",
+            "reg:pseudohubererror",
+        ],
     )
     @pytest.mark.parametrize("booster", ["gbtree", "dart"])
     def test_xgb_regressor(self, compress_model_definition, objective, booster):


### PR DESCRIPTION
Closes #251 

Also should we start supporting other learning parameters in https://xgboost.readthedocs.io/en/latest/parameter.html#learning-task-parameters ? Perhaps one by one.

such as 
- binary:logitraw
- binary:hinge