### PR TITLE
Add --insecure and --ca-cert options to the model hub upload script

### DIFF
--- a/bin/eland_import_hub_model
+++ b/bin/eland_import_hub_model
@@ -29,10 +29,11 @@ import argparse
 import tempfile
 
 import elasticsearch
+from elastic_transport.client_utils import DEFAULT
 
 from eland.ml.pytorch import PyTorchModel
-from eland.ml.pytorch.transformers import SUPPORTED_TASK_TYPES, TransformerModel
-from elastic_transport.client_utils import DEFAULT
+from eland.ml.pytorch.transformers import (SUPPORTED_TASK_TYPES,
+                                           TransformerModel)
 
 MODEL_HUB_URL = "https://huggingface.co"
 

--- a/bin/eland_import_hub_model
+++ b/bin/eland_import_hub_model
@@ -32,6 +32,7 @@ import elasticsearch
 
 from eland.ml.pytorch import PyTorchModel
 from eland.ml.pytorch.transformers import SUPPORTED_TASK_TYPES, TransformerModel
+from elastic_transport.client_utils import DEFAULT
 
 MODEL_HUB_URL = "https://huggingface.co"
 
@@ -86,10 +87,16 @@ def main():
         action="store_false",
         default=True,
         help="Do not verify SSL certificates"
-    )    
+    )
+    parser.add_argument(
+        "--ca-certs",
+        required=False,
+        default=DEFAULT,
+        help="Path to CA bundle"
+    )        
     args = parser.parse_args()
 
-    es = elasticsearch.Elasticsearch(args.url, request_timeout=300, verify_certs=args.insecure)  # 5 minute timeout
+    es = elasticsearch.Elasticsearch(args.url, request_timeout=300, verify_certs=args.insecure, ca_certs=args.ca_certs)  # 5 minute timeout
 
     # trace and save model, then upload it from temp file
     with tempfile.TemporaryDirectory() as tmp_dir:

--- a/bin/eland_import_hub_model
+++ b/bin/eland_import_hub_model
@@ -32,8 +32,7 @@ import elasticsearch
 from elastic_transport.client_utils import DEFAULT
 
 from eland.ml.pytorch import PyTorchModel
-from eland.ml.pytorch.transformers import (SUPPORTED_TASK_TYPES,
-                                           TransformerModel)
+from eland.ml.pytorch.transformers import SUPPORTED_TASK_TYPES, TransformerModel
 
 MODEL_HUB_URL = "https://huggingface.co"
 

--- a/bin/eland_import_hub_model
+++ b/bin/eland_import_hub_model
@@ -81,9 +81,15 @@ def main():
         default=False,
         help="Should the model previously stored with `elasticsearch-model-id` be deleted"
     )
+    parser.add_argument(
+        "--insecure",
+        action="store_false",
+        default=True,
+        help="Do not verify SSL certificates"
+    )    
     args = parser.parse_args()
 
-    es = elasticsearch.Elasticsearch(args.url, timeout=300)  # 5 minute timeout
+    es = elasticsearch.Elasticsearch(args.url, request_timeout=300, verify_certs=args.insecure)  # 5 minute timeout
 
     # trace and save model, then upload it from temp file
     with tempfile.TemporaryDirectory() as tmp_dir:


### PR DESCRIPTION
When using the `eland_import_hub_model` script with https and a self signed certificate it fails with the error

```
ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self signed certificate in certificate chain (_ssl.c:1131)
```

The `verify_certs` should be set to false when creating the Elasticsearch client to work-around the problem.
Using a self-signed certificate might not be unusual for on prem users.

The change also removes a deprecation warning by switching from `timeout` to `request_timeout` 