### PR TITLE
Add number_samples to lightgbm ML Model

### DIFF
--- a/eland/ml/_model_serializer.py
+++ b/eland/ml/_model_serializer.py
@@ -70,6 +70,7 @@ class TreeNode:
         split_feature: Optional[int] = None,
         threshold: Optional[float] = None,
         leaf_value: Optional[List[float]] = None,
+        number_samples: Optional[int] = None,
     ):
         self._node_idx = node_idx
         self._decision_type = decision_type
@@ -79,6 +80,7 @@ class TreeNode:
         self._threshold = threshold
         self._leaf_value = leaf_value
         self._default_left = default_left
+        self._number_samples = number_samples
 
     @property
     def node_idx(self) -> int:
@@ -93,6 +95,7 @@ class TreeNode:
             add_if_exists(d, "right_child", self._right_child)
             add_if_exists(d, "split_feature", self._split_feature)
             add_if_exists(d, "threshold", self._threshold)
+            add_if_exists(d, "number_samples", self._number_samples)
         else:
             if len(self._leaf_value) == 1:
                 # Support Elasticsearch 7.6 which only

--- a/eland/ml/transformers/lightgbm.py
+++ b/eland/ml/transformers/lightgbm.py
@@ -88,6 +88,7 @@ class LGBMForestTransformer(ModelTransformer):
             decision_type=transform_decider(tree_node_json_obj["decision_type"]),
             left_child=left_child,
             right_child=right_child,
+            number_samples=int(tree_node_json_obj["internal_count"]),
         )
 
     def make_leaf_node(

--- a/eland/ml/transformers/lightgbm.py
+++ b/eland/ml/transformers/lightgbm.py
@@ -97,6 +97,9 @@ class LGBMForestTransformer(ModelTransformer):
         return TreeNode(
             node_idx=node_id,
             leaf_value=[float(tree_node_json_obj["leaf_value"])],
+            number_samples=int(tree_node_json_obj["leaf_count"])
+            if "leaf_count" in tree_node_json_obj
+            else None,
         )
 
     def build_tree(self, tree_id: int, tree_json_obj: Dict[str, Any]) -> Tree:
@@ -229,7 +232,13 @@ class LGBMClassifierTransformer(LGBMForestTransformer):
             return super().make_leaf_node(tree_id, node_id, tree_node_json_obj)
         leaf_val = [0.0] * self.n_classes
         leaf_val[tree_id % self.n_classes] = float(tree_node_json_obj["leaf_value"])
-        return TreeNode(node_idx=node_id, leaf_value=leaf_val)
+        return TreeNode(
+            node_idx=node_id,
+            leaf_value=leaf_val,
+            number_samples=int(tree_node_json_obj["leaf_count"])
+            if "leaf_count" in tree_node_json_obj
+            else None,
+        )
 
     def check_model_booster(self) -> None:
         if self._model.params["boosting_type"] not in {"gbdt", "rf", "dart", "goss"}:


### PR DESCRIPTION
Work on #243 

I added `internal_count` for `lightgbm` 

@benwtrent Please take a look at this. Do we have a similar variable for `sklearn` and `xgboost` ?

Also should we add `leaf_count` for leaf_nodes ?
Sample JSON
```json
"tree_info": [
        {
            "tree_index": 0,
            "num_leaves": 4,
            "num_cat": 0,
            "shrinkage": 1,
            "tree_structure": {
                "split_index": 0,
                "split_feature": 3,
                "split_gain": 21.871400833129883,
                "threshold": -0.4775317725756382,
                "decision_type": "<=",
                "default_left": True,
                "missing_type": "None",
                "internal_value": -0.187661,
                "internal_weight": 0,
                "internal_count": 100,
                "left_child": {
                    "leaf_index": 0,
                    "leaf_value": -0.25650466873000066,
                    "leaf_weight": 30,
                    "leaf_count": 30
                },
                "right_child": {
                    "split_index": 1,
                    "split_feature": 1,
                    "split_gain": 22.457199096679688,
                    "threshold": -0.19213694565101705,
                    "decision_type": "<=",
                    "default_left": True,
                    "missing_type": "None",
                    "internal_value": -0.154451,
                    "internal_weight": 70,
                    "internal_count": 70,
                    "left_child": {
                        "leaf_index": 1,
                        "leaf_value": -0.22179852471269412,
                        "leaf_weight": 29,
                        "leaf_count": 29
                    },
```