### PR TITLE
[ML] add support for question_answering NLP tasks

### DIFF
--- a/bin/eland_import_hub_model
+++ b/bin/eland_import_hub_model
@@ -113,8 +113,12 @@ def main():
         ptm = PyTorchModel(es, es_model_id)
         if args.clear_previous:
             print(f"Stopping previous deployment and deleting model: {ptm.model_id}")
-            ptm.stop()
-            ptm.delete()
+            try:
+                ptm.stop()
+                ptm.delete()
+            except elasticsearch.NotFoundError:
+                print(f"Previous deployment for {ptm.model_id} not found")
+
         print(f"Importing model: {ptm.model_id}")
         ptm.import_model(model_path, config_path, vocab_path)
 

--- a/eland/ml/pytorch/nlp_ml_model.py
+++ b/eland/ml/pytorch/nlp_ml_model.py
@@ -19,8 +19,22 @@ import typing as t
 
 
 class NlpTokenizationConfig:
-    def __init__(self, *, configuration_type: str):
+    def __init__(
+        self,
+        *,
+        configuration_type: str,
+        with_special_tokens: t.Optional[bool] = None,
+        max_sequence_length: t.Optional[int] = None,
+        truncate: t.Optional[
+            t.Union["t.Literal['first', 'none', 'second']", str]
+        ] = None,
+        span: t.Optional[int] = None,
+    ):
         self.name = configuration_type
+        self.with_special_tokens = with_special_tokens
+        self.max_sequence_length = max_sequence_length
+        self.truncate = truncate
+        self.span = span
 
     def to_dict(self):
         return {
@@ -42,12 +56,14 @@ class NlpRobertaTokenizationConfig(NlpTokenizationConfig):
         ] = None,
         span: t.Optional[int] = None,
     ):
-        super().__init__(configuration_type="roberta")
+        super().__init__(
+            configuration_type="roberta",
+            with_special_tokens=with_special_tokens,
+            max_sequence_length=max_sequence_length,
+            truncate=truncate,
+            span=span,
+        )
         self.add_prefix_space = add_prefix_space
-        self.with_special_tokens = with_special_tokens
-        self.max_sequence_length = max_sequence_length
-        self.truncate = truncate
-        self.span = span
 
 
 class NlpBertTokenizationConfig(NlpTokenizationConfig):
@@ -62,12 +78,14 @@ class NlpBertTokenizationConfig(NlpTokenizationConfig):
         ] = None,
         span: t.Optional[int] = None,
     ):
-        super().__init__(configuration_type="bert")
+        super().__init__(
+            configuration_type="bert",
+            with_special_tokens=with_special_tokens,
+            max_sequence_length=max_sequence_length,
+            truncate=truncate,
+            span=span,
+        )
         self.do_lower_case = do_lower_case
-        self.with_special_tokens = with_special_tokens
-        self.max_sequence_length = max_sequence_length
-        self.truncate = truncate
-        self.span = span
 
 
 class NlpMPNetTokenizationConfig(NlpTokenizationConfig):
@@ -82,12 +100,14 @@ class NlpMPNetTokenizationConfig(NlpTokenizationConfig):
         ] = None,
         span: t.Optional[int] = None,
     ):
-        super().__init__(configuration_type="mpnet")
+        super().__init__(
+            configuration_type="mpnet",
+            with_special_tokens=with_special_tokens,
+            max_sequence_length=max_sequence_length,
+            truncate=truncate,
+            span=span,
+        )
         self.do_lower_case = do_lower_case
-        self.with_special_tokens = with_special_tokens
-        self.max_sequence_length = max_sequence_length
-        self.truncate = truncate
-        self.span = span
 
 
 class InferenceConfig:

--- a/eland/ml/pytorch/transformers.py
+++ b/eland/ml/pytorch/transformers.py
@@ -47,10 +47,11 @@ from eland.ml.pytorch.nlp_ml_model import (
     NlpTokenizationConfig,
     NlpTrainedModelConfig,
     PassThroughInferenceOptions,
+    QuestionAnsweringInferenceOptions,
     TextClassificationInferenceOptions,
     TextEmbeddingInferenceOptions,
     TrainedModelInput,
-    ZeroShotClassificationInferenceOptions, QuestionAnsweringInferenceOptions,
+    ZeroShotClassificationInferenceOptions,
 )
 
 DEFAULT_OUTPUT_KEY = "sentence_embedding"

