### PR TITLE
Freeze the traced PyTorch model

### DIFF
--- a/eland/ml/pytorch/traceable_model.py
+++ b/eland/ml/pytorch/traceable_model.py
@@ -59,5 +59,6 @@ class TraceableModel(ABC):
     def save(self, path: str) -> str:
         model_path = os.path.join(path, "traced_pytorch_model.pt")
         trace_model = self.trace()
+        trace_model = torch.jit.freeze(trace_model)    
         torch.jit.save(trace_model, model_path)
         return model_path


### PR DESCRIPTION
Freezing PyTorch/TorchScript models is an optimisation of the internal format that strips attributes and inlines constant values. A frozen model should only be used for inference. 

Benchmarking with 2 commonly used NLP models (https://huggingface.co/sentence-transformers/multi-qa-MiniLM-L6-cos-v1 and https://huggingface.co/sentence-transformers/all-distilroberta-v1) shows there is a small performance gain of < 1% when using frozen models. The gain is small there is no downside to freezing models that will only be used for inference. 