### PR TITLE
Start supporting Python 3.11

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -100,7 +100,7 @@ def lint(session):
             session.error("\n" + "\n".join(sorted(set(errors))))
 
 
-@nox.session(python=["3.8", "3.9", "3.10"])
+@nox.session(python=["3.8", "3.9", "3.10", "3.11"])
 @nox.parametrize("pandas_version", ["1.5.0"])
 def test(session, pandas_version: str):
     session.install("-r", "requirements-dev.txt")

--- a/noxfile.py
+++ b/noxfile.py
@@ -119,9 +119,6 @@ def test(session, pandas_version: str):
         "--nbval",
     )
 
-    # PyTorch doesn't support Python 3.11 yet
-    if session.python == "3.11":
-        pytest_args += ("--ignore=eland/ml/pytorch",)
     session.run(
         *pytest_args,
         *(session.posargs or ("eland/", "tests/")),

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,13 +16,11 @@ scikit-learn>=1.3,<2
 xgboost>=0.90,<2
 lightgbm>=2,<4
 
-# PyTorch doesn't support Python 3.11 yet (pytorch/pytorch#86566)
-
 # Elasticsearch uses v1.13.1 of PyTorch
-torch>=1.13.1,<2.0; python_version<'3.11'
+torch>=1.13.1,<2.0
 # Versions known to be compatible with PyTorch 1.13.1
-sentence-transformers>=2.1.0,<=2.2.2; python_version<'3.11'
-transformers[torch]>=4.12.0,<=4.27.4; python_version<'3.11'
+sentence-transformers>=2.1.0,<=2.2.2
+transformers[torch]>=4.12.0,<=4.27.4
 
 #
 # Testing


### PR DESCRIPTION
The issue of PyTorch not supporting Python 3.11 (pytorch/pytorch#86566) seems to have been resolved. I did not see any apparent other issues with supporting Python 3.11 in the code.