### PR TITLE
Make it easier to find an entrypoint on Windows

### DIFF
--- a/eland/__main__.py
+++ b/eland/__main__.py
@@ -15,7 +15,7 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     from eland.cli import eland_import_hub_model
 
     eland_import_hub_model.main()

--- a/eland/__main__.py
+++ b/eland/__main__.py
@@ -1,0 +1,21 @@
+#  Licensed to Elasticsearch B.V. under one or more contributor
+#  license agreements. See the NOTICE file distributed with
+#  this work for additional information regarding copyright
+#  ownership. Elasticsearch B.V. licenses this file to you under
+#  the Apache License, Version 2.0 (the "License"); you may
+#  not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+# 	http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+
+if __name__ == '__main__':
+    from eland.cli import eland_import_hub_model
+
+    eland_import_hub_model.main()

--- a/eland/cli/__init__.py
+++ b/eland/cli/__init__.py
@@ -1,0 +1,16 @@
+#  Licensed to Elasticsearch B.V. under one or more contributor
+#  license agreements. See the NOTICE file distributed with
+#  this work for additional information regarding copyright
+#  ownership. Elasticsearch B.V. licenses this file to you under
+#  the Apache License, Version 2.0 (the "License"); you may
+#  not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+# 	http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.

--- a/eland/cli/eland_import_hub_model.py
+++ b/eland/cli/eland_import_hub_model.py
@@ -30,7 +30,6 @@ import sys
 import tempfile
 import textwrap
 
-import torch
 from elastic_transport.client_utils import DEFAULT
 from elasticsearch import AuthenticationException, Elasticsearch
 
@@ -184,6 +183,8 @@ def check_cluster_version(es_client, logger):
     # PyTorch was upgraded to version 1.13.1 in 8.7.
     # and is incompatible with earlier versions
     if major_version == 8 and minor_version < 7:
