### PR TITLE
Update Docker image to Debian 12 Bookworm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
-FROM debian:bullseye-20230522
+FROM python:3-10-slim-bookworm@sha256:cc91315c3561d0b87d0525cb814d430cfbc70f10ca54577def184da80e87c1db
 
 RUN apt-get update && \
     apt-get install -y build-essential pkg-config cmake \
-                       python3-dev python3-pip python3-venv \
                        libzip-dev libjpeg-dev && \
     apt-get clean
 


### PR DESCRIPTION
Closes #585 

When upgrading to Debian 12 Bookworm, I've hit https://pythonspeed.com/articles/externally-managed-environment-pep-668/ and got Python 3.11 which isn't supported yet by Eland so I decided to use the Python 3.10 official image instead. It does not offer date-based tags, so I followed https://snyk.io/blog/best-practices-containerizing-python-docker/ and pinned using the sha256 digest instead.

I've used the README to test that this was still working, including:

 * Calling eland_import_hub_model to load elastic/distilbert-base-cased-finetuned-conll03-english on an Elastic Cloud cluster. I then started it on Kibana and tested that it worked as expected on short sentences.
 * Using the DataFrame API to reproduce the various examples.
 * Fitting a XGBoost classifier locally, importing it on Elasticsearch and getting the same values when calling predict() on that imported MLModel.