### PR TITLE
Fix README so that copy/pastes work without warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,10 +205,12 @@ libraries to be serialized and used as an inference model in Elasticsearch.
 ➤ [Read more about Machine Learning in Elasticsearch](https://www.elastic.co/guide/en/machine-learning/current/ml-getting-started.html)
 
 ```python
+>>> from sklearn import datasets
 >>> from xgboost import XGBClassifier
 >>> from eland.ml import MLModel
 
 # Train and exercise an XGBoost ML model locally
+>>> training_data = datasets.make_classification(n_features=5)
 >>> xgb_model = XGBClassifier(booster="gbtree")
 >>> xgb_model.fit(training_data[0], training_data[1])
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ from elasticsearch import Elasticsearch
 
 es = Elasticsearch(
     cloud_id="cluster-name:...",
-    http_auth=("elastic", "<password>")
+    basic_auth=("elastic", "<password>")
 )
 df = ed.DataFrame(es, es_index_pattern="flights")
 ```

--- a/README.md
+++ b/README.md
@@ -114,8 +114,8 @@ or a string containing the host to connect to:
 ```python
 import eland as ed
 
-# Connecting to an Elasticsearch instance running on 'localhost:9200'
-df = ed.DataFrame("localhost:9200", es_index_pattern="flights")
+# Connecting to an Elasticsearch instance running on 'http://localhost:9200'
+df = ed.DataFrame("http://localhost:9200", es_index_pattern="flights")
 
 # Connecting to an Elastic Cloud instance
 from elasticsearch import Elasticsearch
@@ -143,7 +143,7 @@ without overloading your machine.
 >>> import eland as ed
 
 >>> # Connect to 'flights' index via localhost Elasticsearch node
->>> df = ed.DataFrame('localhost:9200', 'flights')
+>>> df = ed.DataFrame('http://localhost:9200', 'flights')
 
 # eland.DataFrame instance has the same API as pandas.DataFrame
 # except all data is in Elasticsearch. See .info() memory usage.
@@ -217,7 +217,7 @@ libraries to be serialized and used as an inference model in Elasticsearch.
 
 # Import the model into Elasticsearch
 >>> es_model = MLModel.import_model(
-    es_client="localhost:9200",
+    es_client="http://localhost:9200",
     model_id="xgb-classifier",
     model=xgb_model,
     feature_names=["f0", "f1", "f2", "f3", "f4"],


### PR DESCRIPTION
 * Using `basic_auth` prints the following warning since elasticsearch-py 8.0:

    ```python
    DeprecationWarning: The 'http_auth' parameter is deprecated. Use 'basic_auth' or 'bearer_auth' parameters instead
    ```
* Using "localhost:9200" fails outright since elasticsearch-py 8.0. I wasn't sure if `http` or `https` should be used, but the rest of the repo uses `http`.

    ```python
    ValueError: URL must include a 'scheme', 'host', and 'port' component (ie 'https://localhost:9200')
    ```
* The XGBoost section assumes `training_data` exists: let's help users by creating it for them.