### PR TITLE
[ML] Better memory estimation for NLP models

### DIFF
--- a/.buildkite/run-elasticsearch.sh
+++ b/.buildkite/run-elasticsearch.sh
@@ -16,7 +16,12 @@ fi
 
 set -euxo pipefail
 
-SCRIPT_PATH=$(dirname $(realpath -s $0))
+# realpath on MacOS use different flags than on Linux
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  SCRIPT_PATH=$(dirname $(realpath $0))
+else 
+  SCRIPT_PATH=$(dirname $(realpath -s $0))
+fi
 
 moniker=$(echo "$ELASTICSEARCH_VERSION" | tr -C "[:alnum:]" '-')
 suffix=rest-test
@@ -132,7 +137,7 @@ url="http://elastic:$ELASTIC_PASSWORD@$NODE_NAME"
 docker_pull_attempts=0
 until [ "$docker_pull_attempts" -ge 5 ]
 do
-   docker pull docker.elastic.co/elasticsearch/"$ELASTICSEARCH_VERSION" && break
+   docker pull docker.elastic.co/elasticsearch/$ELASTICSEARCH_VERSION && break
    docker_pull_attempts=$((docker_pull_attempts+1))
    sleep 10
 done

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -169,7 +169,7 @@ currently using a minimum version of PyCharm 2019.2.4.
 * Setup Elasticsearch instance with docker
 
     ``` bash
-    > ELASTICSEARCH_VERSION=elasticsearch:7.x-SNAPSHOT .ci/run-elasticsearch.sh
+    > ELASTICSEARCH_VERSION=elasticsearch:8.x-SNAPSHOT BUILDKITE=false .buildkite/run-elasticsearch.sh
     ```
 
 * Now check `http://localhost:9200`

--- a/eland/ml/pytorch/traceable_model.py
+++ b/eland/ml/pytorch/traceable_model.py
@@ -66,3 +66,7 @@ class TraceableModel(ABC):
         trace_model = torch.jit.freeze(trace_model)
         torch.jit.save(trace_model, model_path)
         return model_path
+    
+    @property
+    def model(self) -> nn.Module:
+        return self._model

--- a/eland/ml/pytorch/traceable_model.py
+++ b/eland/ml/pytorch/traceable_model.py
@@ -66,7 +66,7 @@ class TraceableModel(ABC):
         trace_model = torch.jit.freeze(trace_model)
         torch.jit.save(trace_model, model_path)
         return model_path
-    
+
     @property
     def model(self) -> nn.Module:
         return self._model

--- a/eland/ml/pytorch/transformers.py
+++ b/eland/ml/pytorch/transformers.py
@@ -21,7 +21,6 @@ libraries such as sentence-transformers.
 """
 
 import json
-import logging
 import os.path
 import random
 import re
@@ -63,8 +62,6 @@ from eland.ml.pytorch.nlp_ml_model import (
     ZeroShotClassificationInferenceOptions,
 )
 from eland.ml.pytorch.traceable_model import TraceableModel
-
-logger = logging.getLogger(__name__)
 
 DEFAULT_OUTPUT_KEY = "sentence_embedding"
 SUPPORTED_TASK_TYPES = {

--- a/eland/ml/pytorch/transformers.py
+++ b/eland/ml/pytorch/transformers.py
@@ -813,16 +813,14 @@ class TransformerModel:
         )
         return (psize + bsize) / 1024**2  # in MB
 
-    def _get_transient_memory(
-        self, max_seq_length: int, batch_size: int
-    ) -> float:
+    def _get_transient_memory(self, max_seq_length: int, batch_size: int) -> float:
         """
         Returns the transient memory size of the model in MB.
 
         Parameters
         ----------
         max_seq_length : Optional[int]
