### PR TITLE
Remove deprecated check_less_precise

### DIFF
--- a/tests/series/test_arithmetics_pytest.py
+++ b/tests/series/test_arithmetics_pytest.py
@@ -74,7 +74,8 @@ class TestSeriesArithmetics(TestData):
             ed_series.__class__ = ModifiedElandSeries
 
             assert_pandas_eland_series_equal(
-                pd_series, ed_series, check_less_precise=True
+                pd_series, ed_series,
+                rtol=1e-3  # previously known as check_less_precise
             )
 
     def test_ecommerce_series_invalid_div(self):

--- a/tests/series/test_arithmetics_pytest.py
+++ b/tests/series/test_arithmetics_pytest.py
@@ -74,8 +74,9 @@ class TestSeriesArithmetics(TestData):
             ed_series.__class__ = ModifiedElandSeries
 
             assert_pandas_eland_series_equal(
-                pd_series, ed_series,
-                rtol=1e-3  # previously known as check_less_precise
+                pd_series,
+                ed_series,
+                rtol=1e-3,  # previously known as check_less_precise
             )
 
     def test_ecommerce_series_invalid_div(self):

--- a/tests/series/test_arithmetics_pytest.py
+++ b/tests/series/test_arithmetics_pytest.py
@@ -76,6 +76,7 @@ class TestSeriesArithmetics(TestData):
             assert_pandas_eland_series_equal(
                 pd_series,
                 ed_series,
+                check_exact=False,
                 rtol=1e-3,  # previously known as check_less_precise
             )
 


### PR DESCRIPTION
This removes the deprecated `check_less_precise` argument from one of the unit tests.

Part of the necessary adjustments to maybe start supporting `pandas>=2.0.0`