### PR TITLE
[DOCS] Include missing attributes

### DIFF
--- a/docs/guide/index.asciidoc
+++ b/docs/guide/index.asciidoc
@@ -2,8 +2,8 @@
 
 :doctype:           book
 
-include::{docs-root}/shared/versions/stack/{source_branch}.asciidoc[]
-include::{docs-root}/shared/attributes.asciidoc[]
+include::{asciidoc-dir}/../../shared/versions/stack/{source_branch}.asciidoc[]
+include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
 include::overview.asciidoc[]
 

--- a/docs/guide/index.asciidoc
+++ b/docs/guide/index.asciidoc
@@ -2,7 +2,8 @@
 
 :doctype:           book
 
-include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
+include::{docs-root}/shared/versions/stack/{source_branch}.asciidoc[]
+include::{docs-root}/shared/attributes.asciidoc[]
 
 include::overview.asciidoc[]
 


### PR DESCRIPTION
Relates to https://github.com/elastic/eland/pull/467, which encounters the following documentation build error due to the lack of a "branch" attribute:

> 13:26:19 INFO:build_docs:Bad cross-document links:
13:26:19 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/client/eland/current/machine-learning.html contains broken links to:
13:26:19 INFO:build_docs:   - en/machine-learning/{branch}/ml-nlp-model-ref.html
