### PR TITLE
Use the workaround if we can't determine the server's version

### DIFF
--- a/eland/field_mappings.py
+++ b/eland/field_mappings.py
@@ -948,10 +948,12 @@ def _compat_field_caps(client, fields, index=None):
     # If we lack sufficient permission to determine the Elasticsearch version,
     # to be sure we use the workaround for versions smaller than 8.5.0
     except elasticsearch.AuthorizationException as e:
-        raise RuntimeWarning("Couldn't determine Elasticsearch host's version. "
-                             "Probably missing monitor/main permissions. "
-                             "Continuing with the query string work-around. "
-                             "Original exception: " + str(e))
+        raise RuntimeWarning(
+            "Couldn't determine Elasticsearch host's version. "
+            "Probably missing monitor/main permissions. "
+            "Continuing with the query string work-around. "
+            "Original exception: " + str(e)
+        )
         elastic_version = None
     if elastic_version and elastic_version >= (8, 5, 0):
         return client.field_caps(index=index, fields=fields)

--- a/eland/field_mappings.py
+++ b/eland/field_mappings.py
@@ -30,6 +30,7 @@ from typing import (
     Union,
 )
 
+import elasticsearch
 import numpy as np
 import pandas as pd  # type: ignore
 from pandas.core.dtypes.common import (  # type: ignore

--- a/eland/field_mappings.py
+++ b/eland/field_mappings.py
@@ -947,7 +947,11 @@ def _compat_field_caps(client, fields, index=None):
         elastic_version = es_version(client)
     # If we lack sufficient permission to determine the Elasticsearch version,
     # to be sure we use the workaround for versions smaller than 8.5.0
-    except elasticsearch.AuthorizationException:
+    except elasticsearch.AuthorizationException as e:
+        raise RuntimeWarning("Couldn't determine Elasticsearch host's version. "
+                             "Probably missing monitor/main permissions. "
+                             "Continuing with the query string work-around. "
+                             "Original exception: " + str(e))
         elastic_version = None
     if elastic_version and elastic_version >= (8, 5, 0):
         return client.field_caps(index=index, fields=fields)

--- a/eland/field_mappings.py
+++ b/eland/field_mappings.py
@@ -942,7 +942,13 @@ def _compat_field_caps(client, fields, index=None):
     # If the server version is 8.5.0 or later we don't need
     # the query string work-around. Sending via any client
     # version should be just fine.
-    if es_version(client) >= (8, 5, 0):
+    try:
+        elastic_version = es_version(client)
+    # If we lack sufficient permission to determine the Elasticsearch version,
+    # to be sure we use the workaround for versions smaller than 8.5.0
+    except elasticsearch.AuthorizationException:
+        elastic_version = None
+    if elastic_version and elastic_version >= (8, 5, 0):
         return client.field_caps(index=index, fields=fields)
 
     # Otherwise we need to force sending via the query string.

--- a/eland/field_mappings.py
+++ b/eland/field_mappings.py
@@ -952,7 +952,7 @@ def _compat_field_caps(client, fields, index=None):
             "Couldn't determine Elasticsearch host's version. "
             "Probably missing monitor/main permissions. "
             "Continuing with the query string work-around. "
-            "Original exception: " + str(e)
+            "Original exception: " + repr(e)
         )
         elastic_version = None
     if elastic_version and elastic_version >= (8, 5, 0):


### PR DESCRIPTION
This is related to issue #580 

In some scenarios (a limited-scope API key, or maybe a corporate environment) a user of `eland` might not have enough permissions to determine the host's Elasticsearch version.

In that case, we could default to using the workaround, to be sure.