### PR TITLE
Fix downloads badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
   <a href="https://pypi.org/project/eland"><img src="https://img.shields.io/pypi/v/eland.svg" alt="PyPI Version"></a>
   <a href="https://anaconda.org/conda-forge/eland"><img src="https://img.shields.io/conda/vn/conda-forge/eland"
       alt="Conda Version"></a>
-  <a href="https://pepy.tech/project/eland"><img src="https://pepy.tech/badge/eland" alt="Downloads"></a>
+  <a href="https://pepy.tech/project/eland"><img src="https://static.pepy.tech/badge/eland" alt="Downloads"></a>
   <a href="https://pypi.org/project/eland"><img src="https://img.shields.io/pypi/status/eland.svg"
       alt="Package Status"></a>
   <a href="https://clients-ci.elastic.co/job/elastic+eland+main"><img


### PR DESCRIPTION
You can see the result here: https://github.com/pquentin/eland/tree/badge-url.