### PR TITLE
Generate valid model id from file path

### DIFF
--- a/bin/eland_import_hub_model
+++ b/bin/eland_import_hub_model
@@ -171,6 +171,7 @@ if __name__ == "__main__":
             SUPPORTED_TASK_TYPES,
             TaskTypeError,
             TransformerModel,
+            elasticsearch_model_id,
         )
     except ModuleNotFoundError as e:
         logger.error(textwrap.dedent(f"""\
@@ -200,7 +201,7 @@ if __name__ == "__main__":
             logger.error(f"Failed to get model for task type, please provide valid task type via '--task-type' parameter. Caused by {err}")
             exit(1)
 
-        ptm = PyTorchModel(es, args.es_model_id if args.es_model_id else tm.elasticsearch_model_id())
+        ptm = PyTorchModel(es, args.es_model_id if args.es_model_id else elasticsearch_model_id(args.hub_model_id))
         model_exists = es.options(ignore_status=404).ml.get_trained_models(model_id=ptm.model_id).meta.status == 200
 
         if model_exists:

--- a/bin/eland_import_hub_model
+++ b/bin/eland_import_hub_model
@@ -187,7 +187,6 @@ if __name__ == "__main__":
             SUPPORTED_TASK_TYPES,
             TaskTypeError,
             TransformerModel,
-            elasticsearch_model_id,
         )
     except ModuleNotFoundError as e:
         logger.error(textwrap.dedent(f"""\
@@ -218,7 +217,7 @@ if __name__ == "__main__":
             logger.error(f"Failed to get model for task type, please provide valid task type via '--task-type' parameter. Caused by {err}")
             exit(1)
 
-        ptm = PyTorchModel(es, args.es_model_id if args.es_model_id else elasticsearch_model_id(args.hub_model_id))
+        ptm = PyTorchModel(es, args.es_model_id if args.es_model_id else tm.elasticsearch_model_id())
         model_exists = es.options(ignore_status=404).ml.get_trained_models(model_id=ptm.model_id).meta.status == 200
 
         if model_exists:

--- a/eland/ml/pytorch/transformers.py
+++ b/eland/ml/pytorch/transformers.py
@@ -740,6 +740,9 @@ class TransformerModel:
                 f"Unknown task type {self._task_type}, must be one of: {SUPPORTED_TASK_TYPES_NAMES}"
             )
 
+    def elasticsearch_model_id(self) -> str:
+        return elasticsearch_model_id(self._model_id)
+
     def save(self, path: str) -> Tuple[str, NlpTrainedModelConfig, str]:
         # save traced model
         model_path = self._traceable_model.save(path)

--- a/eland/ml/pytorch/transformers.py
+++ b/eland/ml/pytorch/transformers.py
@@ -22,6 +22,7 @@ libraries such as sentence-transformers.
 
 import json
 import os.path
+import re
 from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
@@ -739,10 +740,6 @@ class TransformerModel:
                 f"Unknown task type {self._task_type}, must be one of: {SUPPORTED_TASK_TYPES_NAMES}"
             )
 
-    def elasticsearch_model_id(self) -> str:
-        # Elasticsearch model IDs need to be a specific format: no special chars, all lowercase, max 64 chars
-        return self._model_id.replace("/", "__").lower()[:64]
-
     def save(self, path: str) -> Tuple[str, NlpTrainedModelConfig, str]:
         # save traced model
         model_path = self._traceable_model.save(path)
@@ -753,3 +750,21 @@ class TransformerModel:
             json.dump(self._vocab, outfile)
 
         return model_path, self._config, vocab_path
+
+
+def elasticsearch_model_id(model_id: str) -> str:
+    """
+    Elasticsearch model IDs need to be a specific format:
+    no special chars, all lowercase, max 64 chars. If the
+    Id is longer than 64 charaters take the last 64- in the
+    case where the id is long file path this captures the
+    model name.
+
+    Ids starting with __ are not valid elasticsearch Ids,
+    # this might be the case if model_id is a file path
+    """
+
+    id = re.sub(r"[\s\\/]", "__", model_id).lower()[-64:]
+    if id.startswith("__"):
+        id = id.removeprefix("__")
+    return id

--- a/tests/ml/pytorch/test_transformer_pytorch_model_pytest.py
+++ b/tests/ml/pytorch/test_transformer_pytorch_model_pytest.py
@@ -34,7 +34,7 @@ except ImportError:
 try:
     import torch  # noqa: F401
     from torch import Tensor, nn  # noqa: F401
-    from transformers import PretrainedConfig  # noqa: F401
+    from transformers import PretrainedConfig, elasticsearch_model_id  # noqa: F401
 
     from eland.ml.pytorch import (  # noqa: F401
         NlpBertTokenizationConfig,
@@ -338,3 +338,21 @@ class TestPytorchModelUpload:
             )
         )
         assert task_type_from_model_config(model_config=config) == expected_task
+
+    def test_elasticsearch_model_id(self):
+        model_id_from_path = elasticsearch_model_id(r"/foo/bar")
+        assert model_id_from_path == "foo_bar"
+
+        model_id_from_path = elasticsearch_model_id(r"\BAZ\with space")
+        assert model_id_from_path == "baz__with__space"
+
+        model_id_from_path = elasticsearch_model_id(r"/foo/with tab\tback\slash")
+        assert model_id_from_path == "foo__with__space__back__slash"
+
+        long_id_left_truncated = elasticsearch_model_id(
+            "/foo/bar/64charactersoftext64charactersoftext64charactersoftext64charofte"
+        )
+        assert (
+            long_id_left_truncated
+            == "64charactersoftext64charactersoftext64charactersoftext64charofte"
+        )


### PR DESCRIPTION
The `eland_import_hub_model` script supports uploading a local file where the `--hub-model-id` argument is a file path. 

If the `--es-model-id` option is not used the model Id is generated from the hub model id and when that is a file path the path must be converted to a valid elasticsearch model id.

- Replace whitespace, forward slash and back slash with double underscore '__'
- Lower case
- Left truncated to 64 chars