### PR TITLE
Handle OSError for missing LightGBM dependency

### DIFF
--- a/eland/ml/transformers/__init__.py
+++ b/eland/ml/transformers/__init__.py
@@ -93,5 +93,5 @@ try:
         "LGBMClassifierTransformer",
     ]
     _MODEL_TRANSFORMERS.update(_LIGHTGBM_MODEL_TRANSFORMERS)
-except ImportError:
+except (ImportError, OSError):
     pass

--- a/eland/ml/transformers/__init__.py
+++ b/eland/ml/transformers/__init__.py
@@ -93,5 +93,9 @@ try:
         "LGBMClassifierTransformer",
     ]
     _MODEL_TRANSFORMERS.update(_LIGHTGBM_MODEL_TRANSFORMERS)
+    # LightGBM may be installed but missing a required library
+    # (e.g. libomp) in which case an OSError is thrown. Allow
+    # the error to happen here so that code using other features
+    # is not blocked by the missing dependency
 except (ImportError, OSError):
     pass


### PR DESCRIPTION
In some environments simply importing the `TransformerModel` class used to configure NLP models can generate an error in an unrelated dependency:

```
from eland.ml.pytorch.transformers import TransformerModel

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File " /source/eland/eland/ml/__init__.py", line 18, in <module>
    from eland.ml.ml_model import ImportedMLModel, MLModel  # noqa: F401
  File " /source/eland/eland/ml/ml_model.py", line 27, in <module>
    from .transformers import get_model_transformer
  File " /source/eland/eland/ml/transformers/__init__.py", line 83, in <module>
    from .lightgbm import _MODEL_TRANSFORMERS as _LIGHTGBM_MODEL_TRANSFORMERS
  File " /source/eland/eland/ml/transformers/lightgbm.py", line 25, in <module>
    import_optional_dependency("lightgbm", on_version="warn")
  File " /source/eland/eland/ml/_optional.py", line 97, in import_optional_dependency
    module = importlib.import_module(name)
  File " /opt/anaconda3/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File " /opt/anaconda3/lib/python3.8/site-packages/lightgbm/__init__.py", line 8, in <module>
    from .basic import Booster, Dataset, Sequence, register_logger
  File " /opt/anaconda3/lib/python3.8/site-packages/lightgbm/basic.py", line 110, in <module>
    _LIB = _load_lib()
  File " /opt/anaconda3/lib/python3.8/site-packages/lightgbm/basic.py", line 101, in _load_lib
    lib = ctypes.cdll.LoadLibrary(lib_path[0])
  File " /opt/anaconda3/lib/python3.8/ctypes/__init__.py", line 451, in LoadLibrary
    return self._dlltype(name)
  File " /opt/anaconda3/lib/python3.8/ctypes/__init__.py", line 373, in __init__
    self._handle = _dlopen(self._name, mode)
OSError: dlopen( /opt/anaconda3/lib/python3.8/site-packages/lightgbm/lib_lightgbm.so, 0x0006): Library not loaded: '/usr/local/opt/libomp/lib/libomp.dylib'
  Referenced from: ' /opt/anaconda3/lib/python3.8/site-packages/lightgbm/lib_lightgbm.so'
  Reason: tried: '/usr/local/opt/libomp/lib/libomp.dylib' (no such file), '/usr/local/lib/libomp.dylib' (no such file), '/usr/lib/libomp.dylib' (no such file)
```

The root cause is the missing library `libomp.dylib` required by LightGBM.  No LightGBM code is being used but it is pulled in by the `ml.transformers` [__init__.py](https://github.com/elastic/eland/blob/main/eland/ml/transformers/__init__.py). 

It might be preferable to not have those packages automatically imported but I believe that would constitute a breaking change. Catching the `OSError` is sufficient in this case as LightGBM is not used.


The error is most likely to happen on macOS using Anaconda where LightGBM has been installed but is missing libomp.dylib.