### PR TITLE
Add flynt and add more excluded lines to improve coverage

### DIFF
--- a/eland/dataframe.py
+++ b/eland/dataframe.py
@@ -889,10 +889,7 @@ class DataFrame(NDFrame):
                 counts = self.count()
                 if len(cols) != len(counts):  # pragma: no cover
                     raise AssertionError(
-                        "Columns must equal counts "
-                        "({cols:d} != {counts:d})".format(
-                            cols=len(cols), counts=len(counts)
-                        )
+                        f"Columns must equal counts ({len(cols):d} != {len(counts):d})"
                     )
                 count_header = "Non-Null Count"
                 len_count = len(count_header)

--- a/noxfile.py
+++ b/noxfile.py
@@ -55,10 +55,11 @@ TYPED_FILES = (
 
 @nox.session(reuse_venv=True)
 def format(session):
-    session.install("black", "isort")
+    session.install("black", "isort", "flynt")
     session.run("python", "utils/license-headers.py", "fix", *SOURCE_FILES)
+    session.run("flynt", *SOURCE_FILES)
     session.run("black", "--target-version=py37", *SOURCE_FILES)
-    session.run("isort", *SOURCE_FILES)
+    session.run("isort", "--profile=black", *SOURCE_FILES)
     lint(session)
 
 
@@ -70,7 +71,7 @@ def lint(session):
     session.install("--pre", "elasticsearch")
     session.run("python", "utils/license-headers.py", "check", *SOURCE_FILES)
     session.run("black", "--check", "--target-version=py37", *SOURCE_FILES)
-    session.run("isort", "--check", *SOURCE_FILES)
+    session.run("isort", "--check", "--profile=black", *SOURCE_FILES)
     session.run("flake8", "--ignore=E501,W503,E402,E712,E203", *SOURCE_FILES)
 
     # TODO: When all files are typed we can change this to .run("mypy", "--strict", "eland/")
@@ -107,8 +108,7 @@ def test(session, pandas_version: str):
         "python",
         "-m",
         "pytest",
-        "--cov-report",
-        "term-missing",
+        "--cov-report=term-missing",
         "--cov=eland/",
         "--cov-config=setup.cfg",
         "--doctest-modules",

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,3 +6,4 @@ plugins = numpy.typing.mypy_plugin
 exclude_lines=
     @abstractmethod
     if TYPE_CHECKING:
+    raise NotImplementedError*


### PR DESCRIPTION
This PR will bump test coverage from 90% to 91% by excluding `NotImplementedError*`

Also we add `flynt` to nox format to ensure we use f-strings

@sethmlarson  take a look and hit Jenkins once.