### PR TITLE
Revert "Set embedding_size config parameter for Text Embedding models"

### DIFF
--- a/eland/ml/pytorch/nlp_ml_model.py
+++ b/eland/ml/pytorch/nlp_ml_model.py
@@ -238,12 +238,10 @@ class TextEmbeddingInferenceOptions(InferenceConfig):
         *,
         tokenization: NlpTokenizationConfig,
         results_field: t.Optional[str] = None,
-        embedding_size: t.Optional[int] = None,
     ):
         super().__init__(configuration_type="text_embedding")
         self.tokenization = tokenization
         self.results_field = results_field
-        self.embedding_size = embedding_size
 
 
 class TextExpansionInferenceOptions(InferenceConfig):

--- a/eland/ml/pytorch/traceable_model.py
+++ b/eland/ml/pytorch/traceable_model.py
@@ -50,10 +50,6 @@ class TraceableModel(ABC):
         return self._trace()
 
     @abstractmethod
-    def sample_output(self) -> torch.Tensor:
-        ...
-
-    @abstractmethod
     def _trace(self) -> TracedModelTypes:
         ...
 

--- a/eland/ml/pytorch/transformers.py
+++ b/eland/ml/pytorch/transformers.py
@@ -443,14 +443,6 @@ class _TransformerTraceableModel(TraceableModel):
         self._tokenizer = tokenizer
 
     def _trace(self) -> TracedModelTypes:
-        inputs = self._compatible_inputs()
-        return torch.jit.trace(self._model, inputs)
-
-    def sample_output(self) -> Tensor:
-        inputs = self._compatible_inputs()
-        return self._model(*inputs)
-
-    def _compatible_inputs(self) -> Tuple[Tensor, ...]:
         inputs = self._prepare_inputs()
 
         # Add params when not provided by the tokenizer (e.g. DistilBERT), to conform to BERT interface
@@ -466,16 +458,21 @@ class _TransformerTraceableModel(TraceableModel):
                 transformers.BartConfig,
             ),
         ):
-            del inputs["token_type_ids"]
-            return (inputs["input_ids"], inputs["attention_mask"])
+            return torch.jit.trace(
+                self._model,
+                (inputs["input_ids"], inputs["attention_mask"]),
+            )
 
         position_ids = torch.arange(inputs["input_ids"].size(1), dtype=torch.long)
-        inputs["position_ids"] = position_ids
-        return (
-            inputs["input_ids"],
-            inputs["attention_mask"],
-            inputs["token_type_ids"],
-            inputs["position_ids"],
+
+        return torch.jit.trace(
+            self._model,
+            (
+                inputs["input_ids"],
+                inputs["attention_mask"],
+                inputs["token_type_ids"],
+                position_ids,
+            ),
         )
 
     @abstractmethod
@@ -643,23 +640,16 @@ class TransformerModel:
             tokenization_config.max_sequence_length = 386
             tokenization_config.span = 128
             tokenization_config.truncate = "none"
-
-        if self._traceable_model.classification_labels():
-            inference_config = TASK_TYPE_TO_INFERENCE_CONFIG[self._task_type](
+        inference_config = (
+            TASK_TYPE_TO_INFERENCE_CONFIG[self._task_type](
                 tokenization=tokenization_config,
                 classification_labels=self._traceable_model.classification_labels(),
             )
-        elif self._task_type == "text_embedding":
-            sample_embedding, _ = self._traceable_model.sample_output()
-            embedding_size = sample_embedding.size(-1)
-            inference_config = TASK_TYPE_TO_INFERENCE_CONFIG[self._task_type](
-                tokenization=tokenization_config,
-                embedding_size=embedding_size,
-            )
-        else:
-            inference_config = TASK_TYPE_TO_INFERENCE_CONFIG[self._task_type](
+            if self._traceable_model.classification_labels()
+            else TASK_TYPE_TO_INFERENCE_CONFIG[self._task_type](
                 tokenization=tokenization_config
             )
+        )
 
         return NlpTrainedModelConfig(
             description=f"Model {self._model_id} for task type '{self._task_type}'",

--- a/tests/ml/pytorch/test_transformer_pytorch_model_pytest.py
+++ b/tests/ml/pytorch/test_transformer_pytorch_model_pytest.py
@@ -136,13 +136,6 @@ class TestTraceableModel(TraceableModel, ABC):
             ),
         )
 
-    def sample_output(self) -> torch.Tensor:
-        input_ids = torch.tensor(np.array(range(0, len(TEST_BERT_VOCAB))))
-        attention_mask = torch.tensor([1] * len(TEST_BERT_VOCAB))
-        token_type_ids = torch.tensor([0] * len(TEST_BERT_VOCAB))
-        position_ids = torch.arange(len(TEST_BERT_VOCAB), dtype=torch.long)
-        return self._model(input_ids, attention_mask, token_type_ids, position_ids)
-
 
 class NerModule(nn.Module):
     def forward(


### PR DESCRIPTION
#532 added the `embedding_size` field to `text_embedding` inference config but the field will not be recognised by Elasticsearch until version 8.8.

This change will be reapplied in 8.8

This reverts commit 50d301f7cba1c8e84e4bd42c85774f3741d8b383.