-            Maximum sequence length to use for the model. 
+            Maximum sequence length to use for the model.
         batch_size : int
             Batch size to use for the model.
         """

--- a/eland/ml/pytorch/transformers.py
+++ b/eland/ml/pytorch/transformers.py
@@ -831,7 +831,9 @@ class TransformerModel:
             self._traceable_model.model(**inputs_1)
         mem1 = prof.key_averages().total_average().cpu_memory_usage / 1024**2
 
-        # Get the memory usage of the model with a batch size of 2.
+        # This is measuring memory usage of the model with a batch size of 2 and 
+        # then linearly extrapolating it to get the memory usage of the model for 
+        # a batch size of batch_size.
         if batch_size == 1:
             return mem1  # in MB
         else:

--- a/eland/ml/pytorch/transformers.py
+++ b/eland/ml/pytorch/transformers.py
@@ -815,7 +815,7 @@ class TransformerModel:
             buffer.nelement() * buffer.element_size()
             for buffer in self._traceable_model.model.buffers()
         )
-        return (psize + bsize) 
+        return psize + bsize
 
     def _get_transient_memory(self, max_seq_length: int, batch_size: int) -> float:
         """
@@ -834,19 +834,19 @@ class TransformerModel:
         inputs_1 = self._get_model_inputs(max_seq_length, 1)
         with profile(activities=activities, profile_memory=True) as prof:
             self._traceable_model.model(**inputs_1)
-        mem1 = prof.key_averages().total_average().cpu_memory_usage 
+        mem1 = prof.key_averages().total_average().cpu_memory_usage
 
-        # This is measuring memory usage of the model with a batch size of 2 and 
-        # then linearly extrapolating it to get the memory usage of the model for 
+        # This is measuring memory usage of the model with a batch size of 2 and
+        # then linearly extrapolating it to get the memory usage of the model for
         # a batch size of batch_size.
         if batch_size == 1:
-            return mem1  
+            return mem1
         else:
             inputs_2 = self._get_model_inputs(max_seq_length, 2)
             with profile(activities=activities, profile_memory=True) as prof:
                 self._traceable_model.model(**inputs_2)
-            mem2 = prof.key_averages().total_average().cpu_memory_usage 
-            return mem1 + (mem2 - mem1) * (batch_size - 1)  
+            mem2 = prof.key_averages().total_average().cpu_memory_usage
+            return mem1 + (mem2 - mem1) * (batch_size - 1)
 
     def _get_peak_memory(self, size_model_mb: float, transient: float) -> float:
         """

--- a/eland/ml/pytorch/transformers.py
+++ b/eland/ml/pytorch/transformers.py
@@ -25,14 +25,13 @@ import os.path
 import random
 import re
 from abc import ABC, abstractmethod
-from functools import partial
-from math import trunc
-from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union
+from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
 import torch  # type: ignore
 import transformers  # type: ignore
 from sentence_transformers import SentenceTransformer  # type: ignore
 from torch import Tensor, nn
+from torch.profiler import profile
 from transformers import (
     AutoConfig,
     AutoModel,

--- a/eland/ml/pytorch/transformers.py
+++ b/eland/ml/pytorch/transformers.py
@@ -773,20 +773,15 @@ class TransformerModel:
             )
 
         # add static and dynamic memory state size to metadata
-        static_memory_size = self._get_model_memory(self._traceable_model._model)
+        static_memory_size = self._get_model_memory()
 
-        get_inputs = partial(
-            self._get_model_inputs,
-            self._traceable_model._model,
-            self._tokenizer,
-            tokenization_config.max_sequence_length,
-        )
         transient_memory_size = self._get_transient_memory(
-            self._traceable_model._model, get_inputs, 1
+            tokenization_config.max_sequence_length, 1
         )
         peak_memory_size = self._get_peak_memory(
             static_memory_size, transient_memory_size
         )
+        # TODO: final field names are subject to change
         metadata = {
             "static_memory_size": static_memory_size,
             "transient_memory_size": transient_memory_size,
@@ -800,65 +795,95 @@ class TransformerModel:
             input=TrainedModelInput(
                 field_names=["text_field"],
             ),
+            # TODO: uncomment this line once memory metadata is supported by ES
+            # metadata=metadata,
         )
 
-    def _get_model_memory(self, model: nn.Module) -> float:
+    def _get_model_memory(self) -> float:
+        """
+        Returns the static memory size of the model in MB.
+        """
         psize = sum(
-            param.nelement() * param.element_size() for param in model.parameters()
+            param.nelement() * param.element_size()
+            for param in self._traceable_model.model.parameters()
         )
         bsize = sum(
-            buffer.nelement() * buffer.element_size() for buffer in model.buffers()
+            buffer.nelement() * buffer.element_size()
+            for buffer in self._traceable_model.model.buffers()
         )
         return (psize + bsize) / 1024**2  # in MB
 
     def _get_transient_memory(
-        self, model: nn.Module, get_inputs: Callable, batch_size: int
+        self, max_seq_length: int, batch_size: int
     ) -> float:
-        batch_1 = get_inputs(1)
-        batch_2 = get_inputs(2)
+        """
+        Returns the transient memory size of the model in MB.
 
