### PR TITLE
Adds PyTorch model management

### DIFF
--- a/bin/upload_hub_model.py
+++ b/bin/upload_hub_model.py
@@ -1,0 +1,80 @@
+#!venv/bin/python
+
+#  Licensed to Elasticsearch B.V. under one or more contributor
+#  license agreements. See the NOTICE file distributed with
+#  this work for additional information regarding copyright
+#  ownership. Elasticsearch B.V. licenses this file to you under
+#  the Apache License, Version 2.0 (the "License"); you may
+#  not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+# 	http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+
+"""
+Copies a model from the Hugging Face model hub into an Elasticsearch cluster.
+This will create local cached copies that will be traced (necessary) and
+optionally quantized before uploading to Elasticsearch. This will also check
+the task type is supported as well as the model and tokenizer types. All
+necessary configuration is uploaded along with the model.
+"""
+
+import argparse
+import elasticsearch
+import os
+import sys
+import tempfile
+
+# project library
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from eland.ml.pytorch.external_models import *
+from eland.ml.pytorch.pytorch_model import *
+
+DEFAULT_URL = 'http://elastic:changeme@localhost:9200'
+MODEL_HUB_URL = 'https://huggingface.co'
+
+
+def main():
+    parser = argparse.ArgumentParser(prog='upload_hub_model.py')
+    parser.add_argument('--url', default=DEFAULT_URL,
+                        help="An Elasticsearch connection URL, e.g. http://user:secret@localhost:9200")
+    parser.add_argument('--model-id', required=True,
+                        help="The model ID in the Hugging Face model hub, "
+                             "e.g. dbmdz/bert-large-cased-finetuned-conll03-english")
+    parser.add_argument('--task-type', required=True, choices=SUPPORTED_TASK_TYPES,
+                        help=f"The task type that the model will be used for.")
+    parser.add_argument('--start', action='store_true', default=False,
+                        help="Start the model deployment after uploading. Default: False")
+    args = parser.parse_args()
+
+    es = elasticsearch.Elasticsearch(args.url, timeout=300)  # 5 minute timeout
+
+    # trace and save model, then upload it from temp file
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        print("Loading HuggingFace transformer tokenizer and model")
+        hftm = HuggingFaceTransformerModel(args.model_id, args.task_type)
+        model_path, config_path, vocab_path = hftm.save(tmp_dir)
+
+        ptm = PyTorchModel(es, args.model_id)
+        ptm.stop(ignore_not_found=True)
+        ptm.delete(ignore_not_found=True)
+        print("Uploading model")
+        ptm.upload(model_path, config_path, vocab_path)
+
+    # start the deployed model
+    if args.start:
+        print("Starting model deployment")
+        if ptm.start():
+            print(f" - started: {ptm.model_id}")
+        else:
+            print(f" - failed")
+
+
+if __name__ == '__main__':
+    main()

--- a/bin/upload_hub_model.py
+++ b/bin/upload_hub_model.py
@@ -1,5 +1,3 @@
-#!venv/bin/python
-
 #  Licensed to Elasticsearch B.V. under one or more contributor
 #  license agreements. See the NOTICE file distributed with
 #  this work for additional information regarding copyright
@@ -61,9 +59,9 @@ def main():
         hftm = HuggingFaceTransformerModel(args.model_id, args.task_type)
         model_path, config_path, vocab_path = hftm.save(tmp_dir)
 
-        ptm = PyTorchModel(es, args.model_id)
-        ptm.stop(ignore_not_found=True)
-        ptm.delete(ignore_not_found=True)
+        ptm = PyTorchModel(es, hftm.es_model_id)
+        ptm.stop()
+        ptm.delete()
         print("Uploading model")
         ptm.upload(model_path, config_path, vocab_path)
 

--- a/eland/ml/pytorch/__init__.py
+++ b/eland/ml/pytorch/__init__.py
@@ -14,4 +14,3 @@
 #  KIND, either express or implied.  See the License for the
 #  specific language governing permissions and limitations
 #  under the License.
