### PR TITLE
Fix iteritems deprecation in pandas

### DIFF
--- a/eland/field_mappings.py
+++ b/eland/field_mappings.py
@@ -548,7 +548,7 @@ class FieldMappings:
                     f"{repr(non_existing_columns)[1:-1]} column(s) not in given dataframe"
                 )
 
-        for column, dtype in dataframe.dtypes.iteritems():
+        for column, dtype in dataframe.dtypes.items():
             if es_type_overrides is not None and column in es_type_overrides:
                 es_dtype = es_type_overrides[column]
                 if es_dtype == "text":


### PR DESCRIPTION
This PR fixes another of the more easy-to-squash deprecations for when `eland` might start supporting `pandas>=2.0.0`.