+        Parameters
+        ----------
+        max_seq_length : Optional[int]
+            Maximum sequence length to use for the model. 
+        batch_size : int
+            Batch size to use for the model.
+        """
         activities = [torch.profiler.ProfilerActivity.CPU]
-        prepared_inputs_1 = self._tokenizer(
-            batch_1["t"], padding="max_length", return_tensors="pt", truncation=True
-        )
 
+        # Get the memory usage of the model with a batch size of 1.
+        inputs_1 = self._get_model_inputs(max_seq_length, 1)
         with profile(activities=activities, profile_memory=True) as prof:
-            model(**prepared_inputs_1)
+            self._traceable_model.model(**inputs_1)
         mem1 = prof.key_averages().total_average().cpu_memory_usage / 1024**2
 
+        # Get the memory usage of the model with a batch size of 2.
         if batch_size == 1:
             return mem1  # in MB
-
-        prepared_inputs_2 = self._tokenizer(
-            batch_2["t"], padding="max_length", return_tensors="pt", truncation=True
-        )
-        with profile(activities=activities, profile_memory=True) as prof:
-            model(prepared_inputs_2)
-        mem2 = prof.key_averages().total_average().cpu_memory_usage / 1024**2
-
-        return mem1 + (mem2 - mem1) * (batch_size - 1)  # in MB
+        else:
+            inputs_2 = self._get_model_inputs(max_seq_length, 2)
+            with profile(activities=activities, profile_memory=True) as prof:
+                self._traceable_model.model(**inputs_2)
+            mem2 = prof.key_averages().total_average().cpu_memory_usage / 1024**2
+            return mem1 + (mem2 - mem1) * (batch_size - 1)  # in MB
 
     def _get_peak_memory(self, size_model_mb: float, transient: float) -> float:
         return max(2 * size_model_mb, size_model_mb + transient)
 
     def _get_model_inputs(
         self,
-        model: nn.Module,
-        tokenizer: PreTrainedTokenizerFast,
         max_length: Optional[int],
         batch_size: int,
     ) -> Dict[str, List[str]]:
-        vocab: list[str] = list(tokenizer.get_vocab().keys())
+        """
+        Returns a random batch of inputs for the model.
+
+        Parameters
+        ----------
+        max_length : Optional[int]
+            Maximum sequence length to use for the model. Default is 512.
+        batch_size : int
+            Batch size to use for the model.
+        """
+        vocab: list[str] = list(self._tokenizer.get_vocab().keys())
 
         # if optional max_length is not set, set it to 512
         if max_length is None:
             max_length = 512
 
-        inputs: list[str] = [
+        # generate random text
+        texts: list[str] = [
             " ".join(random.choices(vocab, k=max_length)) for _ in range(batch_size)
         ]
 
-        return {"t": inputs}  # TODO: there should be a different key
+        # tokenize text
+        inputs = self._tokenizer(
+            texts, padding="max_length", return_tensors="pt", truncation=True
+        )
+
+        # add position_ids
+        if not isinstance(self._tokenizer, transformers.DistilBertTokenizer):
+            position_ids = torch.arange(inputs["input_ids"].size(1), dtype=torch.long)
+            inputs["position_ids"] = position_ids
+
+        return inputs
 
     def _create_traceable_model(self) -> _TransformerTraceableModel:
         if self._task_type == "auto":

--- a/tests/ml/pytorch/test_pytorch_model_config_pytest.py
+++ b/tests/ml/pytorch/test_pytorch_model_config_pytest.py
@@ -173,6 +173,15 @@ class TestModelConfguration:
             assert ["text_field"] == config.input.field_names
             assert isinstance(config.inference_config, config_type)
             tokenization = config.inference_config.tokenization
+            assert isinstance(config.metadata, dict)
+            assert (
+                "per_deployment_memory_bytes" in config.metadata
+                and config.metadata["per_deployment_memory_bytes"] > 0
+            )
+            assert (
+                "per_allocation_memory_bytes" in config.metadata
+                and config.metadata["per_allocation_memory_bytes"] > 0
+            )
             assert isinstance(tokenization, tokenizer_type)
             assert max_sequence_len == tokenization.max_sequence_length
 

--- a/tests/ml/pytorch/test_pytorch_model_upload_pytest.py
+++ b/tests/ml/pytorch/test_pytorch_model_upload_pytest.py
@@ -126,9 +126,11 @@ class TestPytorchModel:
     @pytest.mark.parametrize("model_id,task,text_input,value", TEXT_PREDICTION_MODELS)
     def test_text_prediction(self, model_id, task, text_input, value, quantize):
         with tempfile.TemporaryDirectory() as tmp_dir:
-            ptm = download_model_and_start_deployment(tmp_dir, quantize, model_id, task)
-            results = ptm.infer(docs=[{"text_field": text_input}])
-            assert results.body["inference_results"][0]["predicted_value"] == value
+            ptm = download_model_and_start_deployment(
+                tmp_dir, self.quantize, model_id, task
+            )
+            result = ptm.infer(docs=[{"text_field": text_input}])
+            assert result['inference_results'][0]['predicted_value'] == value
 
     @pytest.mark.parametrize("model_id,task,text_input", TEXT_EMBEDDING_MODELS)
     def test_text_embedding(self, model_id, task, text_input, quantize):

--- a/tests/ml/pytorch/test_pytorch_model_upload_pytest.py
+++ b/tests/ml/pytorch/test_pytorch_model_upload_pytest.py
@@ -112,6 +112,17 @@ def download_model_and_start_deployment(tmp_dir, quantize, model_id, task):
 
 
 class TestPytorchModel:
+    @property
+    def quantize(self) -> bool: 
+        # quantization does not work on ARM processors
+        # TODO: It seems that PyTorch 2.0 supports OneDNN for aarch64. We should
+        # revisit this when we upgrade to PyTorch 2.0.
+        import platform
+
+        return (
+            True if platform.machine() not in ["arm64", "aarch64"] else False
+        )
+
     @pytest.mark.parametrize("model_id,task,text_input,value", TEXT_PREDICTION_MODELS)
     def test_text_prediction(self, model_id, task, text_input, value, quantize):
         with tempfile.TemporaryDirectory() as tmp_dir:

--- a/tests/ml/pytorch/test_pytorch_model_upload_pytest.py
+++ b/tests/ml/pytorch/test_pytorch_model_upload_pytest.py
@@ -112,21 +112,12 @@ def download_model_and_start_deployment(tmp_dir, quantize, model_id, task):
 
 
 class TestPytorchModel:
-    # @property
-    # def quantize(self) -> bool:
-    #     # quantization does not work on ARM processors
-    #     # TODO: It seems that PyTorch 2.0 supports OneDNN for aarch64. We should
-    #     # revisit this when we upgrade to PyTorch 2.0.
-    #     import platform
-
-    #     return True if platform.machine() not in ["arm64", "aarch64"] else False
-
     @pytest.mark.parametrize("model_id,task,text_input,value", TEXT_PREDICTION_MODELS)
     def test_text_prediction(self, model_id, task, text_input, value, quantize):
         with tempfile.TemporaryDirectory() as tmp_dir:
             ptm = download_model_and_start_deployment(tmp_dir, quantize, model_id, task)
-            result = ptm.infer(docs=[{"text_field": text_input}])
-            assert result["inference_results"][0]["predicted_value"] == value
+            results = ptm.infer(docs=[{"text_field": text_input}])
+            assert results.body["inference_results"][0]["predicted_value"] == value
 
     @pytest.mark.parametrize("model_id,task,text_input", TEXT_EMBEDDING_MODELS)
     def test_text_embedding(self, model_id, task, text_input, quantize):

--- a/tests/ml/pytorch/test_pytorch_model_upload_pytest.py
+++ b/tests/ml/pytorch/test_pytorch_model_upload_pytest.py
@@ -113,15 +113,13 @@ def download_model_and_start_deployment(tmp_dir, quantize, model_id, task):
 
 class TestPytorchModel:
     @property
-    def quantize(self) -> bool: 
+    def quantize(self) -> bool:
         # quantization does not work on ARM processors
         # TODO: It seems that PyTorch 2.0 supports OneDNN for aarch64. We should
         # revisit this when we upgrade to PyTorch 2.0.
         import platform
 
-        return (
-            True if platform.machine() not in ["arm64", "aarch64"] else False
-        )
+        return True if platform.machine() not in ["arm64", "aarch64"] else False
 
     @pytest.mark.parametrize("model_id,task,text_input,value", TEXT_PREDICTION_MODELS)
     def test_text_prediction(self, model_id, task, text_input, value, quantize):
@@ -130,7 +128,7 @@ class TestPytorchModel:
                 tmp_dir, self.quantize, model_id, task
             )
             result = ptm.infer(docs=[{"text_field": text_input}])
-            assert result['inference_results'][0]['predicted_value'] == value
+            assert result["inference_results"][0]["predicted_value"] == value
 
     @pytest.mark.parametrize("model_id,task,text_input", TEXT_EMBEDDING_MODELS)
     def test_text_embedding(self, model_id, task, text_input, quantize):

--- a/tests/ml/pytorch/test_pytorch_model_upload_pytest.py
+++ b/tests/ml/pytorch/test_pytorch_model_upload_pytest.py
@@ -112,21 +112,19 @@ def download_model_and_start_deployment(tmp_dir, quantize, model_id, task):
 
 
 class TestPytorchModel:
-    @property
-    def quantize(self) -> bool:
-        # quantization does not work on ARM processors
-        # TODO: It seems that PyTorch 2.0 supports OneDNN for aarch64. We should
-        # revisit this when we upgrade to PyTorch 2.0.
-        import platform
+    # @property
+    # def quantize(self) -> bool:
+    #     # quantization does not work on ARM processors
+    #     # TODO: It seems that PyTorch 2.0 supports OneDNN for aarch64. We should
+    #     # revisit this when we upgrade to PyTorch 2.0.
+    #     import platform
 
-        return True if platform.machine() not in ["arm64", "aarch64"] else False
+    #     return True if platform.machine() not in ["arm64", "aarch64"] else False
 
     @pytest.mark.parametrize("model_id,task,text_input,value", TEXT_PREDICTION_MODELS)
     def test_text_prediction(self, model_id, task, text_input, value, quantize):
         with tempfile.TemporaryDirectory() as tmp_dir:
-            ptm = download_model_and_start_deployment(
-                tmp_dir, self.quantize, model_id, task
-            )
+            ptm = download_model_and_start_deployment(tmp_dir, quantize, model_id, task)
             result = ptm.infer(docs=[{"text_field": text_input}])
             assert result["inference_results"][0]["predicted_value"] == value
 


### PR DESCRIPTION
This PR adds an ability to estimate per deployment and per allocation memory usage of NLP transformer models. It uses `torch.profiler` and performs logs the peak memory usage during the inference.

This information is then used in Elasticsearch to provision models with sufficient memory (elastic/elasticsearch#98874). 