### PR TITLE
Use model specific value of max_sequence_length for Question Answering models

### DIFF
--- a/eland/arithmetics.py
+++ b/eland/arithmetics.py
@@ -33,6 +33,7 @@ class ArithmeticObject(ABC):
     def value(self) -> str:
         pass
 
+    @property
     @abstractmethod
     def dtype(self) -> "DTypeLike":
         pass

--- a/eland/ml/pytorch/transformers.py
+++ b/eland/ml/pytorch/transformers.py
@@ -619,9 +619,8 @@ class TransformerModel:
     def _create_config(self) -> NlpTrainedModelConfig:
         tokenization_config = self._create_tokenization_config()
 
-        # Set squad well known defaults
+        # Set span and truncate defaults for question answering
         if self._task_type == "question_answering":
-            tokenization_config.max_sequence_length = 386
             tokenization_config.span = 128
             tokenization_config.truncate = "none"
         inference_config = (


### PR DESCRIPTION
Eland sets sensible defaults for the `span` and `truncate` settings but it should not overwrite `max_sequence_length` which is model dependant. For example [this](https://huggingface.co/deepset/bert-large-uncased-whole-word-masking-squad2?context=The+Amazon+rainforest+%28Portuguese%3A+Floresta+Amaz%C3%B4nica+or+Amaz%C3%B4nia%3B+Spanish%3A+Selva+Amaz%C3%B3nica%2C+Amazon%C3%ADa+or+usually+Amazonia%3B+French%3A+For%C3%AAt+amazonienne%3B+Dutch%3A+Amazoneregenwoud%29%2C+also+known+in+English+as+Amazonia+or+the+Amazon+Jungle%2C+is+a+moist+broadleaf+forest+that+covers+most+of+the+Amazon+basin+of+South+America.+This+basin+encompasses+7%2C000%2C000+square+kilometres+%282%2C700%2C000+sq+mi%29%2C+of+which+5%2C500%2C000+square+kilometres+%282%2C100%2C000+sq+mi%29+are+covered+by+the+rainforest.+This+region+includes+territory+belonging+to+nine+nations.+The+majority+of+the+forest+is+contained+within+Brazil%2C+with+60%25+of+the+rainforest%2C+followed+by+Peru+with+13%25%2C+Colombia+with+10%25%2C+and+with+minor+amounts+in+Venezuela%2C+Ecuador%2C+Bolivia%2C+Guyana%2C+Suriname+and+French+Guiana.+States+or+departments+in+four+nations+contain+%22Amazonas%22+in+their+names.+The+Amazon+represents+over+half+of+the+planet%27s+remaining+rainforests%2C+and+comprises+the+largest+and+most+biodiverse+tract+of+tropical+rainforest+in+the+world%2C+with+an+estimated+390+billion+individual+trees+divided+into+16%2C000+species.&question=Which+name+is+also+used+to+describe+the+Amazon+rainforest+in+English%3F) BERT based QA model has a max sequence length of 512.




