### PR TITLE
[ML] add text_similarity task support

### DIFF
--- a/eland/ml/pytorch/nlp_ml_model.py
+++ b/eland/ml/pytorch/nlp_ml_model.py
@@ -218,6 +218,20 @@ class QuestionAnsweringInferenceOptions(InferenceConfig):
         self.num_top_classes = num_top_classes
 
 
+class ReRankingInferenceOptions(InferenceConfig):
+    def __init__(
+        self,
+        *,
+        tokenization: NlpTokenizationConfig,
+        results_field: t.Optional[str] = None,
+        question: t.Optional[str] = None,
+    ):
+        super().__init__(configuration_type="re_ranking")
+        self.tokenization = tokenization
+        self.results_field = results_field
+        self.question = question
+
+
 class TextEmbeddingInferenceOptions(InferenceConfig):
     def __init__(
         self,

--- a/eland/ml/pytorch/nlp_ml_model.py
+++ b/eland/ml/pytorch/nlp_ml_model.py
@@ -218,18 +218,18 @@ class QuestionAnsweringInferenceOptions(InferenceConfig):
         self.num_top_classes = num_top_classes
 
 
-class ReRankingInferenceOptions(InferenceConfig):
+class TextSimilarityInferenceOptions(InferenceConfig):
     def __init__(
         self,
         *,
         tokenization: NlpTokenizationConfig,
         results_field: t.Optional[str] = None,
-        question: t.Optional[str] = None,
+        text: t.Optional[str] = None,
     ):
-        super().__init__(configuration_type="re_ranking")
+        super().__init__(configuration_type="text_similarity")
         self.tokenization = tokenization
         self.results_field = results_field
-        self.question = question
+        self.text = text
 
 
 class TextEmbeddingInferenceOptions(InferenceConfig):

--- a/eland/ml/pytorch/transformers.py
+++ b/eland/ml/pytorch/transformers.py
@@ -49,9 +49,9 @@ from eland.ml.pytorch.nlp_ml_model import (
     NlpTrainedModelConfig,
     PassThroughInferenceOptions,
     QuestionAnsweringInferenceOptions,
-    TextSimilarityInferenceOptions,
     TextClassificationInferenceOptions,
     TextEmbeddingInferenceOptions,
+    TextSimilarityInferenceOptions,
     TrainedModelInput,
     ZeroShotClassificationInferenceOptions,
 )


### PR DESCRIPTION
Adds text_similarity task support. This is a cross-encoder transformer task where both sequences are given to the transformer at once. 

According to 🤗 (or at least how the cross-encoder models are concerned) this is a sequence classification task with just one classification "label". But really, it isn't labeled at all and is more akin to a regression model.

related: https://github.com/elastic/elasticsearch/pull/88439