### PR TITLE
Remove `PandasToCSVCollector`, `PandasToDataFrameCollector` 

### DIFF
--- a/eland/dataframe.py
+++ b/eland/dataframe.py
@@ -1310,7 +1310,7 @@ class DataFrame(NDFrame):
         doublequote=True,
         escapechar=None,
         decimal=".",
-    ):
+    ) -> Optional[str]:
         """
         Write Elasticsearch data to a comma-separated values (csv) file.
 

--- a/eland/etl.py
+++ b/eland/etl.py
@@ -526,29 +526,18 @@ def csv_to_eland(  # type: ignore
 
     first_write = True
     for chunk in reader:
-        if first_write:
-            pandas_to_eland(
-                chunk,
-                es_client,
-                es_dest_index,
-                es_if_exists=es_if_exists,
-                chunksize=chunksize,
-                es_refresh=es_refresh,
-                es_dropna=es_dropna,
-                es_type_overrides=es_type_overrides,
-            )
-            first_write = False
-        else:
-            pandas_to_eland(
-                chunk,
-                es_client,
-                es_dest_index,
-                es_if_exists="append",
-                chunksize=chunksize,
-                es_refresh=es_refresh,
-                es_dropna=es_dropna,
-                es_type_overrides=es_type_overrides,
-            )
+        pandas_to_eland(
+            chunk,
+            es_client,
+            es_dest_index,
+            chunksize=chunksize,
+            es_refresh=es_refresh,
+            es_dropna=es_dropna,
+            es_type_overrides=es_type_overrides,
+            # es_if_exists should be 'append' except on the first call to pandas_to_eland()
+            es_if_exists=(es_if_exists if first_write else "append"),
+        )
+        first_write = False
 
     # Now create an eland.DataFrame that references the new index
     return DataFrame(es_client, es_index_pattern=es_dest_index)

--- a/eland/query_compiler.py
+++ b/eland/query_compiler.py
@@ -528,7 +528,7 @@ class QueryCompiler:
         return self._operations.to_pandas(self, show_progress)
 
     # To CSV
-    def to_csv(self, **kwargs):
+    def to_csv(self, **kwargs) -> Optional[str]:
         """Serialises Eland Dataframe to CSV
 
         Returns:


### PR DESCRIPTION
This PR is a small change that removes `PandasToCSVCollector`, `PandasToDataFrameCollector` 

This has a basic functionality, But at the moment I think its not required. 

If any additional functionality comes, I think we can achieve it without a class!

@sethmlarson  Take a look at it :)