### PR TITLE
Align dependencies between requirement files and setup.py

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,7 +10,7 @@ tqdm<5
 #
 # Extras
 #
-scikit-learn>=0.22.1
+scikit-learn>=0.22.1,<2
 xgboost>=0.90,<2
 scikit-learn>=0.22.1,<2
 lightgbm>=2,<4

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,19 +1,36 @@
+#
+# Basic requirements
+#
 elasticsearch>=8,<9
-pandas>=1.2.0
-matplotlib
+pandas>=1.2,<2
+matplotlib<4
+numpy<2
+tqdm<5
+
+#
+# Extras
+#
+scikit-learn>=0.22.1
+xgboost>=0.90,<2
+scikit-learn>=0.22.1,<2
+lightgbm>=2,<4
+
+# PyTorch doesn't support Python 3.10 yet (pytorch/pytorch#66424)
+sentence-transformers>=2.1.0,<3; python_version<'3.10'
+torch>=1.9.0,<2; python_version<'3.10'
+transformers[torch]>=4.12.0,<5; python_version<'3.10'
+
+#
+# Testing
+#
 pytest>=5.2.1
 pytest-mock
-nbval
-numpydoc>=0.9.0
-scikit-learn>=0.22.1
-xgboost>=1
-nox
-lightgbm
 pytest-cov
-mypy
-huggingface-hub>=0.0.17
+nbval
 
-# Torch doesn't support Python 3.10 yet (pytorch/pytorch#66424)
-sentence-transformers>=2.1.0; python_version<'3.10'
-torch>=1.9.0; python_version<'3.10'
-transformers[torch]>=4.12.0; python_version<'3.10'
+#
+# Docs
+#
+nox
+numpydoc>=0.9.0
+mypy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,7 @@
-elasticsearch>=8.0.0a1,<9
-pandas>=1
-matplotlib
+#
+# Basic requirements
+#
+elasticsearch>=8,<9
+pandas>=1.2,<2
+matplotlib<4
+numpy<2

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ with open(path.join(here, "README.md"), "r", "utf-8") as f:
 
 extras = {
     "xgboost": ["xgboost>=0.90,<2"],
-    "scikit-learn": ["scikit-learn>=0.22.1,<1"],
+    "scikit-learn": ["scikit-learn>=0.22.1,<2"],
     "lightgbm": ["lightgbm>=2,<4"],
     "pytorch": [
         "sentence-transformers>=2.1.0,<3",
@@ -83,9 +83,9 @@ setup(
     packages=find_packages(include=["eland", "eland.*"]),
     install_requires=[
         "elasticsearch>=8,<9",
-        "pandas>=1.2,<1.4",
-        "matplotlib",
-        "numpy",
+        "pandas>=1.2,<2",
+        "matplotlib<4",
+        "numpy<2"
     ],
     scripts=["bin/eland_import_hub_model"],
     python_requires=">=3.7",

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,7 @@ setup(
         "elasticsearch>=8,<9",
         "pandas>=1.2,<2",
         "matplotlib<4",
-        "numpy<2"
+        "numpy<2",
     ],
     scripts=["bin/eland_import_hub_model"],
     python_requires=">=3.7",


### PR DESCRIPTION
Dependencies weren't matching between `setup.py` and `requirements.txt`/`requirements-dev.txt`. 

This PR aligns them to match, and locks the dependency version to the current major where a version was previously specified.

Note: 
`scikit-learn` was locked to versions lower than `1.0.0` in `setup.py`, but it was open-ended on the high side in `requirements-dev.txt`. At the time this PR was raised, the latest version is `1.0.2`, which is why I locked the max version `<2`.