-

--- a/eland/ml/pytorch/__init__.py
+++ b/eland/ml/pytorch/__init__.py
@@ -1,0 +1,17 @@
+#  Licensed to Elasticsearch B.V. under one or more contributor
+#  license agreements. See the NOTICE file distributed with
+#  this work for additional information regarding copyright
+#  ownership. Elasticsearch B.V. licenses this file to you under
+#  the Apache License, Version 2.0 (the "License"); you may
+#  not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+# 	http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+

--- a/eland/ml/pytorch/external_models.py
+++ b/eland/ml/pytorch/external_models.py
@@ -363,7 +363,7 @@ class HuggingFaceTransformerModel:
 
     @staticmethod
     def dict_to_ordered_list(
-        dict: Dict[Any, Any], sort_by_key: bool = False, sort_by_value: bool = False
+        input_dict: Dict[Any, Any], sort_by_key: bool = False, sort_by_value: bool = False
     ) -> List[Any]:
         assert not (sort_by_key and sort_by_value)
         assert sort_by_key or sort_by_value
@@ -375,7 +375,7 @@ class HuggingFaceTransformerModel:
             sort_index = 1
             select_index = 0
 
-        items = list(dict.items())
+        items = list(input_dict.items())
         items.sort(key=lambda x: x[sort_index])
         new_list = [x[select_index] for x in items]
         return new_list

