### PR TITLE
Prepare for deprecation of is_datetime_or_timedelta_dtype in Pandas 2.0

### DIFF
--- a/eland/field_mappings.py
+++ b/eland/field_mappings.py
@@ -34,11 +34,11 @@ import numpy as np
 import pandas as pd  # type: ignore
 from pandas.core.dtypes.common import (  # type: ignore
     is_bool_dtype,
-    is_datetime64_any_dtype,
-    is_datetime_or_timedelta_dtype,
+    is_datetime64_dtype,
     is_float_dtype,
     is_integer_dtype,
     is_string_dtype,
+    is_timedelta64_dtype,
 )
 from pandas.core.dtypes.inference import is_list_like
 
@@ -86,7 +86,7 @@ class Field(NamedTuple):
 
     @property
     def is_timestamp(self) -> bool:
-        return is_datetime_or_timedelta_dtype(self.pd_dtype)
+        return is_datetime64_dtype(self.pd_dtype) or is_timedelta64_dtype(self.pd_dtype)
 
     @property
     def is_bool(self) -> bool:
@@ -506,9 +506,7 @@ class FieldMappings:
             es_dtype = "boolean"
         elif is_string_dtype(pd_dtype):
             es_dtype = "keyword"
-        elif is_datetime_or_timedelta_dtype(pd_dtype):
-            es_dtype = "date"
-        elif is_datetime64_any_dtype(pd_dtype):
+        elif is_timedelta64_dtype(pd_dtype) or is_datetime64_dtype(pd_dtype):
             es_dtype = "date"
         else:
             warnings.warn(
@@ -791,7 +789,9 @@ class FieldMappings:
                 pd_dtypes.append(np.dtype(pd_dtype))
                 es_field_names.append(es_field_name)
                 es_date_formats.append(es_date_format)
-            elif include_timestamp and is_datetime_or_timedelta_dtype(pd_dtype):
+            elif include_timestamp and (
+                is_datetime64_dtype(pd_dtype) or is_timedelta64_dtype(pd_dtype)
+            ):
                 pd_dtypes.append(np.dtype(pd_dtype))
                 es_field_names.append(es_field_name)
                 es_date_formats.append(es_date_format)

--- a/eland/field_mappings.py
+++ b/eland/field_mappings.py
@@ -34,7 +34,7 @@ import numpy as np
 import pandas as pd  # type: ignore
 from pandas.core.dtypes.common import (  # type: ignore
     is_bool_dtype,
-    is_datetime64_dtype,
+    is_datetime64_any_dtype,
     is_float_dtype,
     is_integer_dtype,
     is_string_dtype,
@@ -86,7 +86,9 @@ class Field(NamedTuple):
 
     @property
     def is_timestamp(self) -> bool:
-        return is_datetime64_dtype(self.pd_dtype) or is_timedelta64_dtype(self.pd_dtype)
+        return is_datetime64_any_dtype(self.pd_dtype) or is_timedelta64_dtype(
+            self.pd_dtype
+        )
 
     @property
     def is_bool(self) -> bool:
@@ -506,7 +508,9 @@ class FieldMappings:
             es_dtype = "boolean"
         elif is_string_dtype(pd_dtype):
             es_dtype = "keyword"
-        elif is_timedelta64_dtype(pd_dtype) or is_datetime64_dtype(pd_dtype):
+        elif is_timedelta64_dtype(pd_dtype):
+            es_dtype = "date"
+        elif is_datetime64_any_dtype(pd_dtype):
             es_dtype = "date"
         else:
             warnings.warn(
@@ -790,7 +794,7 @@ class FieldMappings:
                 es_field_names.append(es_field_name)
                 es_date_formats.append(es_date_format)
             elif include_timestamp and (
-                is_datetime64_dtype(pd_dtype) or is_timedelta64_dtype(pd_dtype)
+                is_datetime64_any_dtype(pd_dtype) or is_timedelta64_dtype(pd_dtype)
             ):
                 pd_dtypes.append(np.dtype(pd_dtype))
                 es_field_names.append(es_field_name)


### PR DESCRIPTION
I have been trying using `eland` with `pandas>2`. This is one of the minor changes I had to make to prepare for the removal of the `is_datetime_or_timedelta_dtype` utility.

More pull requests might be coming, but I try to keep them as small as possible.