### PR TITLE
Revert "Update Docker image to Debian 12 Bookworm (#586)"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
-FROM python:3-10-slim-bookworm@sha256:cc91315c3561d0b87d0525cb814d430cfbc70f10ca54577def184da80e87c1db
+FROM debian:bullseye-20230522
 
 RUN apt-get update && \
     apt-get install -y build-essential pkg-config cmake \
+                       python3-dev python3-pip python3-venv \
                        libzip-dev libjpeg-dev && \
     apt-get clean
 


### PR DESCRIPTION
This reverts commit 0be509730a8d78d453fd7fb12149852c5552050f. It requires an up-to-date Docker/libseccomp version and breaks the image build for some users.

We can add this back when we start publishing an Eland Docker image.