### PR TITLE
Limit NumPy to a range of versions and add note

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,9 @@
 elasticsearch>=8.3,<9
 pandas>=1.5,<2
 matplotlib>=3.6
-numpy<1.24
+# Shap is incompatible with NumPy >= 1.24 (elastic/eland#539)
+# Fix NumPy to a known good range of versions
+numpy>=1.2.0,<1.24
 tqdm<5
 
 #

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,6 @@
 elasticsearch>=8.3,<9
 pandas>=1.5,<2
 matplotlib>=3.6
-numpy<2
+# Shap is incompatible with NumPy >= 1.24 (elastic/eland#539)
+# Fix NumPy to a known good range of versions
+numpy>=1.2.0,<1.24

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,7 @@ setup(
         "elasticsearch>=8.3,<9",
         "pandas>=1.5,<2",
         "matplotlib>=3.6",
-        "numpy<1.24",
+        "numpy>=1.2.0,<1.24",
     ],
     scripts=["bin/eland_import_hub_model"],
     python_requires=">=3.8",


### PR DESCRIPTION
Follow up to #539 this adds a comment explaining why the NumPy versions has been limited and sets a lower bound