--- a/eland/ml/pytorch/transformers.py
+++ b/eland/ml/pytorch/transformers.py
@@ -32,6 +32,7 @@ from torch import Tensor, nn
 from transformers import (
     AutoConfig,
     AutoModel,
+    AutoModelForQuestionAnswering,
     PreTrainedModel,
     PreTrainedTokenizer,
     PreTrainedTokenizerFast,
@@ -44,6 +45,7 @@ SUPPORTED_TASK_TYPES = {
     "text_classification",
     "text_embedding",
     "zero_shot_classification",
+    "question_answering",
 }
 SUPPORTED_TASK_TYPES_NAMES = ", ".join(sorted(SUPPORTED_TASK_TYPES))
 SUPPORTED_TOKENIZERS = (
@@ -67,6 +69,86 @@ TracedModelTypes = Union[
     torch.jit.ScriptModule,
     torch.jit.TopLevelTracedModule,
 ]
+
+
+class _QuestionAnsweringWrapperModule(nn.Module):  # type: ignore
+    """
+    A wrapper around a question answering model.
+    Our inference engine only takes the first tuple if the inference response
+    is a tuple.
+
+    This wrapper transforms the output to be a stacked tensor if its a tuple.
+
+    Otherwise it passes it through
+    """
+
+    def __init__(self, model: PreTrainedModel):
+        super().__init__()
+        self._hf_model = model
+        self.config = model.config
+
+    @staticmethod
+    def from_pretrained(model_id: str) -> Optional[Any]:
+        model = AutoModelForQuestionAnswering.from_pretrained(
+            model_id, torchscript=True
+        )
+        if isinstance(
+            model.config,
+            (
+                transformers.MPNetConfig,
+                transformers.RobertaConfig,
+                transformers.BartConfig,
+            ),
+        ):
+            return _TwoParameterQuestionAnsweringWrapper(model)
+        else:
+            return _QuestionAnsweringWrapper(model)
+
+
+class _QuestionAnsweringWrapper(_QuestionAnsweringWrapperModule):
+    def __init__(self, model: PreTrainedModel):
+        super().__init__(model=model)
+
+    def forward(
+        self,
+        input_ids: Tensor,
+        attention_mask: Tensor,
+        token_type_ids: Tensor,
+        position_ids: Tensor,
+    ) -> Tensor:
+        """Wrap the input and output to conform to the native process interface."""
+
+        inputs = {
+            "input_ids": input_ids,
+            "attention_mask": attention_mask,
+            "token_type_ids": token_type_ids,
+            "position_ids": position_ids,
+        }
+
+        # remove inputs for specific model types
+        if isinstance(self._hf_model.config, transformers.DistilBertConfig):
+            del inputs["token_type_ids"]
+            del inputs["position_ids"]
+        response = self._hf_model(**inputs)
+        if isinstance(response, tuple):
+            return torch.stack(list(response), dim=0)
+        return response
+
+
+class _TwoParameterQuestionAnsweringWrapper(_QuestionAnsweringWrapperModule):
+    def __init__(self, model: PreTrainedModel):
+        super().__init__(model=model)
+
+    def forward(self, input_ids: Tensor, attention_mask: Tensor) -> Tensor:
+        """Wrap the input and output to conform to the native process interface."""
+        inputs = {
+            "input_ids": input_ids,
+            "attention_mask": attention_mask,
+        }
+        response = self._hf_model(**inputs)
+        if isinstance(response, tuple):
+            return torch.stack(list(response), dim=0)
+        return response
 
 
 class _DistilBertWrapper(nn.Module):  # type: ignore
@@ -381,6 +463,16 @@ class _TraceableZeroShotClassificationModel(_TraceableClassificationModel):
         )
 
 
+class _TraceableQuestionAnsweringModel(_TraceableModel):
+    def _prepare_inputs(self) -> transformers.BatchEncoding:
+        return self._tokenizer(
+            "What is the meaning of life?"
+            "The meaning of life, according to the hitchikers guide, is 42.",
+            padding="max_length",
+            return_tensors="pt",
+        )
+
+
 class TransformerModel:
     def __init__(self, model_id: str, task_type: str, quantize: bool = False):
         self._model_id = model_id
@@ -451,7 +543,17 @@ class TransformerModel:
                 inference_config[self._task_type]["tokenization"][tokenizer_type][
                     "max_sequence_length"
                 ] = max_sequence_length
-
+        # Set squad well known defaults
+        if self._task_type == "question_answering":
+            inference_config[self._task_type]["tokenization"][tokenizer_type][
+                "max_sequence_length"
+            ] = 386
+            inference_config[self._task_type]["tokenization"][tokenizer_type][
+                "span"
+            ] = 128
+            inference_config[self._task_type]["tokenization"][tokenizer_type][
+                "truncate"
+            ] = "none"
         if self._traceable_model.classification_labels():
             inference_config[self._task_type][
                 "classification_labels"
@@ -504,7 +606,9 @@ class TransformerModel:
             )
             model = _DistilBertWrapper.try_wrapping(model)
             return _TraceableZeroShotClassificationModel(self._tokenizer, model)
-
+        elif self._task_type == "question_answering":
+            model = _QuestionAnsweringWrapperModule.from_pretrained(self._model_id)
+            return _TraceableQuestionAnsweringModel(self._tokenizer, model)
         else:
             raise TypeError(
                 f"Unknown task type {self._task_type}, must be one of: {SUPPORTED_TASK_TYPES_NAMES}"


### PR DESCRIPTION
Adds support for `question_answering` NLP models within the pytorch model uploader.

Related: https://github.com/elastic/elasticsearch/pull/85958