### PR TITLE
Restrict PyTorch version not to be more advanced than that used in Elasticsearch 

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,10 @@ $ conda install -c conda-forge eland
 ### Compatibility
 
 - Supports Python 3.7+ and Pandas 1.3
-- Supports Elasticsearch clusters that are 7.11+, recommended 7.14 or later for all features to work.
-  Make sure your Eland major version matches the major version of your Elasticsearch cluster.
+- Supports Elasticsearch clusters that are 7.11+, recommended 8.3 or later for all features to work.
+  If you are using the NLP with PyTorch feature make sure your Eland minor version matches the minor 
+  version of your Elasticsearch cluster. For all other features it is sufficient for the major versions
+  to match.
 
 ### Prerequisites
 

--- a/eland/ml/pytorch/_pytorch_model.py
+++ b/eland/ml/pytorch/_pytorch_model.py
@@ -125,9 +125,7 @@ class PyTorchModel:
         docs: List[Mapping[str, str]],
         timeout: str = DEFAULT_TIMEOUT,
     ) -> Any:
-        return self._client.options(
-            request_timeout=60
-        ).ml.infer_trained_model(
+        return self._client.options(request_timeout=60).ml.infer_trained_model(
             model_id=self.model_id,
             timeout=timeout,
             docs=docs,

--- a/eland/ml/pytorch/_pytorch_model.py
+++ b/eland/ml/pytorch/_pytorch_model.py
@@ -127,7 +127,7 @@ class PyTorchModel:
     ) -> Any:
         return self._client.options(
             request_timeout=60
-        ).ml.infer_trained_model_deployment(
+        ).ml.infer_trained_model(
             model_id=self.model_id,
             timeout=timeout,
             docs=docs,

--- a/eland/ml/pytorch/_pytorch_model.py
+++ b/eland/ml/pytorch/_pytorch_model.py
@@ -22,6 +22,7 @@ import os
 from typing import (
     TYPE_CHECKING,
     Any,
+    Dict,
     Iterable,
     List,
     Mapping,
@@ -38,6 +39,8 @@ from eland.ml.pytorch.nlp_ml_model import NlpTrainedModelConfig
 
 if TYPE_CHECKING:
     from elasticsearch import Elasticsearch
+
+from elasticsearch._sync.client.utils import _quote
 
 DEFAULT_CHUNK_SIZE = 4 * 1024 * 1024  # 4MB
 DEFAULT_TIMEOUT = "60s"
@@ -125,10 +128,19 @@ class PyTorchModel:
         docs: List[Mapping[str, str]],
         timeout: str = DEFAULT_TIMEOUT,
     ) -> Any:
-        return self._client.options(request_timeout=60).ml.infer_trained_model(
-            model_id=self.model_id,
-            timeout=timeout,
-            docs=docs,
+        if docs is None:
+            raise ValueError("Empty value passed for parameter 'docs'")
+
+        __body: Dict[str, Any] = {}
+        __body["docs"] = docs
+
+        __path = f"/_ml/trained_models/{_quote(self.model_id)}/deployment/_infer"
+        __query: Dict[str, Any] = {}
+        __query["timeout"] = timeout
+        __headers = {"accept": "application/json", "content-type": "application/json"}
+
+        return self._client.options(request_timeout=60).perform_request(
+            "POST", __path, params=__query, headers=__headers, body=__body
         )
 
     def start(self, timeout: str = DEFAULT_TIMEOUT) -> None:

--- a/noxfile.py
+++ b/noxfile.py
@@ -71,7 +71,7 @@ def lint(session):
     # Install numpy to use its mypy plugin
     # https://numpy.org/devdocs/reference/typing.html#mypy-plugin
     session.install("black", "flake8", "mypy", "isort", "numpy")
-    session.install("--pre", "elasticsearch>=8.0.0a1,<9")
+    session.install("--pre", "elasticsearch>=8.3,<9")
     session.run("python", "utils/license-headers.py", "check", *SOURCE_FILES)
     session.run("black", "--check", "--target-version=py37", *SOURCE_FILES)
     session.run("isort", "--check", "--profile=black", *SOURCE_FILES)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 #
 # Basic requirements
 #
-elasticsearch>=8,<9
+elasticsearch>=8.3,<9
 pandas>=1.2,<2
 matplotlib<4
 numpy<2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,9 +16,12 @@ scikit-learn>=0.22.1,<2
 lightgbm>=2,<4
 
 # PyTorch doesn't support Python 3.10 yet (pytorch/pytorch#66424)
-sentence-transformers>=2.1.0,<3; python_version<'3.10'
-torch>=1.11.0,<2; python_version<'3.10'
-transformers[torch]>=4.12.0,<5; python_version<'3.10'
+
+# Elasticsearch uses v1.11.0 of PyTorch
+torch>=1.11.0,<1.12.0; python_version<'3.10'
+# Versions known to be compatible with torch 1.11
+sentence-transformers>=2.1.0,<=2.2.2; python_version<'3.10'
+transformers[torch]>=4.12.0,<=4.20.1; python_version<'3.10'
 
 #
 # Testing

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 #
 # Basic requirements
 #
-elasticsearch>=8,<9
+elasticsearch>=8.3,<9
 pandas>=1.2,<2
 matplotlib<4
 numpy<2

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ setup(
     keywords="elastic eland pandas python",
     packages=find_packages(include=["eland", "eland.*"]),
     install_requires=[
-        "elasticsearch>=8,<9",
+        "elasticsearch>=8.3,<9",
         "pandas>=1.2,<2",
         "matplotlib<4",
         "numpy<2",

--- a/setup.py
+++ b/setup.py
@@ -58,10 +58,10 @@ extras = {
     "xgboost": ["xgboost>=0.90,<2"],
     "scikit-learn": ["scikit-learn>=0.22.1,<2"],
     "lightgbm": ["lightgbm>=2,<4"],
-    "pytorch": [
-        "sentence-transformers>=2.1.0,<3",
-        "torch>=1.11.0,<2",
-        "transformers[torch]>=4.12.0,<5",
+    "pytorch": [        
+        "torch>=1.11.0,<1.12.0",
+        "sentence-transformers>=2.1.0,<=2.2.2",
+        "transformers[torch]>=4.12.0,<=4.20.1",
     ],
 }
 extras["all"] = list({dep for deps in extras.values() for dep in deps})

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ extras = {
     "xgboost": ["xgboost>=0.90,<2"],
     "scikit-learn": ["scikit-learn>=0.22.1,<2"],
     "lightgbm": ["lightgbm>=2,<4"],
-    "pytorch": [        
+    "pytorch": [
         "torch>=1.11.0,<1.12.0",
         "sentence-transformers>=2.1.0,<=2.2.2",
         "transformers[torch]>=4.12.0,<=4.20.1",


### PR DESCRIPTION
PyTorch recently released [version 1.12](https://github.com/pytorch/pytorch/releases/tag/v1.12.0) which contains breaking changes to torchscript models making them incompatible with earlier versions. 

The Elastic stack uses version 1.11 of the PyTorch C++ library (libtorch), a model traced to torchscript format using a v1.12 Python PyTorch install cannot be evaluated in libtorch v1.11. 

Anyone using Eland to import a model into Elastic today would pull the latest version of PyTorch and find the model cannot be evaluated in Elasticsearch. Opening the model errors with the message: 

`Attempted to read a PyTorch file with version 10, but the maximum supported version for reading is 9. Your PyTorch installation may be too old.` 

This change to the requirements prevents Eland using v1.12 of PyTorch.

HuggingFace transformers has also pinned the torch requirement to `<1.12` in https://github.com/huggingface/transformers/commit/5a3d0cbdda73afafebbb8516901e622242a67863

The `sentence-transformers` and `transformers` versions have also been tighten to a range known to be compatible with PyTorch 1.11. 


 