### PR TITLE
Include pitfall of `--start` in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,7 @@ $ docker run -it --rm --network host \
     eland_import_hub_model \
       --url http://host.docker.internal:9200/ \
       --hub-model-id elastic/distilbert-base-cased-finetuned-conll03-english \
-      --task-type ner \
-      --start
+      --task-type ner
 ```
 
 ### Connecting to Elasticsearch 
@@ -236,6 +235,17 @@ $ eland_import_hub_model \
   --task-type ner \
   --start
 ```
+
+The example above will automatically start a model deployment. This is a
+good shortcut for initial experimentation, but for anything that needs
+good throughput you should omit the `--start` argument from the Eland
+command line and instead start the model using the ML UI in Kibana.
+The `--start` argument will deploy the model with one allocation and one
+thread per allocation, which will not offer good performance. When starting
+the model deployment using the ML UI in Kibana or the Elasticsearch
+[API](https://www.elastic.co/guide/en/elasticsearch/reference/current/start-trained-model-deployment.html)
+you will be able to set the threading options to make best use of your
+hardware.
 
 ```python
 >>> import elasticsearch


### PR DESCRIPTION
Users who follow the Eland README as a guide to importing models can easily end up seeing inexplicably poor performance due to unknowingly running the model with one allocation and one thread per allocation.

This change spells out the effect of `--start` and links to alternatives that allow better use of available hardware.