### PR TITLE
Default the optional es_version parameter

### DIFF
--- a/eland/ml/pytorch/transformers.py
+++ b/eland/ml/pytorch/transformers.py
@@ -578,7 +578,7 @@ class TransformerModel:
         model_id: str,
         task_type: str,
         *,
-        es_version: Optional[Tuple[int, int, int]],
+        es_version: Optional[Tuple[int, int, int]] = None,
         quantize: bool = False,
     ):
         """


### PR DESCRIPTION
The `es_version` parameter to `TransformerModel` is optional but missing a default value. 