--- a/eland/ml/pytorch/external_models.py
+++ b/eland/ml/pytorch/external_models.py
@@ -34,7 +34,7 @@ from transformers import (
 
 DEFAULT_OUTPUT_KEY = "sentence_embedding"
 SUPPORTED_TASK_TYPES = {"fill_mask", "ner", "text_classification", "text_embedding"}
-SUPPORTED_TASK_TYPES_NAMES = ", ".join(list(SUPPORTED_TASK_TYPES).sorted())
+SUPPORTED_TASK_TYPES_NAMES = ", ".join(list(SUPPORTED_TASK_TYPES).sort())
 SUPPORTED_TOKENIZERS = (
     transformers.BertTokenizer,
     transformers.BertTokenizerFast,
@@ -51,7 +51,7 @@ SUPPORTED_TOKENIZERS = (
     transformers.RetriBertTokenizer,
     transformers.RetriBertTokenizerFast,
 )
-SUPPORTED_TOKENIZERS_NAMES = ", ".join([str(x) for x in SUPPORTED_TOKENIZERS].sorted())
+SUPPORTED_TOKENIZERS_NAMES = ", ".join([str(x) for x in SUPPORTED_TOKENIZERS].sort())
 
 TracedModelTypes = Union[
     torch.nn.Module,

--- a/eland/ml/pytorch/external_models.py
+++ b/eland/ml/pytorch/external_models.py
@@ -363,7 +363,9 @@ class HuggingFaceTransformerModel:
 
     @staticmethod
     def dict_to_ordered_list(
-        input_dict: Dict[Any, Any], sort_by_key: bool = False, sort_by_value: bool = False
+        input_dict: Dict[Any, Any],
+        sort_by_key: bool = False,
+        sort_by_value: bool = False,
     ) -> List[Any]:
         assert not (sort_by_key and sort_by_value)
         assert sort_by_key or sort_by_value

--- a/eland/ml/pytorch/external_models.py
+++ b/eland/ml/pytorch/external_models.py
@@ -34,7 +34,7 @@ from transformers import (
 
 DEFAULT_OUTPUT_KEY = "sentence_embedding"
 SUPPORTED_TASK_TYPES = {"fill_mask", "ner", "text_classification", "text_embedding"}
-SUPPORTED_TASK_TYPES_NAMES = ", ".join(list(SUPPORTED_TASK_TYPES).sort())
+SUPPORTED_TASK_TYPES_NAMES = ", ".join(sorted(SUPPORTED_TASK_TYPES))
 SUPPORTED_TOKENIZERS = (
     transformers.BertTokenizer,
     transformers.BertTokenizerFast,
@@ -51,7 +51,7 @@ SUPPORTED_TOKENIZERS = (
     transformers.RetriBertTokenizer,
     transformers.RetriBertTokenizerFast,
 )
-SUPPORTED_TOKENIZERS_NAMES = ", ".join([str(x) for x in SUPPORTED_TOKENIZERS].sort())
+SUPPORTED_TOKENIZERS_NAMES = ", ".join(sorted([str(x) for x in SUPPORTED_TOKENIZERS]))
 
 TracedModelTypes = Union[
     torch.nn.Module,

--- a/eland/ml/pytorch/external_models.py
+++ b/eland/ml/pytorch/external_models.py
@@ -1,0 +1,391 @@
+#  Licensed to Elasticsearch B.V. under one or more contributor
+#  license agreements. See the NOTICE file distributed with
+#  this work for additional information regarding copyright
+#  ownership. Elasticsearch B.V. licenses this file to you under
+#  the Apache License, Version 2.0 (the "License"); you may
+#  not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+# 	http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+
+import json
+import os.path
+import torch
+import transformers
+from abc import ABC, abstractmethod
+from sentence_transformers import SentenceTransformer
+from torch import nn, Tensor
+from transformers import AutoConfig, AutoModel, PreTrainedModel, PreTrainedTokenizer, PreTrainedTokenizerFast
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+DEFAULT_OUTPUT_KEY = 'sentence_embedding'
+SUPPORTED_TASK_TYPES = {'fill_mask', 'ner', 'text_classification', 'text_embedding'}
+SUPPORTED_TASK_TYPES_STR = ', '.join(SUPPORTED_TASK_TYPES)
+SUPPORTED_TOKENIZERS = (
+    transformers.BertTokenizer,
+    transformers.BertTokenizerFast,
+    transformers.DPRContextEncoderTokenizer,
+    transformers.DPRContextEncoderTokenizerFast,
+    transformers.DPRQuestionEncoderTokenizer,
+    transformers.DPRQuestionEncoderTokenizerFast,
+    transformers.DistilBertTokenizer,
+    transformers.DistilBertTokenizerFast,
+    transformers.ElectraTokenizer,
+    transformers.ElectraTokenizerFast,
+    transformers.MobileBertTokenizer,
+    transformers.MobileBertTokenizerFast,
+    transformers.RetriBertTokenizer,
+    transformers.RetriBertTokenizerFast,
+)
+SUPPORTED_TOKENIZERS_STR = ', '.join([str(x) for x in SUPPORTED_TOKENIZERS])
+
+TracedModelTypes = Union[torch.nn.Module, torch.ScriptModule, torch.jit.ScriptModule, torch.jit.TopLevelTracedModule]
+
+
+class DistilBertWrapper(nn.Module):
+    def __init__(self, model: transformers.DistilBertModel):
+        super(DistilBertWrapper, self).__init__()
+        self._model = model
+        self.config = model.config
+
+    @staticmethod
+    def try_wrapping(model: PreTrainedModel) -> Optional[Any]:
+        if isinstance(model.config, transformers.DistilBertConfig):
+            return DistilBertWrapper(model)
+        else:
+            return model
+
+    def forward(self, input_ids: Tensor, attention_mask: Tensor,
+                token_type_ids: Tensor, position_ids: Tensor) -> Tensor:
+        """Wrap the input and output to conform to the native process interface."""
+
+        return self._model(input_ids=input_ids, attention_mask=attention_mask)
+
+
+class SentenceTransformerWrapper(nn.Module):
+    def __init__(self, model: PreTrainedModel, output_key: str = DEFAULT_OUTPUT_KEY):
+        super(SentenceTransformerWrapper, self).__init__()
+        self._hf_model = model
+        self._st_model = SentenceTransformer(model.name_or_path)
+        self._output_key = output_key
+
+        self._remove_pooling_layer()
+        self._replace_transformer_layer()
+
+    @staticmethod
+    def from_pretrained(model_id: str, output_key: str = DEFAULT_OUTPUT_KEY) -> Optional[Any]:
+        if model_id.startswith('sentence-transformers/'):
+            model = AutoModel.from_pretrained(model_id, torchscript=True)
+            return SentenceTransformerWrapper(model, output_key)
+        else:
+            return None
+
+    def _remove_pooling_layer(self):
+        """
+        Removes any last pooling layer which is not used to create embeddings.
+        Leaving this layer in will cause it to return a NoneType which in turn
+        will fail to load in libtorch. Alternatively, we can just use the output
+        of the pooling layer as a dummy but this also affects (if only in a
+        minor way) the performance of inference, so we're better off removing
+        the layer if we can.
+        """
+
+        if getattr(self._hf_model, 'pooler', lambda: None):
+            self._hf_model.pooler = None
+
+    def _replace_transformer_layer(self):
+        """
+        Replaces the HuggingFace Transformer layer in the SentenceTransformer
+        modules so we can set it with one that has pooling layer removed and
+        was loaded ready for TorchScript export.
+        """
+
+        self._st_model._modules['0'].auto_model = self._hf_model
+
+    def forward(self, input_ids: Tensor, attention_mask: Tensor,
+                token_type_ids: Tensor, position_ids: Tensor) -> Tensor:
+        """Wrap the input and output to conform to the native process interface."""
+
+        inputs = {
+            'input_ids': input_ids,
+            'attention_mask': attention_mask,
+            'token_type_ids': token_type_ids,
+            'position_ids': position_ids,
+        }
+
+        # remove inputs for specific model types
+        if isinstance(self._hf_model.config, transformers.DistilBertConfig):
+            del inputs['token_type_ids']
+
+        return self._st_model(inputs)[self._output_key]
+
+
+class DPREncoderWrapper(nn.Module):
+    """
+    AutoModel loading does not work for DPRContextEncoders, this only exists as
+    a workaround.
+    See: https://github.com/huggingface/transformers/issues/13670
+    """
+    _SUPPORTED_MODELS = {
+        transformers.DPRContextEncoder,
+        transformers.DPRQuestionEncoder,
+    }
+    _SUPPORTED_MODELS_STR = set([x.__name__ for x in _SUPPORTED_MODELS])
+
+    def __init__(self, model: Union[transformers.DPRContextEncoder, transformers.DPRQuestionEncoder]):
+        super(DPREncoderWrapper, self).__init__()
+        self._model = model
+
+    @staticmethod
+    def from_pretrained(model_id: str) -> Optional[Any]:
+
+        config = AutoConfig.from_pretrained(model_id)
+
+        def is_compatible() -> bool:
+            is_dpr_model = config.model_type == 'dpr'
+            has_architectures = len(config.architectures) == 1
+            is_supported_architecture = config.architectures[0] in DPREncoderWrapper._SUPPORTED_MODELS_STR
+            return is_dpr_model and has_architectures and is_supported_architecture
+
+        if is_compatible():
+            model = getattr(transformers, config.architectures[0]).from_pretrained(model_id, torchscript=True)
+            return DPREncoderWrapper(model)
+        else:
+            return None
+
+    def forward(self, input_ids: Tensor, attention_mask: Tensor,
+                token_type_ids: Tensor, position_ids: Tensor) -> Tensor:
+        """Wrap the input and output to conform to the native process interface."""
+
+        return self._model(**{
+            'input_ids': input_ids,
+            'attention_mask': attention_mask,
+            'token_type_ids': token_type_ids,
+        })
+
+
+class HuggingFaceTransformerModel:
+
+    class TraceableModel(ABC):
+        def __init__(
+                self,
+                tokenizer: Union[PreTrainedTokenizer, PreTrainedTokenizerFast],
+                model: Union[PreTrainedModel, SentenceTransformerWrapper, DPREncoderWrapper, DistilBertWrapper]
+        ):
+            self._tokenizer = tokenizer
+            self._model = model
+
+        def classification_labels(self) -> Optional[List[str]]:
+            return None
+
+        @abstractmethod
+        def trace(self) -> TracedModelTypes:
+            ...
+
+    class TraceableClassificationModel(TraceableModel, ABC):
+        def classification_labels(self) -> Optional[List[str]]:
+            labels = HuggingFaceTransformerModel._dict_to_ordered_list(self._model.config.id2label, sort_by_key=True)
+            # Make classes like I-PER into I_PER which fits Java enumerations
+            return [x.replace('-', '_') for x in labels]
+
+    class FillMaskModel(TraceableModel):
+        def trace(self) -> TracedModelTypes:
+            # model needs to be in evaluate mode
+            self._model.eval()
+
+            # tokenizing dummy input text
+            text = "[CLS] Who was Jim Henson ? [SEP] [MASK] Henson was a puppeteer [SEP]"
+            tokenized_text = self._tokenizer.tokenize(text)
+
+            # create token and segment IDs
+            indexed_tokens = self._tokenizer.convert_tokens_to_ids(tokenized_text)
+            segments_ids = [0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1]
+
+            # prepare dummy input tensors
+            tokens_tensor = torch.tensor([indexed_tokens])
+            attention_mask = torch.ones(tokens_tensor.size())
+            segments_tensors = torch.tensor([segments_ids])
+            position_ids = torch.arange(tokens_tensor.size(1))
+
+            return torch.jit.trace(self._model, (tokens_tensor, attention_mask, segments_tensors, position_ids))
+
+    class NerModel(TraceableClassificationModel):
+        def trace(self) -> TracedModelTypes:
+            # model needs to be in evaluate mode
+            self._model.eval()
+
+            # tokenizing dummy input text
+            text = "Hugging Face Inc. is a company based in New York City. Its headquarters are in DUMBO, therefore very" \
+                   "close to the Manhattan Bridge."
+            tokenized_text = self._tokenizer.tokenize(text)
+
+            # create token IDs
+            indexed_tokens = self._tokenizer.convert_tokens_to_ids(tokenized_text)
+
+            # prepare dummy input tensors
+            tokens_tensor = torch.tensor([indexed_tokens])
+            attention_mask = torch.ones(tokens_tensor.size())
+            token_type_ids = torch.zeros(tokens_tensor.size(), dtype=torch.long)
+            position_ids = torch.arange(tokens_tensor.size(1), dtype=torch.long)
+
+            return torch.jit.trace(self._model, (tokens_tensor, attention_mask, token_type_ids, position_ids))
+
+    class TextClassificationModel(TraceableClassificationModel):
+        def trace(self) -> TracedModelTypes:
+            # model needs to be in evaluate mode
+            self._model.eval()
+
+            # tokenizing dummy input text
+            text = "The cat was sick on the bed."
+            tokenized_text = self._tokenizer.tokenize(text)
+
+            # create token IDs
+            indexed_tokens = self._tokenizer.convert_tokens_to_ids(tokenized_text)
+
+            # prepare dummy input tensors
+            tokens_tensor = torch.tensor([indexed_tokens])
+            attention_mask = torch.ones(tokens_tensor.size())
+            token_type_ids = torch.zeros(tokens_tensor.size(), dtype=torch.long)
+            position_ids = torch.arange(tokens_tensor.size(1), dtype=torch.long)
+
+            return torch.jit.trace(self._model, (tokens_tensor, attention_mask, token_type_ids, position_ids))
+
+    class TextEmbeddingModel(TraceableModel):
+        def trace(self) -> TracedModelTypes:
+            # model needs to be in evaluate mode
+            self._model.eval()
+
+            # tokenizing dummy input text
+            text = "This is an example sentence"
+            tokenized_text = self._tokenizer.tokenize(text)
+
+            # create token IDs
+            indexed_tokens = self._tokenizer.convert_tokens_to_ids(tokenized_text)
+
+            # prepare dummy input tensors
+            tokens_tensor = torch.tensor([indexed_tokens])
+            attention_mask = torch.ones(tokens_tensor.size())
+            token_type_ids = torch.zeros(tokens_tensor.size(), dtype=torch.long)
+            position_ids = torch.arange(tokens_tensor.size(1), dtype=torch.long)
+
+            return torch.jit.trace(self._model, (tokens_tensor, attention_mask, token_type_ids, position_ids))
+
+    def __init__(self, model_id: str, task_type: str):
+        self._model_id = model_id
+        self._task_type = task_type.replace('-', '_')
+
+        # Elasticsearch model IDs need to be a specific format: no special chars, all lowercase, max 64 chars
+        self._es_model_id = self._model_id.replace('/', '__').lower()[:64]
+
+        # load Hugging Face model and tokenizer
+        self._tokenizer = transformers.AutoTokenizer.from_pretrained(self._model_id)
+
+        # check for a supported tokenizer
+        if not isinstance(self._tokenizer, SUPPORTED_TOKENIZERS):
+            raise TypeError(f"Tokenizer type {self._tokenizer} not supported, must be one of: {SUPPORTED_TOKENIZERS_STR}")
+
+        self._traceable_model = self._create_traceable_model()
+        self._traced_model = self._traceable_model.trace()
+        self._vocab = self._load_vocab()
+        self._config = self._create_config()
+
+    @staticmethod
+    def _dict_to_ordered_list(dict: Dict[Any, Any], sort_by_key: bool = False, sort_by_value: bool = False) -> List[Any]:
+        assert not (sort_by_key and sort_by_value)
+        assert sort_by_key or sort_by_value
+
+        if sort_by_key:
+            sort_index = 0
+            select_index = 1
+        else:
+            sort_index = 1
+            select_index = 0
+
+        l = list(dict.items())
+        l.sort(key=lambda x: x[sort_index])
+        new_list = [x[select_index] for x in l]
+        return new_list
+
+    def _load_vocab(self):
+        vocabulary = HuggingFaceTransformerModel._dict_to_ordered_list(self._tokenizer.get_vocab(), sort_by_value=True)
+        return {
+            'vocabulary': vocabulary,
+        }
+
+    def _create_config(self):
+        do_lower_case = hasattr(self._tokenizer, 'do_lower_case') and self._tokenizer.do_lower_case
+
+        inference_config = {
+            self._task_type: {
+                'tokenization': {
+                    'bert': {
+                        'do_lower_case': do_lower_case,
+                    }
+                }
+            }
+        }
+
+        if hasattr(self._tokenizer, 'max_model_input_sizes'):
+            max_sequence_length = self._tokenizer.max_model_input_sizes.get(self._model_id)
+            if max_sequence_length:
+                inference_config[self._task_type]['tokenization']['bert']['max_sequence_length'] = max_sequence_length
+
+        if self._traceable_model.classification_labels():
+            inference_config[self._task_type]['classification_labels'] = self._traceable_model.classification_labels()
+
+        return {
+            'description': f"Model {self._model_id} for task type '{self._task_type}'",
+            'model_type': 'pytorch',
+            'inference_config': inference_config,
+            'input': {
+                'field_names': ['text_field'],
+            }
+        }
+
+    def _create_traceable_model(self) -> TraceableModel:
+
+        if self._task_type == 'fill_mask':
+            model = transformers.AutoModelForMaskedLM.from_pretrained(self._model_id, torchscript=True)
+            model = DistilBertWrapper.try_wrapping(model)
+            return HuggingFaceTransformerModel.FillMaskModel(self._tokenizer, model)
+        elif self._task_type == 'ner':
+            model = transformers.AutoModelForTokenClassification.from_pretrained(self._model_id, torchscript=True)
+            model = DistilBertWrapper.try_wrapping(model)
+            return HuggingFaceTransformerModel.NerModel(self._tokenizer, model)
+        elif self._task_type == 'text_classification':
+            model = transformers.AutoModelForSequenceClassification.from_pretrained(self._model_id, torchscript=True)
+            model = DistilBertWrapper.try_wrapping(model)
+            return HuggingFaceTransformerModel.TextClassificationModel(self._tokenizer, model)
+        elif self._task_type == 'text_embedding':
+            model = SentenceTransformerWrapper.from_pretrained(self._model_id)
+            if not model:
+                model = DPREncoderWrapper.from_pretrained(self._model_id)
+            if not model:
+                model = transformers.AutoModel.from_pretrained(self._model_id, torchscript=True)
+            return HuggingFaceTransformerModel.TextEmbeddingModel(self._tokenizer, model)
+        else:
+            raise TypeError(f"Unknown task type {self._task_type}, must be one of: {SUPPORTED_TASK_TYPES_STR}")
+
+    def save(self, path: str) -> Tuple[str, str, str]:
+        # save traced model
+        model_path = os.path.join(path, 'traced_pytorch_model.pt')
+        torch.jit.save(self._traced_model, model_path)
+
+        # save configuration
+        config_path = os.path.join(path, 'config.json')
+        with open(config_path, 'w') as outfile:
+            json.dump(self._config, outfile)
+
+        # save vocabulary
+        vocab_path = os.path.join(path, 'vocabulary.json')
+        with open(vocab_path, 'w') as outfile:
+            json.dump(self._vocab, outfile)
+
+        return model_path, config_path, vocab_path

--- a/eland/ml/pytorch/external_models.py
+++ b/eland/ml/pytorch/external_models.py
@@ -375,9 +375,9 @@ class HuggingFaceTransformerModel:
             sort_index = 1
             select_index = 0
 
-        l = list(dict.items())
-        l.sort(key=lambda x: x[sort_index])
-        new_list = [x[select_index] for x in l]
+        items = list(dict.items())
+        items.sort(key=lambda x: x[sort_index])
+        new_list = [x[select_index] for x in items]
         return new_list
 
     def _load_vocab(self):

--- a/eland/ml/pytorch/pytorch_model.py
+++ b/eland/ml/pytorch/pytorch_model.py
@@ -1,0 +1,122 @@
+#  Licensed to Elasticsearch B.V. under one or more contributor
+#  license agreements. See the NOTICE file distributed with
+#  this work for additional information regarding copyright
+#  ownership. Elasticsearch B.V. licenses this file to you under
+#  the Apache License, Version 2.0 (the "License"); you may
+#  not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+# 	http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+
+import base64
+import json
+import math
+import os
+from eland.common import ensure_es_client
+from tqdm import tqdm
+from typing import TYPE_CHECKING, Any, Dict, List, Tuple, Union
+
+if TYPE_CHECKING:
+    from elasticsearch import Elasticsearch
+
+DEFAULT_CHUNK_SIZE = 4 * 1024 * 1024  # 4MB
+QUEUE_SIZE = 4
+THREAD_COUNT = 4
+
+
+class PyTorchModel:
+    """
+    A PyTorch model managed by Elasticsearch.
+
+    These models must be trained outside of Elasticsearch, conform to the
+    support tokenization and inference interfaces, and exported as their
+    TorchScript representations.
+    """
+
+    def __init__(
+        self,
+        es_client: Union[str, List[str], Tuple[str, ...], "Elasticsearch"],
+        model_id: str,
+    ):
+        self._client = ensure_es_client(es_client)
+        # Elasticsearch model IDs need to be a specific format: no special chars, all lowercase, max 64 chars
+        self.model_id = model_id.replace('/', '__').lower()[:64]
+
+    @staticmethod
+    def _load_json(path: str) -> Dict[str, Any]:
+        with open(path, 'r') as infile:
+            return json.load(infile)
+
+    def _upload_config(self, path: str) -> bool:
+        config = PyTorchModel._load_json(path)
+        response = self._client.ml.put_trained_model(model_id=self.model_id, body=config)
+        # TODO: Check actual result code in response
+        return response is not None
+
+    def _upload_vocab(self, path: str) -> bool:
+        vocab = PyTorchModel._load_json(path)
+        return self._client.transport.perform_request(
+            method='PUT', url=f'/_ml/trained_models/{self.model_id}/vocabulary', body=vocab)
+
+    def _upload_model(self, model_path: str, chunk_size: int = DEFAULT_CHUNK_SIZE) -> bool:
+        file_stats = os.stat(model_path)
+        total_parts = math.ceil(file_stats.st_size / chunk_size)
+
+        def model_file_chunk_generator():
+            with open(model_path, 'rb') as f:
+                while True:
+                    data = f.read(chunk_size)
+                    if not data:
+                        break
+                    yield base64.b64encode(data).decode()
+
+        for i, data in tqdm(enumerate(model_file_chunk_generator(), start=0), total=total_parts):
+            body = {
+                'total_definition_length': file_stats.st_size,
+                'total_parts': total_parts,
+                'definition': data,
+            }
+            self._client.transport.perform_request(
+                method='PUT', url=f'/_ml/trained_models/{self.model_id}/definition/{i}', body=body)
+
+        return True
+
+    def upload(self, model_path: str, config_path: str, vocab_path: str, chunk_size: int = DEFAULT_CHUNK_SIZE) -> bool:
+        # TODO: Implement some pre-flight checks on config, vocab, and model
+        return self._upload_config(config_path) and \
+               self._upload_vocab(vocab_path) and \
+               self._upload_model(model_path, chunk_size)
+
+    def start(self) -> bool:
+        return self._client.transport.perform_request(
+            method='POST',
+            url=f'/_ml/trained_models/{self.model_id}/deployment/_start',
+            params={'timeout': '60s', 'wait_for': 'started'}
+        )
+
+    def stop(self, ignore_not_found=False) -> bool:
+        if ignore_not_found:
+            ignorables = 404
+        else:
+            ignorables = ()
+
+        return self._client.transport.perform_request(
+            method='POST',
+            url=f'/_ml/trained_models/{self.model_id}/deployment/_stop',
+            params={'ignore': ignorables},
+        )
+
+    def delete(self, ignore_not_found=False) -> Dict[str, Any]:
+        if ignore_not_found:
+            ignorables = 404
+        else:
+            ignorables = ()
+
+        return self._client.ml.delete_trained_model(self.model_id, ignore=ignorables)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,3 +11,7 @@ nox
 lightgbm
 pytest-cov
 mypy
+huggingface-hub>=0.0.12
+sentence-transformers>=2.0.0
+torch>=1.9.0
+transformers[torch]>=4.10.2

--- a/setup.py
+++ b/setup.py
@@ -84,5 +84,11 @@ setup(
         "xgboost": ["xgboost>=0.90,<2"],
         "scikit-learn": ["scikit-learn>=0.22.1,<1"],
         "lightgbm": ["lightgbm>=2,<4"],
+        "pytorch": [
+            "huggingface-hub>=0.0.12,<1",
+            "sentence-transformers>=2.0.0,<3",
+            "torch>=1.9.0,<2",
+            "transformers[torch]>=4.10.2<5",
+        ]
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -89,6 +89,6 @@ setup(
             "sentence-transformers>=2.0.0,<3",
             "torch>=1.9.0,<2",
             "transformers[torch]>=4.10.2<5",
-        ]
+        ],
     },
 )


### PR DESCRIPTION
This is a rough (and working) draft of porting PyTorch code into eland. This is the general shape of what I'm thinking of. It splits concerns into two - (1) generic PyTorch model management in Elasticsearch, and (2) interoperability with HuggingFace transformers and model hub.

Help and comments are welcome. There's surely a lot of formatting and general Python-ification that needs to happen still so help is welcome.