### PR TITLE
Fix autosummary directive by removing hack autosummaries

### DIFF
--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -58,6 +58,7 @@ release = version
 # ones.
 extensions = [
     "sphinx.ext.autodoc",
+    "sphinx.ext.autosummary",
     "sphinx.ext.doctest",
     "sphinx.ext.extlinks",
     "matplotlib.sphinxext.plot_directive",

--- a/docs/sphinx/reference/api/eland.DataFrame.rst
+++ b/docs/sphinx/reference/api/eland.DataFrame.rst
@@ -4,15 +4,3 @@ eland.DataFrame
 .. currentmodule:: eland
 
 .. autoclass:: DataFrame
-
-   
-
-
-..
-   HACK -- the point here is that we don't want this to appear in the output, but the autosummary should still generate the pages.
-   .. autosummary::
-      :toctree:
-      
-      DataFrame.abs
-      DataFrame.add
-

--- a/docs/sphinx/reference/api/eland.groupby.DataFrameGroupBy.rst
+++ b/docs/sphinx/reference/api/eland.groupby.DataFrameGroupBy.rst
@@ -4,12 +4,3 @@ eland.groupby.DataFrameGroupBy
 .. currentmodule:: eland.groupby
 
 .. autoclass:: DataFrameGroupBy
-
-
-..
-   HACK -- the point here is that we don't want this to appear in the output, but the autosummary should still generate the pages.
-   .. autosummary::
-      :toctree:
-
-      DataFrame.abs
-      DataFrame.add

--- a/docs/sphinx/reference/api/eland.groupby.GroupBy.rst
+++ b/docs/sphinx/reference/api/eland.groupby.GroupBy.rst
@@ -4,12 +4,3 @@ eland.groupby.GroupBy
 .. currentmodule:: eland.groupby
 
 .. autoclass:: GroupBy
-
-
-..
-   HACK -- the point here is that we don't want this to appear in the output, but the autosummary should still generate the pages.
-   .. autosummary::
-      :toctree:
-
-      DataFrame.abs
-      DataFrame.add

--- a/docs/sphinx/reference/api/eland.ml.MLModel.rst
+++ b/docs/sphinx/reference/api/eland.ml.MLModel.rst
@@ -4,12 +4,3 @@ eland.ml.MLModel
 .. currentmodule:: eland.ml
 
 .. autoclass:: MLModel
-
-
-..
-   HACK -- the point here is that we don't want this to appear in the output, but the autosummary should still generate the pages.
-   .. autosummary::
-      :toctree:
-
-      DataFrame.abs
-      DataFrame.add


### PR DESCRIPTION
I'm unsure what these hack autosummaries are for because the documentation generates properly for the pages once they've been removed. They were added [4 years ago in the initial documentation commit](https://github.com/elastic/eland/commit/e181476dfe25a2abbe3dcf16ea663d2cbf09eab2#diff-b737ddab0ea189a06b340c34e8dca2352b1b3a55df783308abcf9094cadfba17R12) and haven't changed since. I think these are okay to remove as they're obviously incorrect content-wise.