### PR TITLE
Switch to the 'Furo' Sphinx theme

### DIFF
--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -7,7 +7,7 @@ xgboost>=1
 lightgbm
 sphinx==5.3.0
 nbsphinx
-git+https://github.com/pandas-dev/pydata-sphinx-theme.git
+furo
 
 # traitlets has been having all sorts of release problems lately.
 traitlets<5.1

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -115,12 +115,7 @@ exclude_patterns = ["**.ipynb_checkpoints"]
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 
-html_theme = "pydata_sphinx_theme"
-html_theme_options = {
-    "external_links": [],
-    "github_url": "https://github.com/elastic/eland",
-    "twitter_url": "https://twitter.com/elastic",
-}
+html_theme = "furo"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,


### PR DESCRIPTION
The pydata-sphinx-theme is failing, leading to our RTD being unusable. Switching to Furo appears to work just fine, let's switch to this for now to get the docs usable again.