### PR TITLE
[NLP] Add support for the pass_through task

### DIFF
--- a/eland/ml/pytorch/transformers.py
+++ b/eland/ml/pytorch/transformers.py
@@ -62,6 +62,7 @@ DEFAULT_OUTPUT_KEY = "sentence_embedding"
 SUPPORTED_TASK_TYPES = {
     "fill_mask",
     "ner",
+    "pass_through",
     "text_classification",
     "text_embedding",
     "text_expansion",
@@ -508,6 +509,15 @@ class _TraceableNerModel(_TraceableClassificationModel):
         )
 
 
+class _TraceablePassThroughModel(_TransformerTraceableModel):
+    def _prepare_inputs(self) -> transformers.BatchEncoding:
+        return self._tokenizer(
+            "This is an example sentence.",
+            padding="max_length",
+            return_tensors="pt",
+        )
+
+
 class _TraceableTextClassificationModel(_TraceableClassificationModel):
     def _prepare_inputs(self) -> transformers.BatchEncoding:
         return self._tokenizer(
@@ -707,6 +717,11 @@ class TransformerModel:
             )
             model = _DistilBertWrapper.try_wrapping(model)
             return _TraceableTextSimilarityModel(self._tokenizer, model)
+        elif self._task_type == "pass_through":
+            model = transformers.AutoModel.from_pretrained(
+                self._model_id, torchscript=True
+            )
+            return _TraceablePassThroughModel(self._tokenizer, model)
         else:
             raise TypeError(
                 f"Unknown task type {self._task_type}, must be one of: {SUPPORTED_TASK_TYPES_NAMES}"


### PR DESCRIPTION
The `pass_through` task returns the models output directly without any post-processing of the results. `pass_through` is typically used for debugging. 

This change allows models to be loaded into Elasticsearch with the `pass_through` task

An example invocation of the `eland_import_hub_model` script with `pass_through` is: 
```
eland_import_hub_model \
      --url XXX \
      -u XXX -p XXXX \
      --hub-model-id "sentence-transformers/msmarco-MiniLM-L-12-v3" \
      --task-type pass_through 
```