### PR TITLE
Speedup CI by only installing Nox  in Dockerfile

### DIFF
--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -1,10 +1,7 @@
-ARG PYTHON_VERSION=3.7
+ARG PYTHON_VERSION=3.9
 FROM python:${PYTHON_VERSION}
 
 WORKDIR /code/eland
-COPY requirements-dev.txt .
-RUN pip install -r requirements-dev.txt
+RUN python -m pip install nox
 
 COPY . .
-
-


### PR DESCRIPTION
Since `dev-requirements.txt` is installed in `noxfile.py` we don't need to install it twice.