### PR TITLE
Use compatible versions of numpy and shap

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,9 +2,9 @@
 # Basic requirements
 #
 elasticsearch>=8.3,<9
-pandas>=1.5
+pandas>=1.5,<2
 matplotlib>=3.6
-numpy<2
+numpy<1.24
 tqdm<5
 
 #

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@
 # Basic requirements
 #
 elasticsearch>=8.3,<9
-pandas>=1.5
+pandas>=1.5,<2
 matplotlib>=3.6
 numpy<2

--- a/setup.py
+++ b/setup.py
@@ -83,9 +83,9 @@ setup(
     packages=find_packages(include=["eland", "eland.*"]),
     install_requires=[
         "elasticsearch>=8.3,<9",
-        "pandas>=1.5",
+        "pandas>=1.5,<2",
         "matplotlib>=3.6",
-        "numpy<2",
+        "numpy<1.24",
     ],
     scripts=["bin/eland_import_hub_model"],
     python_requires=">=3.8",


### PR DESCRIPTION
Tests are failing with the error 

```
E           AttributeError: module 'numpy' has no attribute 'bool'.
E           `np.bool` was a deprecated alias for the builtin `bool`. To avoid this error in existing code, use `bool` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.bool_` here.
E           The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
E               https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations. Did you mean: 'bool_'?
```

This is coming from the Shap explainer code using the deprecated `np.bool` attribute. 

```
.nox/test-3-10-pandas_version-1-5-0/lib/python3.10/site-packages/shap/explainers/_tree.py:384: in shap_values
    X, y, X_missing, flat_output, tree_limit, check_additivity = self._validate_inputs(X, y,
.nox/test-3-10-pandas_version-1-5-0/lib/python3.10/site-packages/shap/explainers/_tree.py:250: in _validate_inputs
    X_missing = np.isnan(X, dtype=np.bool)
```

Version 1.24 of numpy is incompatible with Shap 0.41 because of this. There is a PR to fix the problem in Shap but it has not been merged yet.

https://github.com/slundberg/shap/pull/1890
https://github.com/slundberg/shap/pull/1890/files#diff-6be3a33007583066a03d3a9faaed8b7a60713a03145f924fe7eea64bacaa22af

### Pandas
Pandas 2.0 was released in April 2023 it seems prudent to restrict the Pandas version to `<2` to avoid any incompatibilities. 

The Numpy install is probably coming from Pandas so a different fix may be required