### PR TITLE
Add `iterrows()` and `itertuples()` DataFrame API, its usage is similar to `pandas`

### DIFF
--- a/docs/sphinx/reference/api/eland.DataFrame.iterrows.rst
+++ b/docs/sphinx/reference/api/eland.DataFrame.iterrows.rst
@@ -1,0 +1,6 @@
+eland.DataFrame.iterrows
+========================
+
+.. currentmodule:: eland
+
+.. automethod:: DataFrame.iterrows

--- a/docs/sphinx/reference/api/eland.DataFrame.itertuples.rst
+++ b/docs/sphinx/reference/api/eland.DataFrame.itertuples.rst
@@ -1,0 +1,6 @@
+eland.DataFrame.itertuples
+==========================
+
+.. currentmodule:: eland
+
+.. automethod:: DataFrame.itertuples

--- a/docs/sphinx/reference/dataframe.rst
+++ b/docs/sphinx/reference/dataframe.rst
@@ -38,6 +38,8 @@ Indexing, Iteration
    DataFrame.get
    DataFrame.query
    DataFrame.sample
+   DataFrame.iterrows
+   DataFrame.itertuples
 
 Function Application, GroupBy & Window
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/eland/dataframe.py
+++ b/eland/dataframe.py
@@ -1450,7 +1450,8 @@ class DataFrame(NDFrame):
         """
         Iterate over eland.DataFrame rows as (index, pandas.Series) pairs.
 
-        Yields:
+        Yields
+        ------
             index: index
                 The index of the row.
             data: pandas Series
@@ -1488,7 +1489,8 @@ class DataFrame(NDFrame):
         timestamp       2018-01-01 18:27:00
         Name: 1, dtype: object
         """