+        import torch
+
         logger.error(
             f"Eland uses PyTorch version {torch.__version__} which is incompatible "
             "with Elasticsearch versions prior to 8.7. Please upgrade Elasticsearch "

--- a/eland/cli/eland_import_hub_model.py
+++ b/eland/cli/eland_import_hub_model.py
@@ -41,6 +41,8 @@ MODEL_HUB_URL = "https://huggingface.co"
 
 
 def get_arg_parser():
+    from eland.ml.pytorch.transformers import SUPPORTED_TASK_TYPES
+
     parser = argparse.ArgumentParser()
     location_args = parser.add_mutually_exclusive_group(required=True)
     location_args.add_argument(
@@ -180,7 +182,8 @@ def check_cluster_version(es_client):
 
     return sem_ver
 
-if __name__ == "__main__":
+
+def main():
     # Configure logging
     logging.basicConfig(format='%(asctime)s %(levelname)s : %(message)s')
     logger = logging.getLogger(__name__)
@@ -254,3 +257,5 @@ if __name__ == "__main__":
     logger.info(f"Model successfully imported with id '{ptm.model_id}'")
 
 
+if __name__ == "__main__":
+    main()

--- a/eland/cli/eland_import_hub_model.py
+++ b/eland/cli/eland_import_hub_model.py
@@ -52,47 +52,50 @@ def get_arg_parser():
     location_args.add_argument(
         "--cloud-id",
         default=os.environ.get("CLOUD_ID"),
-        help="Cloud ID as found in the 'Manage Deployment' page of an Elastic Cloud deployment",
+        help="Cloud ID as found in the 'Manage Deployment' page of an Elastic Cloud "
+        "deployment",
     )
     parser.add_argument(
         "--hub-model-id",
         required=True,
         help="The model ID in the Hugging Face model hub, "
-             "e.g. dbmdz/bert-large-cased-finetuned-conll03-english",
+        "e.g. dbmdz/bert-large-cased-finetuned-conll03-english",
     )
     parser.add_argument(
         "--es-model-id",
         required=False,
         default=None,
         help="The model ID to use in Elasticsearch, "
-             "e.g. bert-large-cased-finetuned-conll03-english."
-             "When left unspecified, this will be auto-created from the `hub-id`",
+        "e.g. bert-large-cased-finetuned-conll03-english."
+        "When left unspecified, this will be auto-created from the `hub-id`",
     )
     parser.add_argument(
-        "-u", "--es-username",
+        "-u",
+        "--es-username",
         required=False,
         default=os.environ.get("ES_USERNAME"),
-        help="Username for Elasticsearch"
+        help="Username for Elasticsearch",
     )
     parser.add_argument(
-        "-p", "--es-password",
+        "-p",
+        "--es-password",
         required=False,
         default=os.environ.get("ES_PASSWORD"),
-        help="Password for the Elasticsearch user specified with -u/--username"
+        help="Password for the Elasticsearch user specified with -u/--username",
     )
     parser.add_argument(
         "--es-api-key",
         required=False,
         default=os.environ.get("ES_API_KEY"),
-        help="API key for Elasticsearch"
+        help="API key for Elasticsearch",
     )
     parser.add_argument(
         "--task-type",
         required=False,
         choices=SUPPORTED_TASK_TYPES,
-        help="The task type for the model usage. Will attempt to auto-detect task type for the model if not provided. "
-             "Default: auto",
-        default="auto"
+        help="The task type for the model usage. Will attempt to auto-detect task "
+        "type for the model if not provided. Default: auto",
+        default="auto",
     )
     parser.add_argument(
         "--quantize",
@@ -110,48 +113,47 @@ def get_arg_parser():
         "--clear-previous",
         action="store_true",
         default=False,
-        help="Should the model previously stored with `es-model-id` be deleted"
+        help="Should the model previously stored with `es-model-id` be deleted",
     )
     parser.add_argument(
         "--insecure",
         action="store_false",
         default=True,
-        help="Do not verify SSL certificates"
+        help="Do not verify SSL certificates",
     )
     parser.add_argument(
-        "--ca-certs",
-        required=False,
-        default=DEFAULT,
-        help="Path to CA bundle"
+        "--ca-certs", required=False, default=DEFAULT, help="Path to CA bundle"
     )
 
     return parser
 
 
-def get_es_client(cli_args):
+def get_es_client(cli_args, logger):
     try:
         es_args = {
-            'request_timeout': 300,
-            'verify_certs': cli_args.insecure,
-            'ca_certs': cli_args.ca_certs
+            "request_timeout": 300,
+            "verify_certs": cli_args.insecure,
+            "ca_certs": cli_args.ca_certs,
         }
 
         # Deployment location
         if cli_args.url:
-            es_args['hosts'] = cli_args.url
+            es_args["hosts"] = cli_args.url
 
         if cli_args.cloud_id:
-            es_args['cloud_id'] = cli_args.cloud_id
+            es_args["cloud_id"] = cli_args.cloud_id
 
         # Authentication
         if cli_args.es_api_key:
-            es_args['api_key'] = cli_args.es_api_key
+            es_args["api_key"] = cli_args.es_api_key
         elif cli_args.es_username:
             if not cli_args.es_password:
-                logging.error(f"Password for user {cli_args.es_username} was not specified.")
+                logging.error(
+                    f"Password for user {cli_args.es_username} was not specified."
+                )
                 exit(1)
 
-            es_args['basic_auth'] = (cli_args.es_username, cli_args.es_password)
+            es_args["basic_auth"] = (cli_args.es_username, cli_args.es_password)
 
         es_client = Elasticsearch(**es_args)
         return es_client
@@ -160,23 +162,33 @@ def get_es_client(cli_args):
         exit(1)
 
 
-def check_cluster_version(es_client):
+def check_cluster_version(es_client, logger):
     es_info = es_client.info()
-    logger.info(f"Connected to cluster named '{es_info['cluster_name']}' (version: {es_info['version']['number']})")
+    logger.info(
+        f"Connected to cluster named '{es_info['cluster_name']}' "
+        f"(version: {es_info['version']['number']})"
+    )
 
-    sem_ver = parse_es_version(es_info['version']['number'])
+    sem_ver = parse_es_version(es_info["version"]["number"])
     major_version = sem_ver[0]
     minor_version = sem_ver[1]
 
     # NLP models added in 8
     if major_version < 8:
-        logger.error(f"Elasticsearch version {major_version} does not support NLP models. Please upgrade Elasticsearch to the latest version")
+        logger.error(
+            f"Elasticsearch version {major_version} does not support NLP models. "
+            "Please upgrade Elasticsearch to the latest version"
+        )
         exit(1)
 
     # PyTorch was upgraded to version 1.13.1 in 8.7.
     # and is incompatible with earlier versions
     if major_version == 8 and minor_version < 7:
-        logger.error(f"Eland uses PyTorch version {torch.__version__} which is incompatible with Elasticsearch versions prior to 8.7. Please upgrade Elasticsearch to at least version 8.7")
+        logger.error(
+            f"Eland uses PyTorch version {torch.__version__} which is incompatible "
+            "with Elasticsearch versions prior to 8.7. Please upgrade Elasticsearch "
+            "to at least version 8.7"
+        )
         exit(1)
 
     return sem_ver
@@ -184,7 +196,7 @@ def check_cluster_version(es_client):
 
 def main():
     # Configure logging
-    logging.basicConfig(format='%(asctime)s %(levelname)s : %(message)s')
+    logging.basicConfig(format="%(asctime)s %(levelname)s : %(message)s")
     logger = logging.getLogger(__name__)
     logger.setLevel(logging.INFO)
 
@@ -196,36 +208,59 @@ def main():
             TransformerModel,
         )
     except ModuleNotFoundError as e:
-        logger.error(textwrap.dedent(f"""\
-            \033[31mFailed to run because module '{e.name}' is not available.\033[0m
-            
-            This script requires PyTorch extras to run. You can install these by running:
-            
-                \033[1m{sys.executable} -m pip install 'eland[pytorch]'
-            \033[0m"""))
+        logger.error(
+            textwrap.dedent(
+                f"""\
+                \033[31mFailed to run because module '{e.name}' is not available.\033[0m
+
+                This script requires PyTorch extras to run. You can install these by running:
+
+                    \033[1m{sys.executable} -m pip install 'eland[pytorch]'
+                \033[0m"""
+            )
+        )
         exit(1)
+    else:
+        assert SUPPORTED_TASK_TYPES
 
     # Parse arguments
     args = get_arg_parser().parse_args()
 
     # Connect to ES
     logger.info("Establishing connection to Elasticsearch")
-    es = get_es_client(args)
-    cluster_version = check_cluster_version(es)
+    es = get_es_client(args, logger)
+    cluster_version = check_cluster_version(es, logger)
 
     # Trace and save model, then upload it from temp file
     with tempfile.TemporaryDirectory() as tmp_dir:
-        logger.info(f"Loading HuggingFace transformer tokenizer and model '{args.hub_model_id}'")
+        logger.info(
+            f"Loading HuggingFace transformer tokenizer and model '{args.hub_model_id}'"
+        )
 
         try:
-            tm = TransformerModel(model_id=args.hub_model_id, task_type=args.task_type, es_version=cluster_version, quantize=args.quantize)
+            tm = TransformerModel(
+                model_id=args.hub_model_id,
+                task_type=args.task_type,
+                es_version=cluster_version,
+                quantize=args.quantize,
+            )
             model_path, config, vocab_path = tm.save(tmp_dir)
         except TaskTypeError as err:
-            logger.error(f"Failed to get model for task type, please provide valid task type via '--task-type' parameter. Caused by {err}")
+            logger.error(
+                "Failed to get model for task type, please provide valid task type "
+                f"via '--task-type' parameter. Caused by {err}"
+            )
             exit(1)
 
-        ptm = PyTorchModel(es, args.es_model_id if args.es_model_id else tm.elasticsearch_model_id())
-        model_exists = es.options(ignore_status=404).ml.get_trained_models(model_id=ptm.model_id).meta.status == 200
+        ptm = PyTorchModel(
+            es, args.es_model_id if args.es_model_id else tm.elasticsearch_model_id()
+        )
+        model_exists = (
+            es.options(ignore_status=404)
+            .ml.get_trained_models(model_id=ptm.model_id)
+            .meta.status
+            == 200
+        )
 
         if model_exists:
             if args.clear_previous:
@@ -236,21 +271,24 @@ def main():
                 ptm.delete()
             else:
                 logger.error(f"Trained model with id '{ptm.model_id}' already exists")
-                logger.info("Run the script with the '--clear-previous' flag if you want to overwrite the existing model.")
+                logger.info(
+                    "Run the script with the '--clear-previous' flag if you want to "
+                    "overwrite the existing model."
+                )
                 exit(1)
 
         logger.info(f"Creating model with id '{ptm.model_id}'")
         ptm.put_config(config=config)
 
-        logger.info(f"Uploading model definition")
+        logger.info("Uploading model definition")
         ptm.put_model(model_path)
 
-        logger.info(f"Uploading model vocabulary")
+        logger.info("Uploading model vocabulary")
         ptm.put_vocab(vocab_path)
 
     # Start the deployed model
     if args.start:
-        logger.info(f"Starting model deployment")
+        logger.info("Starting model deployment")
         ptm.start()
 
     logger.info(f"Model successfully imported with id '{ptm.model_id}'")

--- a/eland/cli/eland_import_hub_model.py
+++ b/eland/cli/eland_import_hub_model.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-
 #  Licensed to Elasticsearch B.V. under one or more contributor
 #  license agreements. See the NOTICE file distributed with
 #  this work for additional information regarding copyright

--- a/eland/ml/pytorch/transformers.py
+++ b/eland/ml/pytorch/transformers.py
@@ -494,7 +494,7 @@ class _TransformerTraceableModel(TraceableModel):
 class _TraceableClassificationModel(_TransformerTraceableModel, ABC):
     def classification_labels(self) -> Optional[List[str]]:
         id_label_items = self._model.config.id2label.items()
-        labels = [v for _, v in sorted(id_label_items, key=lambda kv: kv[0])]  # type: ignore
+        labels = [v for _, v in sorted(id_label_items, key=lambda kv: kv[0])]
 
         # Make classes like I-PER into I_PER which fits Java enumerations
         return [label.replace("-", "_") for label in labels]
@@ -636,7 +636,7 @@ class TransformerModel:
 
     def _load_vocab(self) -> Dict[str, List[str]]:
         vocab_items = self._tokenizer.get_vocab().items()
-        vocabulary = [k for k, _ in sorted(vocab_items, key=lambda kv: kv[1])]  # type: ignore
+        vocabulary = [k for k, _ in sorted(vocab_items, key=lambda kv: kv[1])]
         vocab_obj = {
             "vocabulary": vocabulary,
         }

--- a/noxfile.py
+++ b/noxfile.py
@@ -22,7 +22,7 @@ from pathlib import Path
 import nox
 
 BASE_DIR = Path(__file__).parent
-SOURCE_FILES = ("setup.py", "noxfile.py", "eland/", "docs/", "utils/", "tests/", "bin/")
+SOURCE_FILES = ("setup.py", "noxfile.py", "eland/", "docs/", "utils/", "tests/")
 
 # Whenever type-hints are completed on a file it should
 # be added here so that this file will continue to be checked

--- a/setup.py
+++ b/setup.py
@@ -88,8 +88,8 @@ setup(
         "numpy>=1.2.0,<1.24",
     ],
     entry_points={
-        "console_scripts": ("eland_import_hub_model="
-                            "eland.cli.eland_import_hub_model:main")
+        "console_scripts": "eland_import_hub_model="
+        "eland.cli.eland_import_hub_model:main"
     },
     python_requires=">=3.8",
     package_data={"eland": ["py.typed"]},

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,10 @@ setup(
         "matplotlib>=3.6",
         "numpy>=1.2.0,<1.24",
     ],
-    scripts=["bin/eland_import_hub_model"],
+    entry_points={
+        "console_scripts": ("eland_import_hub_model="
+                            "eland.cli.eland_import_hub_model:main")
+    },
     python_requires=">=3.8",
     package_data={"eland": ["py.typed"]},
     include_package_data=True,


### PR DESCRIPTION
Fixes #551.

- Make `python -m eland` available on all platforms.
- Make `eland_import_hub_model` executable on Windows.

**On Windows**:
```console
C:\Users\YouheiSakurai\git\myeland>python -m eland --help
usage: __main__.py [-h] (--url URL | --cloud-id CLOUD_ID) --hub-model-id HUB_MODEL_ID [--es-model-id ES_MODEL_ID]
                   [-u ES_USERNAME] [-p ES_PASSWORD] [--es-api-key ES_API_KEY]
...


C:\Users\YouheiSakurai\git\myeland>eland_import_hub_model --help
usage: eland_import_hub_model [-h] (--url URL | --cloud-id CLOUD_ID) --hub-model-id HUB_MODEL_ID
                              [--es-model-id ES_MODEL_ID] [-u ES_USERNAME] [-p ES_PASSWORD] [--es-api-key ES_API_KEY]
...

C:\Users\YouheiSakurai\git\myeland>where eland_import_hub_model
C:\Users\YouheiSakurai\AppData\Roaming\Python\Python311\Scripts\eland_import_hub_model.exe
```

**On Linux**
```console
root@3907c10cff9f:/# python -m eland --help
usage: __main__.py [-h] (--url URL | --cloud-id CLOUD_ID) --hub-model-id HUB_MODEL_ID [--es-model-id ES_MODEL_ID]
...

root@3907c10cff9f:/# eland_import_hub_model --help
usage: eland_import_hub_model [-h] (--url URL | --cloud-id CLOUD_ID) --hub-model-id HUB_MODEL_ID
...

root@3907c10cff9f:/# which eland_import_hub_model
/usr/local/bin/eland_import_hub_model

root@3907c10cff9f:/# file /usr/local/bin/eland_import_hub_model
/usr/local/bin/eland_import_hub_model: Python script, ASCII text executable
```
