### PR TITLE
Bump PyTorch version to 1.11

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -17,7 +17,7 @@ lightgbm>=2,<4
 
 # PyTorch doesn't support Python 3.10 yet (pytorch/pytorch#66424)
 sentence-transformers>=2.1.0,<3; python_version<'3.10'
-torch>=1.9.0,<2; python_version<'3.10'
+torch>=1.11.0,<2; python_version<'3.10'
 transformers[torch]>=4.12.0,<5; python_version<'3.10'
 
 #

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ extras = {
     "lightgbm": ["lightgbm>=2,<4"],
     "pytorch": [
         "sentence-transformers>=2.1.0,<3",
-        "torch>=1.9.0,<2",
+        "torch>=1.11.0,<2",
         "transformers[torch]>=4.12.0,<5",
     ],
 }


### PR DESCRIPTION
Version 8.3 of the elastic stack uses PyTorch 1.11 (https://github.com/elastic/ml-cpp/pull/2238) this changes the required version to match