-        return self._query_compiler.iterrows()
+        for df in self._query_compiler.yield_pandas_dataframe():
+            yield from df.iterrows()
 
     def itertuples(
         self, index: bool = True, name: Union[str, None] = "Eland"
@@ -1496,13 +1498,15 @@ class DataFrame(NDFrame):
         """
         Iterate over eland.DataFrame rows as namedtuples.
 
-        Args:
+        Args
+        ----
             index: bool, default True
                 If True, return the index as the first element of the tuple.
             name: str or None, default "Eland"
                 The name of the returned namedtuples or None to return regular tuples.
 
-        Returns:
+        Returns
+        -------
             iterator
                 An object to iterate over namedtuples for each row in the
                 DataFrame with the first field possibly being the index and
@@ -1542,7 +1546,8 @@ class DataFrame(NDFrame):
         Flight(Index='0', AvgTicketPrice=841.265642, Cancelled=False, ..., dayOfWeek=0, timestamp='2018-01-01 00:00:00')
         Flight(Index='1', AvgTicketPrice=882.982662, Cancelled=False, ..., dayOfWeek=0, timestamp='2018-01-01 18:27:00')
         """
-        return self._query_compiler.itertuples(index=index, name=name)
+        for df in self._query_compiler.yield_pandas_dataframe():
+            yield from df.itertuples(index=index, name=name)
 
     def aggregate(
         self,

--- a/eland/dataframe.py
+++ b/eland/dataframe.py
@@ -1463,31 +1463,34 @@ class DataFrame(NDFrame):
 
         Examples
         --------
-        >>> df = ed.DataFrame('localhost:9200', 'flights')
-        >>> df.head()
-            AvgTicketPrice  Cancelled  ... dayOfWeek           timestamp
-        0      841.265642      False  ...         0 2018-01-01 00:00:00
-        1      882.982662      False  ...         0 2018-01-01 18:27:00
-        2      190.636904      False  ...         0 2018-01-01 17:11:14
-        3      181.694216       True  ...         0 2018-01-01 10:33:28
-        4      730.041778      False  ...         0 2018-01-01 05:13:00
+        >>> df = ed.DataFrame('localhost:9200', 'flights', columns=['AvgTicketPrice', 'Cancelled']).head()
+        >>> df
+           AvgTicketPrice  Cancelled
+        0      841.265642      False
+        1      882.982662      False
+        2      190.636904      False
+        3      181.694216       True
+        4      730.041778      False
         <BLANKLINE>
-        [5 rows x 27 columns]
+        [5 rows x 2 columns]
 
-        >>> for index, row in df.iterrows()
+        >>> for index, row in df.iterrows():
         ...     print(row)
-
-        AvgTicketPrice  841.265642
-        Cancelled       False
-        dayOfWeek       0
-        timestamp       2018-01-01 00:00:00
+        AvgTicketPrice    841.265642
+        Cancelled              False
         Name: 0, dtype: object
-
-        AvgTicketPrice  882.982662
-        Cancelled       False
-        dayOfWeek       0
-        timestamp       2018-01-01 18:27:00
+        AvgTicketPrice    882.982662
+        Cancelled              False
         Name: 1, dtype: object
+        AvgTicketPrice    190.636904
+        Cancelled              False
+        Name: 2, dtype: object
+        AvgTicketPrice    181.694216
+        Cancelled               True
+        Name: 3, dtype: object
+        AvgTicketPrice    730.041778
+        Cancelled              False
+        Name: 4, dtype: object
         """
         for df in self._query_compiler.yield_pandas_dataframe():
             yield from df.iterrows()
@@ -1518,33 +1521,42 @@ class DataFrame(NDFrame):
 
         Examples
         --------
-        >>> df = ed.DataFrame('localhost:9200', 'flights')
-        >>> df.head()
-            AvgTicketPrice  Cancelled  ... dayOfWeek           timestamp
-        0      841.265642      False  ...         0 2018-01-01 00:00:00
-        1      882.982662      False  ...         0 2018-01-01 18:27:00
-        2      190.636904      False  ...         0 2018-01-01 17:11:14
-        3      181.694216       True  ...         0 2018-01-01 10:33:28
-        4      730.041778      False  ...         0 2018-01-01 05:13:00
+        >>> df = ed.DataFrame('localhost:9200', 'flights', columns=['AvgTicketPrice', 'Cancelled']).head()
+        >>> df
+           AvgTicketPrice  Cancelled
+        0      841.265642      False
+        1      882.982662      False
+        2      190.636904      False
+        3      181.694216       True
+        4      730.041778      False
         <BLANKLINE>
-        [5 rows x 27 columns]
+        [5 rows x 2 columns]
 
         >>> for row in df.itertuples():
         ...     print(row)
-        Eland(Index='0', AvgTicketPrice=841.265642, Cancelled=False, ..., dayOfWeek=0, timestamp='2018-01-01 00:00:00')
-        Eland(Index='1', AvgTicketPrice=882.982662, Cancelled=False, ..., dayOfWeek=0, timestamp='2018-01-01 18:27:00')
+        Eland(Index='0', AvgTicketPrice=841.2656419677076, Cancelled=False)
+        Eland(Index='1', AvgTicketPrice=882.9826615595518, Cancelled=False)
+        Eland(Index='2', AvgTicketPrice=190.6369038508356, Cancelled=False)
+        Eland(Index='3', AvgTicketPrice=181.69421554118, Cancelled=True)
+        Eland(Index='4', AvgTicketPrice=730.041778346198, Cancelled=False)
 
         By setting the `index` parameter to False we can remove the index as the first element of the tuple:
         >>> for row in df.itertuples(index=False):
         ...     print(row)
-        Eland(AvgTicketPrice=841.265642, Cancelled=False, ..., dayOfWeek=0, timestamp='2018-01-01 00:00:00')
-        Eland(AvgTicketPrice=882.982662, Cancelled=False, ..., dayOfWeek=0, timestamp='2018-01-01 18:27:00')
+        Eland(AvgTicketPrice=841.2656419677076, Cancelled=False)
+        Eland(AvgTicketPrice=882.9826615595518, Cancelled=False)
+        Eland(AvgTicketPrice=190.6369038508356, Cancelled=False)
+        Eland(AvgTicketPrice=181.69421554118, Cancelled=True)
+        Eland(AvgTicketPrice=730.041778346198, Cancelled=False)
 
         With the `name` parameter set we set a custom name for the yielded namedtuples:
         >>> for row in df.itertuples(name='Flight'):
         ...     print(row)
-        Flight(Index='0', AvgTicketPrice=841.265642, Cancelled=False, ..., dayOfWeek=0, timestamp='2018-01-01 00:00:00')
-        Flight(Index='1', AvgTicketPrice=882.982662, Cancelled=False, ..., dayOfWeek=0, timestamp='2018-01-01 18:27:00')
+        Flight(Index='0', AvgTicketPrice=841.2656419677076, Cancelled=False)
+        Flight(Index='1', AvgTicketPrice=882.9826615595518, Cancelled=False)
+        Flight(Index='2', AvgTicketPrice=190.6369038508356, Cancelled=False)
+        Flight(Index='3', AvgTicketPrice=181.69421554118, Cancelled=True)
+        Flight(Index='4', AvgTicketPrice=730.041778346198, Cancelled=False)
         """
         for df in self._query_compiler.yield_pandas_dataframe():
             yield from df.itertuples(index=index, name=name)

--- a/eland/dataframe.py
+++ b/eland/dataframe.py
@@ -19,7 +19,7 @@ import re
 import sys
 import warnings
 from io import StringIO
-from typing import TYPE_CHECKING, Any, List, Optional, Sequence, Tuple, Union
+from typing import TYPE_CHECKING, Any, Iterable, List, Optional, Sequence, Tuple, Union
 
 import numpy as np
 import pandas as pd  # type: ignore
@@ -1445,6 +1445,104 @@ class DataFrame(NDFrame):
             Elasticsearch field names as pandas.Index
         """
         return self.columns
+
+    def iterrows(self) -> Iterable[Tuple[Union[str, Tuple[str, ...]], pd.Series]]:
+        """
+        Iterate over eland.DataFrame rows as (index, pandas.Series) pairs.
+
+        Yields:
+            index: index
+                The index of the row.
+            data: pandas Series
+                The data of the row as a pandas Series.
+
+        See Also
+        --------
+        eland.DataFrame.itertuples: Iterate over eland.DataFrame rows as namedtuples.
+
+        Examples
+        --------
+        >>> df = ed.DataFrame('localhost:9200', 'flights')
+        >>> df.head()
+            AvgTicketPrice  Cancelled  ... dayOfWeek           timestamp
+        0      841.265642      False  ...         0 2018-01-01 00:00:00
+        1      882.982662      False  ...         0 2018-01-01 18:27:00
+        2      190.636904      False  ...         0 2018-01-01 17:11:14
+        3      181.694216       True  ...         0 2018-01-01 10:33:28
+        4      730.041778      False  ...         0 2018-01-01 05:13:00
+        <BLANKLINE>
+        [5 rows x 27 columns]
+
+        >>> for index, row in df.iterrows()
+        ...     print(row)
+
+        AvgTicketPrice  841.265642
+        Cancelled       False
+        dayOfWeek       0
+        timestamp       2018-01-01 00:00:00
+        Name: 0, dtype: object
+
+        AvgTicketPrice  882.982662
+        Cancelled       False
+        dayOfWeek       0
+        timestamp       2018-01-01 18:27:00
+        Name: 1, dtype: object
+        """
+        return self._query_compiler.iterrows()
+
+    def itertuples(
+        self, index: bool = True, name: Union[str, None] = "Eland"
+    ) -> Iterable[Tuple[Any, ...]]:
+        """
+        Iterate over eland.DataFrame rows as namedtuples.
+
+        Args:
+            index: bool, default True
+                If True, return the index as the first element of the tuple.
+            name: str or None, default "Eland"
+                The name of the returned namedtuples or None to return regular tuples.
+
+        Returns:
+            iterator
+                An object to iterate over namedtuples for each row in the
+                DataFrame with the first field possibly being the index and
+                following fields being the column values.
+
+        See Also
+        --------
+        eland.DataFrame.iterrows: Iterate over eland.DataFrame rows as (index, pandas.Series) pairs.
+
+        Examples
+        --------
+        >>> df = ed.DataFrame('localhost:9200', 'flights')
+        >>> df.head()
+            AvgTicketPrice  Cancelled  ... dayOfWeek           timestamp
+        0      841.265642      False  ...         0 2018-01-01 00:00:00
+        1      882.982662      False  ...         0 2018-01-01 18:27:00
+        2      190.636904      False  ...         0 2018-01-01 17:11:14
+        3      181.694216       True  ...         0 2018-01-01 10:33:28
+        4      730.041778      False  ...         0 2018-01-01 05:13:00
+        <BLANKLINE>
+        [5 rows x 27 columns]
+
+        >>> for row in df.itertuples():
+        ...     print(row)
+        Eland(Index='0', AvgTicketPrice=841.265642, Cancelled=False, ..., dayOfWeek=0, timestamp='2018-01-01 00:00:00')
+        Eland(Index='1', AvgTicketPrice=882.982662, Cancelled=False, ..., dayOfWeek=0, timestamp='2018-01-01 18:27:00')
+
+        By setting the `index` parameter to False we can remove the index as the first element of the tuple:
+        >>> for row in df.itertuples(index=False):
+        ...     print(row)
+        Eland(AvgTicketPrice=841.265642, Cancelled=False, ..., dayOfWeek=0, timestamp='2018-01-01 00:00:00')
+        Eland(AvgTicketPrice=882.982662, Cancelled=False, ..., dayOfWeek=0, timestamp='2018-01-01 18:27:00')
+
+        With the `name` parameter set we set a custom name for the yielded namedtuples:
+        >>> for row in df.itertuples(name='Flight'):
+        ...     print(row)
+        Flight(Index='0', AvgTicketPrice=841.265642, Cancelled=False, ..., dayOfWeek=0, timestamp='2018-01-01 00:00:00')
+        Flight(Index='1', AvgTicketPrice=882.982662, Cancelled=False, ..., dayOfWeek=0, timestamp='2018-01-01 18:27:00')
+        """
+        return self._query_compiler.itertuples(index=index, name=name)
 
     def aggregate(
         self,

--- a/eland/dataframe.py
+++ b/eland/dataframe.py
@@ -1492,7 +1492,7 @@ class DataFrame(NDFrame):
         Cancelled              False
         Name: 4, dtype: object
         """
-        for df in self._query_compiler.yield_pandas_dataframe():
+        for df in self._query_compiler.search_yield_pandas_dataframes():
             yield from df.iterrows()
 
     def itertuples(
@@ -1558,7 +1558,7 @@ class DataFrame(NDFrame):
         Flight(Index='3', AvgTicketPrice=181.69421554118, Cancelled=True)
         Flight(Index='4', AvgTicketPrice=730.041778346198, Cancelled=False)
         """
-        for df in self._query_compiler.yield_pandas_dataframe():
+        for df in self._query_compiler.search_yield_pandas_dataframes():
             yield from df.itertuples(index=index, name=name)
 
     def aggregate(

--- a/eland/operations.py
+++ b/eland/operations.py
@@ -1211,7 +1211,7 @@ class Operations:
         df = self._es_results(query_compiler, show_progress)
         return df.to_csv(**kwargs)  # type: ignore[no-any-return]
 
-    def search_yield_pandas_dataframe(
+    def search_yield_pandas_dataframes(
         self, query_compiler: "QueryCompiler"
     ) -> Generator["pd.DataFrame", None, None]:
         query_params, post_processing = self._resolve_tasks(query_compiler)

--- a/eland/operations.py
+++ b/eland/operations.py
@@ -1196,64 +1196,6 @@ class Operations:
             ["count", "mean", "std", "min", "25%", "50%", "75%", "max"]
         )
 
-    def iterrows(
-        self, query_compiler: "QueryCompiler"
-    ) -> Iterable[Tuple[Union[str, Tuple[str, ...]], pd.Series]]:
-        query_params, post_processing = self._resolve_tasks(query_compiler)
-        result_size, sort_params = Operations._query_params_to_size_and_sort(
-            query_params
-        )
-
-        script_fields = query_params.script_fields
-        query = Query(query_params.query)
-
-        body = query.to_search_body()
-        if script_fields is not None:
-            body["script_fields"] = script_fields
-
-        # Only return requested field_names and add them to body
-        _source = query_compiler.get_field_names(include_scripted_fields=False)
-        body["_source"] = _source if _source else False
-
-        if sort_params:
-            body["sort"] = [sort_params]
-
-        for hits in _search_yield_hits(
-            query_compiler=query_compiler, body=body, max_number_of_hits=result_size
-        ):
-            df = query_compiler._es_results_to_pandas(hits)
-            df = self._apply_df_post_processing(df, post_processing)
-            yield from df.iterrows()
-
-    def itertuples(
-        self, query_compiler: "QueryCompiler", index: bool, name: Union[str, None]
-    ) -> Iterable[Tuple[Any, ...]]:
-        query_params, post_processing = self._resolve_tasks(query_compiler)
-        result_size, sort_params = Operations._query_params_to_size_and_sort(
-            query_params
-        )
-
-        script_fields = query_params.script_fields
-        query = Query(query_params.query)
-
-        body = query.to_search_body()
-        if script_fields is not None:
-            body["script_fields"] = script_fields
-
-        # Only return requested field_names and add them to body
-        _source = query_compiler.get_field_names(include_scripted_fields=False)
-        body["_source"] = _source if _source else False
-
-        if sort_params:
-            body["sort"] = [sort_params]
-
-        for hits in _search_yield_hits(
-            query_compiler=query_compiler, body=body, max_number_of_hits=result_size
-        ):
-            df = query_compiler._es_results_to_pandas(hits)
-            df = self._apply_df_post_processing(df, post_processing)
-            yield from df.itertuples(index=index, name=name)
-
     def to_pandas(
         self, query_compiler: "QueryCompiler", show_progress: bool = False
     ) -> pd.DataFrame:

--- a/eland/operations.py
+++ b/eland/operations.py
@@ -23,6 +23,7 @@ from typing import (
     Any,
     Dict,
     Generator,
+    Iterable,
     List,
     Optional,
     Sequence,
@@ -1194,6 +1195,64 @@ class Operations:
         return pd.concat([df1, df2]).reindex(
             ["count", "mean", "std", "min", "25%", "50%", "75%", "max"]
         )
+
+    def iterrows(
+        self, query_compiler: "QueryCompiler"
+    ) -> Iterable[Tuple[Union[str, Tuple[str, ...]], pd.Series]]:
+        query_params, post_processing = self._resolve_tasks(query_compiler)
+        result_size, sort_params = Operations._query_params_to_size_and_sort(
+            query_params
+        )
+
+        script_fields = query_params.script_fields
+        query = Query(query_params.query)
+
+        body = query.to_search_body()
+        if script_fields is not None:
+            body["script_fields"] = script_fields
+
+        # Only return requested field_names and add them to body
+        _source = query_compiler.get_field_names(include_scripted_fields=False)
+        body["_source"] = _source if _source else False
+
+        if sort_params:
+            body["sort"] = [sort_params]
+
+        for hits in _search_yield_hits(
+            query_compiler=query_compiler, body=body, max_number_of_hits=result_size
+        ):
+            df = query_compiler._es_results_to_pandas(hits)
+            df = self._apply_df_post_processing(df, post_processing)
+            yield from df.iterrows()
+
+    def itertuples(
+        self, query_compiler: "QueryCompiler", index: bool, name: Union[str, None]
+    ) -> Iterable[Tuple[Any, ...]]:
+        query_params, post_processing = self._resolve_tasks(query_compiler)
+        result_size, sort_params = Operations._query_params_to_size_and_sort(
+            query_params
+        )
+
+        script_fields = query_params.script_fields
+        query = Query(query_params.query)
+
+        body = query.to_search_body()
+        if script_fields is not None:
+            body["script_fields"] = script_fields
+
+        # Only return requested field_names and add them to body
+        _source = query_compiler.get_field_names(include_scripted_fields=False)
+        body["_source"] = _source if _source else False
+
+        if sort_params:
+            body["sort"] = [sort_params]
+
+        for hits in _search_yield_hits(
+            query_compiler=query_compiler, body=body, max_number_of_hits=result_size
+        ):
+            df = query_compiler._es_results_to_pandas(hits)
+            df = self._apply_df_post_processing(df, post_processing)
+            yield from df.itertuples(index=index, name=name)
 
     def to_pandas(
         self, query_compiler: "QueryCompiler", show_progress: bool = False

--- a/eland/operations.py
+++ b/eland/operations.py
@@ -1270,6 +1270,36 @@ class Operations:
         df = self._es_results(query_compiler, show_progress)
         return df.to_csv(**kwargs)  # type: ignore[no-any-return]
 
+    def search_yield_pandas_dataframe(
+        self, query_compiler: "QueryCompiler"
+    ) -> Generator["pd.DataFrame", None, None]:
+        query_params, post_processing = self._resolve_tasks(query_compiler)
+
+        result_size, sort_params = Operations._query_params_to_size_and_sort(
+            query_params
+        )
+
+        script_fields = query_params.script_fields
+        query = Query(query_params.query)
+
+        body = query.to_search_body()
+        if script_fields is not None:
+            body["script_fields"] = script_fields
+
+        # Only return requested field_names and add them to body
+        _source = query_compiler.get_field_names(include_scripted_fields=False)
+        body["_source"] = _source if _source else False
+
+        if sort_params:
+            body["sort"] = [sort_params]
+
+        for hits in _search_yield_hits(
+            query_compiler=query_compiler, body=body, max_number_of_hits=result_size
+        ):
+            df = query_compiler._es_results_to_pandas(hits)
+            df = self._apply_df_post_processing(df, post_processing)
+            yield df
+
     def _es_results(
         self, query_compiler: "QueryCompiler", show_progress: bool = False
     ) -> pd.DataFrame:

--- a/eland/operations.py
+++ b/eland/operations.py
@@ -23,7 +23,6 @@ from typing import (
     Any,
     Dict,
     Generator,
-    Iterable,
     List,
     Optional,
     Sequence,

--- a/eland/query_compiler.py
+++ b/eland/query_compiler.py
@@ -21,6 +21,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Dict,
+    Iterable,
     List,
     Optional,
     Sequence,
@@ -526,6 +527,38 @@ class QueryCompiler:
             If path_or_buf is None, returns the resulting csv format as a string. Otherwise returns None.
         """
         return self._operations.to_csv(self, **kwargs)
+
+    def iterrows(self) -> Iterable[Tuple[Union[str, Tuple[str, ...]], pd.Series]]:
+        """
+        Iterate over ed.DataFrame rows as (index, pd.Series) pairs.
+
+        Yields:
+            index: index
+                The index of the row.
+            data: pandas Series
+                The data of the row as a pandas Series.
+        """
+        return self._operations.iterrows(self)
+
+    def itertuples(
+        self, index: bool, name: Union[str, None]
+    ) -> Iterable[Tuple[Any, ...]]:
+        """
+        Iterate over eland.DataFrame rows as namedtuples.
+
+        Args:
+            index : bool, default True
+                If True, return the index as the first element of the tuple.
+            name : str or None, default "Eland"
+                The name of the returned namedtuples or None to return regular tuples.
+
+        Returns:
+            iterator
+                An object to iterate over namedtuples for each row in the
+                DataFrame with the first field possibly being the index and
+                following fields being the column values.
+        """
+        return self._operations.itertuples(self, index, name)
 
     # __getitem__ methods
     def getitem_column_array(self, key, numeric=False):

--- a/eland/query_compiler.py
+++ b/eland/query_compiler.py
@@ -528,8 +528,8 @@ class QueryCompiler:
         """
         return self._operations.to_csv(self, **kwargs)
 
-    def yield_pandas_dataframe(self) -> Generator["pd.DataFrame", None, None]:
-        return self._operations.search_yield_pandas_dataframe(self)
+    def search_yield_pandas_dataframes(self) -> Generator["pd.DataFrame", None, None]:
+        return self._operations.search_yield_pandas_dataframes(self)
 
     # __getitem__ methods
     def getitem_column_array(self, key, numeric=False):

--- a/eland/query_compiler.py
+++ b/eland/query_compiler.py
@@ -21,7 +21,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Dict,
-    Iterable,
+    Generator,
     List,
     Optional,
     Sequence,
@@ -528,37 +528,8 @@ class QueryCompiler:
         """
         return self._operations.to_csv(self, **kwargs)
 
-    def iterrows(self) -> Iterable[Tuple[Union[str, Tuple[str, ...]], pd.Series]]:
-        """
-        Iterate over ed.DataFrame rows as (index, pd.Series) pairs.
-
-        Yields:
-            index: index
-                The index of the row.
-            data: pandas Series
-                The data of the row as a pandas Series.
-        """
-        return self._operations.iterrows(self)
-
-    def itertuples(
-        self, index: bool, name: Union[str, None]
-    ) -> Iterable[Tuple[Any, ...]]:
-        """
-        Iterate over eland.DataFrame rows as namedtuples.
-
-        Args:
-            index : bool, default True
-                If True, return the index as the first element of the tuple.
-            name : str or None, default "Eland"
-                The name of the returned namedtuples or None to return regular tuples.
-
-        Returns:
-            iterator
-                An object to iterate over namedtuples for each row in the
-                DataFrame with the first field possibly being the index and
-                following fields being the column values.
-        """
-        return self._operations.itertuples(self, index, name)
+    def yield_pandas_dataframe(self) -> Generator["pd.DataFrame", None, None]:
+        return self._operations.search_yield_pandas_dataframe(self)
 
     # __getitem__ methods
     def getitem_column_array(self, key, numeric=False):

--- a/tests/dataframe/test_iterrows_itertuples_pytest.py
+++ b/tests/dataframe/test_iterrows_itertuples_pytest.py
@@ -24,22 +24,45 @@ from tests.common import TestData
 
 class TestDataFrameIterrowsItertuples(TestData):
     def test_iterrows(self):
-        ed_flights_iterrows = self.ed_flights().iterrows()
-        pd_flights_iterrows = self.pd_flights().iterrows()
-        assert len(ed_flights_iterrows) == len(pd_flights_iterrows)
+        ed_flights = self.ed_flights()
+        pd_flights = self.pd_flights()
 
-        for i in len(ed_flights_iterrows):
-            ed_index, ed_row = next(ed_flights_iterrows)
+        ed_flights_iterrows = ed_flights.iterrows()
+        pd_flights_iterrows = pd_flights.iterrows()
+
+        assert len(list(ed_flights_iterrows)) == len(list(pd_flights_iterrows))
+
+        for ed_index, ed_row in ed_flights_iterrows:
+
             pd_index, pd_row = next(pd_flights_iterrows)
+
             assert_index_equal(ed_index, pd_index)
             assert_series_equal(ed_row, pd_row)
 
-    def test_itertuples(self):
-        ed_flights_itertuples = self.ed_flights().itertuples(name=None)
-        pd_flights_itertuples = self.pd_flights().itertuples(name=None)
-        assert len(ed_flights_itertuples) == len(pd_flights_itertuples)
+        for pd_index, pd_row in pd_flights_iterrows:
 
-        for i in len(ed_flights_itertuples):
-            ed_row = next(ed_flights_itertuples)
+            ed_index, ed_row = next(ed_flights_iterrows)
+
+            assert_index_equal(pd_index, ed_index)
+            assert_series_equal(pd_row, ed_row)
+
+    def test_itertuples(self):
+        ed_flights = self.ed_flights()
+        pd_flights = self.pd_flights()
+
+        ed_flights_itertuples = ed_flights.itertuples(name=None)
+        pd_flights_itertuples = pd_flights.itertuples(name=None)
+
+        assert len(list(ed_flights_itertuples)) == len(list(pd_flights_itertuples))
+
+        for ed_row in ed_flights_itertuples:
+
             pd_row = next(pd_flights_itertuples)
+
             assert ed_row == pd_row
+
+        for pd_row in pd_flights_itertuples:
+
+            ed_row = next(ed_flights_itertuples)
+
+            assert pd_row == ed_row

--- a/tests/dataframe/test_iterrows_itertuples_pytest.py
+++ b/tests/dataframe/test_iterrows_itertuples_pytest.py
@@ -18,7 +18,7 @@
 # File called _pytest for PyCharm compatability
 
 import pytest
-from pandas.testing import assert_index_equal, assert_series_equal
+from pandas.testing import assert_series_equal
 
 from tests.common import TestData
 
@@ -34,7 +34,7 @@ class TestDataFrameIterrowsItertuples(TestData):
         for ed_index, ed_row in ed_flights_iterrows:
             pd_index, pd_row = next(pd_flights_iterrows)
 
-            assert_index_equal(ed_index, pd_index)
+            assert ed_index == pd_index
             assert_series_equal(ed_row, pd_row)
 
         # Assert that both are the same length and are exhausted.
@@ -50,4 +50,15 @@ class TestDataFrameIterrowsItertuples(TestData):
         ed_flights_itertuples = list(ed_flights.itertuples(name=None))
         pd_flights_itertuples = list(pd_flights.itertuples(name=None))
 
-        assert ed_flights_itertuples == pd_flights_itertuples
+        def assert_tuples_almost_equal(left, right):
+            # Shim which uses pytest.approx() for floating point values inside tuples.
+            assert len(left) == len(right)
+            assert all(
+                (lt == rt)  # Not floats? Use ==
+                if not isinstance(lt, float) and not isinstance(rt, float)
+                else (lt == pytest.approx(rt))  # If both are floats use pytest.approx()
+                for lt, rt in zip(left, right)
+            )
+
+        for ed_tuple, pd_tuple in zip(ed_flights_itertuples, pd_flights_itertuples):
+            assert_tuples_almost_equal(ed_tuple, pd_tuple)

--- a/tests/dataframe/test_iterrows_itertuples_pytest.py
+++ b/tests/dataframe/test_iterrows_itertuples_pytest.py
@@ -17,6 +17,7 @@
 
 # File called _pytest for PyCharm compatability
 
+import pytest
 from pandas.testing import assert_index_equal, assert_series_equal
 
 from tests.common import TestData

--- a/tests/dataframe/test_iterrows_itertuples_pytest.py
+++ b/tests/dataframe/test_iterrows_itertuples_pytest.py
@@ -1,0 +1,45 @@
+#  Licensed to Elasticsearch B.V. under one or more contributor
+#  license agreements. See the NOTICE file distributed with
+#  this work for additional information regarding copyright
+#  ownership. Elasticsearch B.V. licenses this file to you under
+#  the Apache License, Version 2.0 (the "License"); you may
+#  not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+# 	http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+
+# File called _pytest for PyCharm compatability
+
+from pandas.testing import assert_index_equal, assert_series_equal
+
+from tests.common import TestData
+
+
+class TestDataFrameIterrowsItertuples(TestData):
+    def test_iterrows(self):
+        ed_flights_iterrows = self.ed_flights().iterrows()
+        pd_flights_iterrows = self.pd_flights().iterrows()
+        assert len(ed_flights_iterrows) == len(pd_flights_iterrows)
+
+        for i in len(ed_flights_iterrows):
+            ed_index, ed_row = next(ed_flights_iterrows)
+            pd_index, pd_row = next(pd_flights_iterrows)
+            assert_index_equal(ed_index, pd_index)
+            assert_series_equal(ed_row, pd_row)
+
+    def test_itertuples(self):
+        ed_flights_itertuples = self.ed_flights().itertuples(name=None)
+        pd_flights_itertuples = self.pd_flights().itertuples(name=None)
+        assert len(ed_flights_itertuples) == len(pd_flights_itertuples)
+
+        for i in len(ed_flights_itertuples):
+            ed_row = next(ed_flights_itertuples)
+            pd_row = next(pd_flights_itertuples)
+            assert ed_row == pd_row

--- a/tests/dataframe/test_iterrows_itertuples_pytest.py
+++ b/tests/dataframe/test_iterrows_itertuples_pytest.py
@@ -30,39 +30,23 @@ class TestDataFrameIterrowsItertuples(TestData):
         ed_flights_iterrows = ed_flights.iterrows()
         pd_flights_iterrows = pd_flights.iterrows()
 
-        assert len(list(ed_flights_iterrows)) == len(list(pd_flights_iterrows))
-
         for ed_index, ed_row in ed_flights_iterrows:
-
             pd_index, pd_row = next(pd_flights_iterrows)
 
             assert_index_equal(ed_index, pd_index)
             assert_series_equal(ed_row, pd_row)
 
-        for pd_index, pd_row in pd_flights_iterrows:
-
-            ed_index, ed_row = next(ed_flights_iterrows)
-
-            assert_index_equal(pd_index, ed_index)
-            assert_series_equal(pd_row, ed_row)
+        # Assert that both are the same length and are exhausted.
+        with pytest.raises(StopIteration):
+            next(ed_flights_iterrows)
+        with pytest.raises(StopIteration):
+            next(pd_flights_iterrows)
 
     def test_itertuples(self):
         ed_flights = self.ed_flights()
         pd_flights = self.pd_flights()
 
-        ed_flights_itertuples = ed_flights.itertuples(name=None)
-        pd_flights_itertuples = pd_flights.itertuples(name=None)
+        ed_flights_itertuples = list(ed_flights.itertuples(name=None))
+        pd_flights_itertuples = list(pd_flights.itertuples(name=None))
 
-        assert len(list(ed_flights_itertuples)) == len(list(pd_flights_itertuples))
-
-        for ed_row in ed_flights_itertuples:
-
-            pd_row = next(pd_flights_itertuples)
-
-            assert ed_row == pd_row
-
-        for pd_row in pd_flights_itertuples:
-
-            ed_row = next(ed_flights_itertuples)
-
-            assert pd_row == ed_row
+        assert ed_flights_itertuples == pd_flights_itertuples


### PR DESCRIPTION
I'm sorry about this, because I want to squash multiple commits, and accidentally modified the branch name.
So that the PR was automatically closed unexpectedly.

For historical Conversation see PR #369

@sethmlarson  Thanks for your comment
Based on these suggestions, I have completed the modification, And passed the `lint` and `docs` jobs.

Thanks to this change in #379, no need to convert `_es_results_to_pandas` into a generator now, because they have similar effects.
Now, the performance has been further improved and the logic is more concise.

Finally, the same 50,000 data sets, my test results are as follows:
```
ed.iterrows(),  It took a total of `19 seconds` after the iteration
ed.itertuples(), It took a total of `15 seconds` after the iteration
ed.to_pandas(), It took `15 seconds`
```

Closes https://github.com/elastic/eland/issues/345