### PR TITLE
Add `number_samples` to `XGBoost` ML Models

### DIFF
--- a/eland/ml/transformers/xgboost.py
+++ b/eland/ml/transformers/xgboost.py
@@ -89,7 +89,11 @@ class XGBoostForestTransformer(ModelTransformer):
             )
 
     def build_leaf_node(self, row: pd.Series, curr_tree: int) -> TreeNode:
-        return TreeNode(node_idx=row["Node"], leaf_value=[float(row["Gain"])])
+        return TreeNode(
+            node_idx=row["Node"],
+            leaf_value=[float(row["Gain"])],
+            number_samples=int(row["Cover"]),
+        )
 
     def build_tree_node(self, row: pd.Series, curr_tree: int) -> TreeNode:
         node_index = row["Node"]
@@ -103,6 +107,7 @@ class XGBoostForestTransformer(ModelTransformer):
                 right_child=self.extract_node_id(row["No"], curr_tree),
                 threshold=float(row["Split"]),
                 split_feature=self.get_feature_id(row["Feature"]),
+                number_samples=int(row["Cover"]),
             )
 
     def build_tree(self, nodes: List[TreeNode]) -> Tree:
@@ -238,7 +243,9 @@ class XGBoostClassifierTransformer(XGBoostForestTransformer):
             return super().build_leaf_node(row, curr_tree)
         leaf_val = [0.0] * self._num_classes
         leaf_val[curr_tree % self._num_classes] = float(row["Gain"])
-        return TreeNode(node_idx=row["Node"], leaf_value=leaf_val)
+        return TreeNode(
+            node_idx=row["Node"], leaf_value=leaf_val, number_samples=int(row["Cover"])
+        )
 
     def determine_target_type(self) -> str:
         return "classification"


### PR DESCRIPTION
Work on #243 

TreeNode of `xgboost` has the following information:
```
Tree               1
Node               0
ID               1-0
Feature           f1
Split      -0.030468
Yes              1-1
No               1-2
Missing          1-1
Gain       44.768673
Cover      23.395073
Name: 7, dtype: object
```
So, based on 
- `importance_type` parameter of https://xgboost.readthedocs.io/en/latest/python/python_api.html#xgboost.XGBRegressor
- based on https://datascience.stackexchange.com/a/12594

I am thinking `Cover` gives us the number of training samples that is being covered by the node or leaf. I might be wrong though!

@benwtrent Please give a review :)