### PR TITLE
Add coverage for datetime columns with timezones

### DIFF
--- a/eland/field_mappings.py
+++ b/eland/field_mappings.py
@@ -488,7 +488,7 @@ class FieldMappings:
         int64 int int_, int8, int16, int32, int64, uint8, uint16, uint32, uint64 Integer numbers
         float64 float float_, float16, float32, float64 Floating point numbers
         bool bool bool_ True/False values
-        datetime64 NA datetime64[ns] Date and time values
+        datetime64 NA datetime64[ns] datetime64[ns, TIMEZONE] Date and time values
         timedelta[ns] NA NA Differences between two datetimes
         category NA NA Finite list of text values
         ```

--- a/eland/field_mappings.py
+++ b/eland/field_mappings.py
@@ -35,6 +35,7 @@ import pandas as pd  # type: ignore
 from pandas.core.dtypes.common import (  # type: ignore
     is_bool_dtype,
     is_datetime_or_timedelta_dtype,
+    is_datetime64_any_dtype,
     is_float_dtype,
     is_integer_dtype,
     is_string_dtype,
@@ -504,6 +505,8 @@ class FieldMappings:
         elif is_string_dtype(pd_dtype):
             es_dtype = "keyword"
         elif is_datetime_or_timedelta_dtype(pd_dtype):
+            es_dtype = "date"
+        elif is_datetime64_any_dtype(pd_dtype):
             es_dtype = "date"
         else:
             warnings.warn(

--- a/eland/field_mappings.py
+++ b/eland/field_mappings.py
@@ -34,8 +34,8 @@ import numpy as np
 import pandas as pd  # type: ignore
 from pandas.core.dtypes.common import (  # type: ignore
     is_bool_dtype,
-    is_datetime_or_timedelta_dtype,
     is_datetime64_any_dtype,
+    is_datetime_or_timedelta_dtype,
     is_float_dtype,
     is_integer_dtype,
     is_string_dtype,

--- a/tests/dataframe/test_utils_pytest.py
+++ b/tests/dataframe/test_utils_pytest.py
@@ -37,6 +37,7 @@ class TestDataFrameUtils(TestData):
                 "E": [1.0, 2.0, 3.0],
                 "F": False,
                 "G": [1, 2, 3],
+                "H": pd.Timestamp("20190102", tz="UTC"),
             },
             index=["0", "1", "2"],
         )
@@ -51,6 +52,7 @@ class TestDataFrameUtils(TestData):
                     "E": {"type": "double"},
                     "F": {"type": "boolean"},
                     "G": {"type": "long"},
+                    "H": {"type": "date"},
                 }
             }
         }


### PR DESCRIPTION
This PR enables pandas columns that have been cast with a timezone to be automatically be converted to date.

Without this change, the default mapping would be used and an error would be thrown.