### PR TITLE
[DOCS] Adds important note about PyTorch version compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ $ conda install -c conda-forge eland
   If you are using the NLP with PyTorch feature make sure your Eland minor version matches the minor 
   version of your Elasticsearch cluster. For all other features it is sufficient for the major versions
   to match.
+- You need to use PyTorch `1.11.0` or earlier to import an NLP model. 
+  Run `pip install torch==1.11` to install the aproppriate version of PyTorch.
 
 ### Prerequisites
 

--- a/docs/guide/machine-learning.asciidoc
+++ b/docs/guide/machine-learning.asciidoc
@@ -38,6 +38,10 @@ model in {es}.
 [[ml-nlp-pytorch]]
 === Natural language processing (NLP) with PyTorch
 
+
+IMPORTANT: You need to use PyTorch `1.11.0` or earlier to import an NLP model. 
+Run `pip install torch==1.11` to install the aproppriate version of PyTorch.
+
 For NLP tasks, Eland enables you to import PyTorch trained BERT models into {es}. 
 Models can be either plain PyTorch models, or supported 
 https://huggingface.co/transformers[transformers] models from the


### PR DESCRIPTION
## Overview

The latest version of PyTorch 1.12 is not compatible with ES 8.3. Users need to use 1.11.0 or earlier to import a model via eland. This PR adds an important note about it to the docs and the README.