### PR TITLE
Allow running demo_notebook in Google Colab

### DIFF
--- a/docs/sphinx/examples/demo_notebook.ipynb
+++ b/docs/sphinx/examples/demo_notebook.ipynb
@@ -67,37 +67,47 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Collecting git+https://github.com/pquentin/eland.git@demo-notebook-colab\r\n",
-      "  Cloning https://github.com/pquentin/eland.git (to revision demo-notebook-colab) to /tmp/pip-req-build-llaufivk\r\n",
-      "  Running command git clone --filter=blob:none --quiet https://github.com/pquentin/eland.git /tmp/pip-req-build-llaufivk\r\n",
-      "  Running command git checkout -b demo-notebook-colab --track origin/demo-notebook-colab\r\n",
-      "  Switched to a new branch 'demo-notebook-colab'\r\n",
-      "  branch 'demo-notebook-colab' set up to track 'origin/demo-notebook-colab'.\r\n",
-      "  Resolved https://github.com/pquentin/eland.git to commit a85c8debaf44833ea1e8eb0041cd654dc2029709\r\n",
-      "  Preparing metadata (setup.py) ... \u001b[?25l-\b \bdone\r\n",
-      "\u001b[?25hRequirement already satisfied: elasticsearch<9,>=8.3 in /home/q/src/eland/.nox/docs/lib/python3.10/site-packages (from eland==8.9.0) (8.9.0)\r\n",
-      "Requirement already satisfied: pandas<2,>=1.5 in /home/q/src/eland/.nox/docs/lib64/python3.10/site-packages (from eland==8.9.0) (1.5.3)\r\n",
-      "Requirement already satisfied: matplotlib>=3.6 in /home/q/src/eland/.nox/docs/lib64/python3.10/site-packages (from eland==8.9.0) (3.8.0)\r\n",
-      "Requirement already satisfied: numpy<1.24,>=1.2.0 in /home/q/src/eland/.nox/docs/lib64/python3.10/site-packages (from eland==8.9.0) (1.23.5)\r\n",
-      "Requirement already satisfied: elastic-transport<9,>=8 in /home/q/src/eland/.nox/docs/lib/python3.10/site-packages (from elasticsearch<9,>=8.3->eland==8.9.0) (8.4.0)\r\n",
-      "Requirement already satisfied: contourpy>=1.0.1 in /home/q/src/eland/.nox/docs/lib64/python3.10/site-packages (from matplotlib>=3.6->eland==8.9.0) (1.1.1)\r\n",
-      "Requirement already satisfied: cycler>=0.10 in /home/q/src/eland/.nox/docs/lib/python3.10/site-packages (from matplotlib>=3.6->eland==8.9.0) (0.11.0)\r\n",
-      "Requirement already satisfied: fonttools>=4.22.0 in /home/q/src/eland/.nox/docs/lib64/python3.10/site-packages (from matplotlib>=3.6->eland==8.9.0) (4.42.1)\r\n",
-      "Requirement already satisfied: kiwisolver>=1.0.1 in /home/q/src/eland/.nox/docs/lib64/python3.10/site-packages (from matplotlib>=3.6->eland==8.9.0) (1.4.5)\r\n",
-      "Requirement already satisfied: packaging>=20.0 in /home/q/src/eland/.nox/docs/lib/python3.10/site-packages (from matplotlib>=3.6->eland==8.9.0) (23.1)\r\n",
-      "Requirement already satisfied: pillow>=6.2.0 in /home/q/src/eland/.nox/docs/lib64/python3.10/site-packages (from matplotlib>=3.6->eland==8.9.0) (10.0.1)\r\n",
-      "Requirement already satisfied: pyparsing>=2.3.1 in /home/q/src/eland/.nox/docs/lib/python3.10/site-packages (from matplotlib>=3.6->eland==8.9.0) (3.1.1)\r\n",
-      "Requirement already satisfied: python-dateutil>=2.7 in /home/q/src/eland/.nox/docs/lib/python3.10/site-packages (from matplotlib>=3.6->eland==8.9.0) (2.8.2)\r\n",
-      "Requirement already satisfied: pytz>=2020.1 in /home/q/src/eland/.nox/docs/lib/python3.10/site-packages (from pandas<2,>=1.5->eland==8.9.0) (2023.3.post1)\r\n",
-      "Requirement already satisfied: urllib3<2,>=1.26.2 in /home/q/src/eland/.nox/docs/lib/python3.10/site-packages (from elastic-transport<9,>=8->elasticsearch<9,>=8.3->eland==8.9.0) (1.26.16)\r\n",
-      "Requirement already satisfied: certifi in /home/q/src/eland/.nox/docs/lib/python3.10/site-packages (from elastic-transport<9,>=8->elasticsearch<9,>=8.3->eland==8.9.0) (2023.7.22)\r\n",
-      "Requirement already satisfied: six>=1.5 in /home/q/src/eland/.nox/docs/lib/python3.10/site-packages (from python-dateutil>=2.7->matplotlib>=3.6->eland==8.9.0) (1.16.0)\r\n"
+      "Collecting eland\n",
+      "  Downloading eland-8.9.0-py3-none-any.whl (156 kB)\n",
+      "\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/156.0 kB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m \u001b[32m153.6/156.0 kB\u001b[0m \u001b[31m5.0 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m156.0/156.0 kB\u001b[0m \u001b[31m4.1 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[?25hRequirement already satisfied: requests in /usr/local/lib/python3.10/dist-packages (2.31.0)\n",
+      "Collecting elasticsearch<9,>=8.3 (from eland)\n",
+      "  Downloading elasticsearch-8.9.0-py3-none-any.whl (395 kB)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m395.5/395.5 kB\u001b[0m \u001b[31m10.4 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[?25hRequirement already satisfied: pandas<2,>=1.5 in /usr/local/lib/python3.10/dist-packages (from eland) (1.5.3)\n",
+      "Requirement already satisfied: matplotlib>=3.6 in /usr/local/lib/python3.10/dist-packages (from eland) (3.7.1)\n",
+      "Requirement already satisfied: numpy<1.24,>=1.2.0 in /usr/local/lib/python3.10/dist-packages (from eland) (1.23.5)\n",
+      "Requirement already satisfied: charset-normalizer<4,>=2 in /usr/local/lib/python3.10/dist-packages (from requests) (3.2.0)\n",
+      "Requirement already satisfied: idna<4,>=2.5 in /usr/local/lib/python3.10/dist-packages (from requests) (3.4)\n",
+      "Requirement already satisfied: urllib3<3,>=1.21.1 in /usr/local/lib/python3.10/dist-packages (from requests) (2.0.4)\n",
+      "Requirement already satisfied: certifi>=2017.4.17 in /usr/local/lib/python3.10/dist-packages (from requests) (2023.7.22)\n",
+      "Collecting elastic-transport<9,>=8 (from elasticsearch<9,>=8.3->eland)\n",
+      "  Downloading elastic_transport-8.4.0-py3-none-any.whl (59 kB)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m59.5/59.5 kB\u001b[0m \u001b[31m9.5 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[?25hRequirement already satisfied: contourpy>=1.0.1 in /usr/local/lib/python3.10/dist-packages (from matplotlib>=3.6->eland) (1.1.0)\n",
+      "Requirement already satisfied: cycler>=0.10 in /usr/local/lib/python3.10/dist-packages (from matplotlib>=3.6->eland) (0.11.0)\n",
+      "Requirement already satisfied: fonttools>=4.22.0 in /usr/local/lib/python3.10/dist-packages (from matplotlib>=3.6->eland) (4.42.1)\n",
+      "Requirement already satisfied: kiwisolver>=1.0.1 in /usr/local/lib/python3.10/dist-packages (from matplotlib>=3.6->eland) (1.4.5)\n",
+      "Requirement already satisfied: packaging>=20.0 in /usr/local/lib/python3.10/dist-packages (from matplotlib>=3.6->eland) (23.1)\n",
+      "Requirement already satisfied: pillow>=6.2.0 in /usr/local/lib/python3.10/dist-packages (from matplotlib>=3.6->eland) (9.4.0)\n",
+      "Requirement already satisfied: pyparsing>=2.3.1 in /usr/local/lib/python3.10/dist-packages (from matplotlib>=3.6->eland) (3.1.1)\n",
+      "Requirement already satisfied: python-dateutil>=2.7 in /usr/local/lib/python3.10/dist-packages (from matplotlib>=3.6->eland) (2.8.2)\n",
+      "Requirement already satisfied: pytz>=2020.1 in /usr/local/lib/python3.10/dist-packages (from pandas<2,>=1.5->eland) (2023.3.post1)\n",
+      "Collecting urllib3<3,>=1.21.1 (from requests)\n",
+      "  Downloading urllib3-1.26.16-py2.py3-none-any.whl (143 kB)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m143.1/143.1 kB\u001b[0m \u001b[31m9.0 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[?25hRequirement already satisfied: six>=1.5 in /usr/local/lib/python3.10/dist-packages (from python-dateutil>=2.7->matplotlib>=3.6->eland) (1.16.0)\n",
+      "Installing collected packages: urllib3, elastic-transport, elasticsearch, eland\n",
+      "  Attempting uninstall: urllib3\n",
+      "    Found existing installation: urllib3 2.0.4\n",
+      "    Uninstalling urllib3-2.0.4:\n",
+      "      Successfully uninstalled urllib3-2.0.4\n",
+      "Successfully installed eland-8.9.0 elastic-transport-8.4.0 elasticsearch-8.9.0 urllib3-1.26.16\n"
      ]
     }
    ],
    "source": [
-    "# TODO switch to !pip install eland before merging\n",
-    "!pip install git+https://github.com/pquentin/eland.git@demo-notebook-colab\n",
+    "!pip install eland requests\n",
     "\n",
     "import os\n",
     "\n",
@@ -112,24 +122,6 @@
     "# Import standard test settings for consistent results\n",
     "from eland.conftest import *"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-15T20:24:28.813370Z",
-     "iopub.status.busy": "2021-12-15T20:24:28.802670Z",
-     "iopub.status.idle": "2021-12-15T20:24:30.192643Z",
-     "shell.execute_reply": "2021-12-15T20:24:30.192931Z"
-    },
-    "id": "64Wm8FvSNRFD",
-    "pycharm": {
-     "is_executing": false
-    }
-   },
-   "outputs": [],
-   "source": []
   },
   {
    "cell_type": "markdown",
@@ -163,7 +155,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Connected to cluster named 'docker-cluster' (version: 8.10.1)\n"
+      "Elastic Cloud ID: ··········\n",
+      "Elastic username: ··········\n",
+      "Elastic password: ··········\n",
+      "Connected to cluster named '9fcead8be8d2469fa096128e20496cee' (version: 8.9.1)\n"
      ]
     }
    ],

--- a/docs/sphinx/examples/demo_notebook.ipynb
+++ b/docs/sphinx/examples/demo_notebook.ipynb
@@ -1,4083 +1,6822 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Eland Demo Notebook"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-15T20:24:28.813370Z",
-     "iopub.status.busy": "2021-12-15T20:24:28.802670Z",
-     "iopub.status.idle": "2021-12-15T20:24:30.192643Z",
-     "shell.execute_reply": "2021-12-15T20:24:30.192931Z"
-    },
-    "pycharm": {
-     "is_executing": false
-    }
-   },
-   "outputs": [],
-   "source": [
-    "import eland as ed\n",
-    "import pandas as pd\n",
-    "import numpy as np\n",
-    "import matplotlib.pyplot as plt\n",
-    "\n",
-    "from elasticsearch import Elasticsearch\n",
-    "\n",
-    "# Import standard test settings for consistent results\n",
-    "from eland.conftest import *"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Compare Eland DataFrame vs pandas DataFrame"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Create an eland.DataFrame from a `flights` index"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-15T20:24:30.195931Z",
-     "iopub.status.busy": "2021-12-15T20:24:30.195563Z",
-     "iopub.status.idle": "2021-12-15T20:24:30.668077Z",
-     "shell.execute_reply": "2021-12-15T20:24:30.667531Z"
-    },
-    "pycharm": {
-     "is_executing": false
-    }
-   },
-   "outputs": [],
-   "source": [
-    "ed_flights = ed.DataFrame('http://localhost:9200', 'flights')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-15T20:24:30.673583Z",
-     "iopub.status.busy": "2021-12-15T20:24:30.673088Z",
-     "iopub.status.idle": "2021-12-15T20:24:30.677254Z",
-     "shell.execute_reply": "2021-12-15T20:24:30.677676Z"
-    },
-    "pycharm": {
-     "is_executing": false
-    }
-   },
-   "outputs": [
+  "cells": [
     {
-     "data": {
-      "text/plain": [
-       "eland.dataframe.DataFrame"
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "GTid11BRNRFA"
+      },
+      "source": [
+        "# Eland Demo Notebook\n",
+        "\n",
+        "<a target=\"_blank\" href=\"https://colab.research.google.com/github/elastic/eland/blob/main/docs/sphinx/examples/demo_notebook.ipynb\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
+        "\n",
+        "In this notebook we'll show you how to explore and analyze data in Elasticsearch using the familiar Pandas-compatible API."
       ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "type(ed_flights)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Compare to pandas DataFrame (created from the same data)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-15T20:24:30.682438Z",
-     "iopub.status.busy": "2021-12-15T20:24:30.681925Z",
-     "iopub.status.idle": "2021-12-15T20:24:35.046707Z",
-     "shell.execute_reply": "2021-12-15T20:24:35.046060Z"
     },
-    "pycharm": {
-     "is_executing": false
-    }
-   },
-   "outputs": [],
-   "source": [
-    "pd_flights = ed.eland_to_pandas(ed_flights)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-15T20:24:35.050698Z",
-     "iopub.status.busy": "2021-12-15T20:24:35.050158Z",
-     "iopub.status.idle": "2021-12-15T20:24:35.053100Z",
-     "shell.execute_reply": "2021-12-15T20:24:35.052560Z"
-    },
-    "pycharm": {
-     "is_executing": false
-    }
-   },
-   "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "pandas.core.frame.DataFrame"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "type(pd_flights)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Attributes and underlying data"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### DataFrame.columns"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-15T20:24:35.057245Z",
-     "iopub.status.busy": "2021-12-15T20:24:35.056812Z",
-     "iopub.status.idle": "2021-12-15T20:24:35.059852Z",
-     "shell.execute_reply": "2021-12-15T20:24:35.059182Z"
-    },
-    "pycharm": {
-     "is_executing": false
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Index(['AvgTicketPrice', 'Cancelled', 'Carrier', 'Dest', 'DestAirportID', 'DestCityName',\n",
-       "       'DestCountry', 'DestLocation', 'DestRegion', 'DestWeather', 'DistanceKilometers',\n",
-       "       'DistanceMiles', 'FlightDelay', 'FlightDelayMin', 'FlightDelayType', 'FlightNum',\n",
-       "       'FlightTimeHour', 'FlightTimeMin', 'Origin', 'OriginAirportID', 'OriginCityName',\n",
-       "       'OriginCountry', 'OriginLocation', 'OriginRegion', 'OriginWeather', 'dayOfWeek',\n",
-       "       'timestamp'],\n",
-       "      dtype='object')"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "pd_flights.columns"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-15T20:24:35.063057Z",
-     "iopub.status.busy": "2021-12-15T20:24:35.062660Z",
-     "iopub.status.idle": "2021-12-15T20:24:35.065130Z",
-     "shell.execute_reply": "2021-12-15T20:24:35.064757Z"
-    },
-    "pycharm": {
-     "is_executing": false
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Index(['AvgTicketPrice', 'Cancelled', 'Carrier', 'Dest', 'DestAirportID', 'DestCityName',\n",
-       "       'DestCountry', 'DestLocation', 'DestRegion', 'DestWeather', 'DistanceKilometers',\n",
-       "       'DistanceMiles', 'FlightDelay', 'FlightDelayMin', 'FlightDelayType', 'FlightNum',\n",
-       "       'FlightTimeHour', 'FlightTimeMin', 'Origin', 'OriginAirportID', 'OriginCityName',\n",
-       "       'OriginCountry', 'OriginLocation', 'OriginRegion', 'OriginWeather', 'dayOfWeek',\n",
-       "       'timestamp'],\n",
-       "      dtype='object')"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "ed_flights.columns"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### DataFrame.dtypes"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-15T20:24:35.076896Z",
-     "iopub.status.busy": "2021-12-15T20:24:35.076493Z",
-     "iopub.status.idle": "2021-12-15T20:24:35.079007Z",
-     "shell.execute_reply": "2021-12-15T20:24:35.078592Z"
-    },
-    "pycharm": {
-     "is_executing": false
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "AvgTicketPrice           float64\n",
-       "Cancelled                   bool\n",
-       "Carrier                   object\n",
-       "Dest                      object\n",
-       "DestAirportID             object\n",
-       "                       ...      \n",
-       "OriginLocation            object\n",
-       "OriginRegion              object\n",
-       "OriginWeather             object\n",
-       "dayOfWeek                  int64\n",
-       "timestamp         datetime64[ns]\n",
-       "Length: 27, dtype: object"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "pd_flights.dtypes"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-15T20:24:35.083103Z",
-     "iopub.status.busy": "2021-12-15T20:24:35.082693Z",
-     "iopub.status.idle": "2021-12-15T20:24:35.085336Z",
-     "shell.execute_reply": "2021-12-15T20:24:35.084836Z"
-    },
-    "pycharm": {
-     "is_executing": false
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "AvgTicketPrice           float64\n",
-       "Cancelled                   bool\n",
-       "Carrier                   object\n",
-       "Dest                      object\n",
-       "DestAirportID             object\n",
-       "                       ...      \n",
-       "OriginLocation            object\n",
-       "OriginRegion              object\n",
-       "OriginWeather             object\n",
-       "dayOfWeek                  int64\n",
-       "timestamp         datetime64[ns]\n",
-       "Length: 27, dtype: object"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "ed_flights.dtypes"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### DataFrame.select_dtypes"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-15T20:24:35.090387Z",
-     "iopub.status.busy": "2021-12-15T20:24:35.089910Z",
-     "iopub.status.idle": "2021-12-15T20:24:35.113517Z",
-     "shell.execute_reply": "2021-12-15T20:24:35.113801Z"
-    },
-    "pycharm": {
-     "is_executing": false
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>AvgTicketPrice</th>\n",
-       "      <th>DistanceKilometers</th>\n",
-       "      <th>...</th>\n",
-       "      <th>FlightTimeMin</th>\n",
-       "      <th>dayOfWeek</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>841.265642</td>\n",
-       "      <td>16492.326654</td>\n",
-       "      <td>...</td>\n",
-       "      <td>1030.770416</td>\n",
-       "      <td>0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>882.982662</td>\n",
-       "      <td>8823.400140</td>\n",
-       "      <td>...</td>\n",
-       "      <td>464.389481</td>\n",
-       "      <td>0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>190.636904</td>\n",
-       "      <td>0.000000</td>\n",
-       "      <td>...</td>\n",
-       "      <td>0.000000</td>\n",
-       "      <td>0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>181.694216</td>\n",
-       "      <td>555.737767</td>\n",
-       "      <td>...</td>\n",
-       "      <td>222.749059</td>\n",
-       "      <td>0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>730.041778</td>\n",
-       "      <td>13358.244200</td>\n",
-       "      <td>...</td>\n",
-       "      <td>785.779071</td>\n",
-       "      <td>0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>...</th>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>13054</th>\n",
-       "      <td>1080.446279</td>\n",
-       "      <td>8058.581753</td>\n",
-       "      <td>...</td>\n",
-       "      <td>402.929088</td>\n",
-       "      <td>6</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>13055</th>\n",
-       "      <td>646.612941</td>\n",
-       "      <td>7088.598322</td>\n",
-       "      <td>...</td>\n",
-       "      <td>644.418029</td>\n",
-       "      <td>6</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>13056</th>\n",
-       "      <td>997.751876</td>\n",
-       "      <td>10920.652972</td>\n",
-       "      <td>...</td>\n",
-       "      <td>937.540811</td>\n",
-       "      <td>6</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>13057</th>\n",
-       "      <td>1102.814465</td>\n",
-       "      <td>18748.859647</td>\n",
-       "      <td>...</td>\n",
-       "      <td>1697.404971</td>\n",
-       "      <td>6</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>13058</th>\n",
-       "      <td>858.144337</td>\n",
-       "      <td>16809.141923</td>\n",
-       "      <td>...</td>\n",
-       "      <td>1610.761827</td>\n",
-       "      <td>6</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "<p>13059 rows × 7 columns</p>\n",
-       "</div>"
+      "cell_type": "markdown",
+      "source": [
+        "## Requirements 🧰\n",
+        "\n",
+        "For this example, you will need:\n",
+        "\n",
+        "- Python 3.8 or later\n",
+        "- An Elastic deployment\n",
+        "  - We'll be using [Elastic Cloud](https://www.elastic.co/guide/en/cloud/current/ec-getting-started.html) for this example (available with a [free trial](https://cloud.elastic.co/registration))\n",
+        "\n",
+        "### Create Elastic Cloud deployment\n",
+        "\n",
+        "If you don't have an Elastic Cloud deployment, follow these steps to create one.\n",
+        "\n",
+        "1. Go to https://cloud.elastic.co/registration and sign up for a free trial\n",
+        "2. Select **Create Deployment** and follow the instructions\n"
       ],
-      "text/plain": [
-       "       AvgTicketPrice  DistanceKilometers  ...  FlightTimeMin  dayOfWeek\n",
-       "0          841.265642        16492.326654  ...    1030.770416          0\n",
-       "1          882.982662         8823.400140  ...     464.389481          0\n",
-       "2          190.636904            0.000000  ...       0.000000          0\n",
-       "3          181.694216          555.737767  ...     222.749059          0\n",
-       "4          730.041778        13358.244200  ...     785.779071          0\n",
-       "...               ...                 ...  ...            ...        ...\n",
-       "13054     1080.446279         8058.581753  ...     402.929088          6\n",
-       "13055      646.612941         7088.598322  ...     644.418029          6\n",
-       "13056      997.751876        10920.652972  ...     937.540811          6\n",
-       "13057     1102.814465        18748.859647  ...    1697.404971          6\n",
-       "13058      858.144337        16809.141923  ...    1610.761827          6\n",
-       "\n",
-       "[13059 rows x 7 columns]"
-      ]
-     },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "pd_flights.select_dtypes(include=np.number)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-15T20:24:35.131083Z",
-     "iopub.status.busy": "2021-12-15T20:24:35.130699Z",
-     "iopub.status.idle": "2021-12-15T20:24:38.362018Z",
-     "shell.execute_reply": "2021-12-15T20:24:38.360520Z"
+      "metadata": {
+        "id": "Rkdq0gUBOPJn"
+      }
     },
-    "pycharm": {
-     "is_executing": false
-    }
-   },
-   "outputs": [
     {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>AvgTicketPrice</th>\n",
-       "      <th>DistanceKilometers</th>\n",
-       "      <th>...</th>\n",
-       "      <th>FlightTimeMin</th>\n",
-       "      <th>dayOfWeek</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>841.265642</td>\n",
-       "      <td>16492.326654</td>\n",
-       "      <td>...</td>\n",
-       "      <td>1030.770416</td>\n",
-       "      <td>0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>882.982662</td>\n",
-       "      <td>8823.400140</td>\n",
-       "      <td>...</td>\n",
-       "      <td>464.389481</td>\n",
-       "      <td>0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>190.636904</td>\n",
-       "      <td>0.000000</td>\n",
-       "      <td>...</td>\n",
-       "      <td>0.000000</td>\n",
-       "      <td>0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>181.694216</td>\n",
-       "      <td>555.737767</td>\n",
-       "      <td>...</td>\n",
-       "      <td>222.749059</td>\n",
-       "      <td>0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>730.041778</td>\n",
-       "      <td>13358.244200</td>\n",
-       "      <td>...</td>\n",
-       "      <td>785.779071</td>\n",
-       "      <td>0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>...</th>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>13054</th>\n",
-       "      <td>1080.446279</td>\n",
-       "      <td>8058.581753</td>\n",
-       "      <td>...</td>\n",
-       "      <td>402.929088</td>\n",
-       "      <td>6</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>13055</th>\n",
-       "      <td>646.612941</td>\n",
-       "      <td>7088.598322</td>\n",
-       "      <td>...</td>\n",
-       "      <td>644.418029</td>\n",
-       "      <td>6</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>13056</th>\n",
-       "      <td>997.751876</td>\n",
-       "      <td>10920.652972</td>\n",
-       "      <td>...</td>\n",
-       "      <td>937.540811</td>\n",
-       "      <td>6</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>13057</th>\n",
-       "      <td>1102.814465</td>\n",
-       "      <td>18748.859647</td>\n",
-       "      <td>...</td>\n",
-       "      <td>1697.404971</td>\n",
-       "      <td>6</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>13058</th>\n",
-       "      <td>858.144337</td>\n",
-       "      <td>16809.141923</td>\n",
-       "      <td>...</td>\n",
-       "      <td>1610.761827</td>\n",
-       "      <td>6</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>\n",
-       "<p>13059 rows × 7 columns</p>"
+      "cell_type": "markdown",
+      "source": [
+        "## Install packages 📦\n",
+        "\n",
+        "First we `pip install` and import the packages we need for this example.\n"
       ],
-      "text/plain": [
-       "       AvgTicketPrice  DistanceKilometers  ...  FlightTimeMin  dayOfWeek\n",
-       "0          841.265642        16492.326654  ...    1030.770416          0\n",
-       "1          882.982662         8823.400140  ...     464.389481          0\n",
-       "2          190.636904            0.000000  ...       0.000000          0\n",
-       "3          181.694216          555.737767  ...     222.749059          0\n",
-       "4          730.041778        13358.244200  ...     785.779071          0\n",
-       "...               ...                 ...  ...            ...        ...\n",
-       "13054     1080.446279         8058.581753  ...     402.929088          6\n",
-       "13055      646.612941         7088.598322  ...     644.418029          6\n",
-       "13056      997.751876        10920.652972  ...     937.540811          6\n",
-       "13057     1102.814465        18748.859647  ...    1697.404971          6\n",
-       "13058      858.144337        16809.141923  ...    1610.761827          6\n",
-       "\n",
-       "[13059 rows x 7 columns]"
-      ]
-     },
-     "execution_count": 11,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "ed_flights.select_dtypes(include=np.number)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### DataFrame.empty"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-15T20:24:38.376647Z",
-     "iopub.status.busy": "2021-12-15T20:24:38.374422Z",
-     "iopub.status.idle": "2021-12-15T20:24:38.382068Z",
-     "shell.execute_reply": "2021-12-15T20:24:38.383242Z"
+      "metadata": {
+        "id": "8EzcP9SpOYsc"
+      }
     },
-    "pycharm": {
-     "is_executing": false
-    }
-   },
-   "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "False"
-      ]
-     },
-     "execution_count": 12,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "pd_flights.empty"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-15T20:24:38.391560Z",
-     "iopub.status.busy": "2021-12-15T20:24:38.390590Z",
-     "iopub.status.idle": "2021-12-15T20:24:38.463948Z",
-     "shell.execute_reply": "2021-12-15T20:24:38.463507Z"
-    },
-    "pycharm": {
-     "is_executing": false
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "False"
-      ]
-     },
-     "execution_count": 13,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "ed_flights.empty"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### DataFrame.shape"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 14,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-15T20:24:38.467067Z",
-     "iopub.status.busy": "2021-12-15T20:24:38.466671Z",
-     "iopub.status.idle": "2021-12-15T20:24:38.469107Z",
-     "shell.execute_reply": "2021-12-15T20:24:38.468710Z"
-    },
-    "pycharm": {
-     "is_executing": false
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(13059, 27)"
-      ]
-     },
-     "execution_count": 14,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "pd_flights.shape"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 15,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-15T20:24:38.471904Z",
-     "iopub.status.busy": "2021-12-15T20:24:38.471491Z",
-     "iopub.status.idle": "2021-12-15T20:24:38.558583Z",
-     "shell.execute_reply": "2021-12-15T20:24:38.557300Z"
-    },
-    "pycharm": {
-     "is_executing": false
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(13059, 27)"
-      ]
-     },
-     "execution_count": 15,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "ed_flights.shape"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### DataFrame.index\n",
-    "\n",
-    "Note, `eland.DataFrame.index` does not mirror `pandas.DataFrame.index`. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 16,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-15T20:24:38.569600Z",
-     "iopub.status.busy": "2021-12-15T20:24:38.568315Z",
-     "iopub.status.idle": "2021-12-15T20:24:38.575273Z",
-     "shell.execute_reply": "2021-12-15T20:24:38.574007Z"
-    },
-    "pycharm": {
-     "is_executing": false
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Index(['0', '1', '2', '3', '4', '5', '6', '7', '8', '9',\n",
-       "       ...\n",
-       "       '13049', '13050', '13051', '13052', '13053', '13054', '13055', '13056', '13057', '13058'],\n",
-       "      dtype='object', length=13059)"
-      ]
-     },
-     "execution_count": 16,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "pd_flights.index"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 17,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-15T20:24:38.583800Z",
-     "iopub.status.busy": "2021-12-15T20:24:38.582630Z",
-     "iopub.status.idle": "2021-12-15T20:24:38.588504Z",
-     "shell.execute_reply": "2021-12-15T20:24:38.589469Z"
-    },
-    "pycharm": {
-     "is_executing": false
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<eland.index.Index at 0x7ff1a25debb0>"
-      ]
-     },
-     "execution_count": 17,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# NBVAL_IGNORE_OUTPUT\n",
-    "ed_flights.index"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 18,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-15T20:24:38.598654Z",
-     "iopub.status.busy": "2021-12-15T20:24:38.597416Z",
-     "iopub.status.idle": "2021-12-15T20:24:38.604549Z",
-     "shell.execute_reply": "2021-12-15T20:24:38.603361Z"
-    },
-    "pycharm": {
-     "is_executing": false
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'_id'"
-      ]
-     },
-     "execution_count": 18,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "ed_flights.index.es_index_field"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### DataFrame.values\n",
-    "\n",
-    "Note, `eland.DataFrame.values` is not supported."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 19,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-15T20:24:38.634011Z",
-     "iopub.status.busy": "2021-12-15T20:24:38.629434Z",
-     "iopub.status.idle": "2021-12-15T20:24:38.681698Z",
-     "shell.execute_reply": "2021-12-15T20:24:38.681982Z"
-    },
-    "pycharm": {
-     "is_executing": false
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([[841.2656419677076, False, 'Kibana Airlines', ..., 'Sunny', 0,\n",
-       "        Timestamp('2018-01-01 00:00:00')],\n",
-       "       [882.9826615595518, False, 'Logstash Airways', ..., 'Clear', 0,\n",
-       "        Timestamp('2018-01-01 18:27:00')],\n",
-       "       [190.6369038508356, False, 'Logstash Airways', ..., 'Rain', 0,\n",
-       "        Timestamp('2018-01-01 17:11:14')],\n",
-       "       ...,\n",
-       "       [997.7518761454494, False, 'Logstash Airways', ..., 'Sunny', 6,\n",
-       "        Timestamp('2018-02-11 04:09:27')],\n",
-       "       [1102.8144645388556, False, 'JetBeats', ..., 'Hail', 6,\n",
-       "        Timestamp('2018-02-11 08:28:21')],\n",
-       "       [858.1443369038839, False, 'JetBeats', ..., 'Rain', 6,\n",
-       "        Timestamp('2018-02-11 14:54:34')]], dtype=object)"
-      ]
-     },
-     "execution_count": 19,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "pd_flights.values"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 20,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-15T20:24:38.685031Z",
-     "iopub.status.busy": "2021-12-15T20:24:38.684450Z",
-     "iopub.status.idle": "2021-12-15T20:24:38.687106Z",
-     "shell.execute_reply": "2021-12-15T20:24:38.686771Z"
-    },
-    "pycharm": {
-     "is_executing": false
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "This method would scan/scroll the entire Elasticsearch index(s) into memory. If this is explicitly required, and there is sufficient memory, call `ed.eland_to_pandas(ed_df).values`\n"
-     ]
-    }
-   ],
-   "source": [
-    "try:\n",
-    "    ed_flights.values\n",
-    "except AttributeError as e:\n",
-    "    print(e)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Indexing, iteration"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### DataFrame.head"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 21,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-15T20:24:38.694742Z",
-     "iopub.status.busy": "2021-12-15T20:24:38.694371Z",
-     "iopub.status.idle": "2021-12-15T20:24:38.696502Z",
-     "shell.execute_reply": "2021-12-15T20:24:38.696207Z"
-    },
-    "pycharm": {
-     "is_executing": false
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>AvgTicketPrice</th>\n",
-       "      <th>Cancelled</th>\n",
-       "      <th>...</th>\n",
-       "      <th>dayOfWeek</th>\n",
-       "      <th>timestamp</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>841.265642</td>\n",
-       "      <td>False</td>\n",
-       "      <td>...</td>\n",
-       "      <td>0</td>\n",
-       "      <td>2018-01-01 00:00:00</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>882.982662</td>\n",
-       "      <td>False</td>\n",
-       "      <td>...</td>\n",
-       "      <td>0</td>\n",
-       "      <td>2018-01-01 18:27:00</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>190.636904</td>\n",
-       "      <td>False</td>\n",
-       "      <td>...</td>\n",
-       "      <td>0</td>\n",
-       "      <td>2018-01-01 17:11:14</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>181.694216</td>\n",
-       "      <td>True</td>\n",
-       "      <td>...</td>\n",
-       "      <td>0</td>\n",
-       "      <td>2018-01-01 10:33:28</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>730.041778</td>\n",
-       "      <td>False</td>\n",
-       "      <td>...</td>\n",
-       "      <td>0</td>\n",
-       "      <td>2018-01-01 05:13:00</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "<p>5 rows × 27 columns</p>\n",
-       "</div>"
+      "cell_type": "code",
+      "source": [
+        "!pip install eland\n",
+        "\n",
+        "import eland as ed\n",
+        "import pandas as pd\n",
+        "import numpy as np\n",
+        "import matplotlib.pyplot as plt\n",
+        "\n",
+        "from elasticsearch import Elasticsearch\n",
+        "\n",
+        "# Import standard test settings for consistent results\n",
+        "from eland.conftest import *"
       ],
-      "text/plain": [
-       "   AvgTicketPrice  Cancelled  ... dayOfWeek           timestamp\n",
-       "0      841.265642      False  ...         0 2018-01-01 00:00:00\n",
-       "1      882.982662      False  ...         0 2018-01-01 18:27:00\n",
-       "2      190.636904      False  ...         0 2018-01-01 17:11:14\n",
-       "3      181.694216       True  ...         0 2018-01-01 10:33:28\n",
-       "4      730.041778      False  ...         0 2018-01-01 05:13:00\n",
-       "\n",
-       "[5 rows x 27 columns]"
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "YTm5ABvjOaSb",
+        "outputId": "a2c127f2-43d7-4103-ac0d-5cdd90ce54c2"
+      },
+      "execution_count": 1,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Requirement already satisfied: eland in /usr/local/lib/python3.10/dist-packages (8.9.0)\n",
+            "Requirement already satisfied: elasticsearch<9,>=8.3 in /usr/local/lib/python3.10/dist-packages (from eland) (8.9.0)\n",
+            "Requirement already satisfied: pandas<2,>=1.5 in /usr/local/lib/python3.10/dist-packages (from eland) (1.5.3)\n",
+            "Requirement already satisfied: matplotlib>=3.6 in /usr/local/lib/python3.10/dist-packages (from eland) (3.7.1)\n",
+            "Requirement already satisfied: numpy<1.24,>=1.2.0 in /usr/local/lib/python3.10/dist-packages (from eland) (1.23.5)\n",
+            "Requirement already satisfied: elastic-transport<9,>=8 in /usr/local/lib/python3.10/dist-packages (from elasticsearch<9,>=8.3->eland) (8.4.0)\n",
+            "Requirement already satisfied: contourpy>=1.0.1 in /usr/local/lib/python3.10/dist-packages (from matplotlib>=3.6->eland) (1.1.0)\n",
+            "Requirement already satisfied: cycler>=0.10 in /usr/local/lib/python3.10/dist-packages (from matplotlib>=3.6->eland) (0.11.0)\n",
+            "Requirement already satisfied: fonttools>=4.22.0 in /usr/local/lib/python3.10/dist-packages (from matplotlib>=3.6->eland) (4.42.1)\n",
+            "Requirement already satisfied: kiwisolver>=1.0.1 in /usr/local/lib/python3.10/dist-packages (from matplotlib>=3.6->eland) (1.4.5)\n",
+            "Requirement already satisfied: packaging>=20.0 in /usr/local/lib/python3.10/dist-packages (from matplotlib>=3.6->eland) (23.1)\n",
+            "Requirement already satisfied: pillow>=6.2.0 in /usr/local/lib/python3.10/dist-packages (from matplotlib>=3.6->eland) (9.4.0)\n",
+            "Requirement already satisfied: pyparsing>=2.3.1 in /usr/local/lib/python3.10/dist-packages (from matplotlib>=3.6->eland) (3.1.1)\n",
+            "Requirement already satisfied: python-dateutil>=2.7 in /usr/local/lib/python3.10/dist-packages (from matplotlib>=3.6->eland) (2.8.2)\n",
+            "Requirement already satisfied: pytz>=2020.1 in /usr/local/lib/python3.10/dist-packages (from pandas<2,>=1.5->eland) (2023.3.post1)\n",
+            "Requirement already satisfied: urllib3<2,>=1.26.2 in /usr/local/lib/python3.10/dist-packages (from elastic-transport<9,>=8->elasticsearch<9,>=8.3->eland) (1.26.16)\n",
+            "Requirement already satisfied: certifi in /usr/local/lib/python3.10/dist-packages (from elastic-transport<9,>=8->elasticsearch<9,>=8.3->eland) (2023.7.22)\n",
+            "Requirement already satisfied: six>=1.5 in /usr/local/lib/python3.10/dist-packages (from python-dateutil>=2.7->matplotlib>=3.6->eland) (1.16.0)\n"
+          ]
+        }
       ]
-     },
-     "execution_count": 21,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "pd_flights.head()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 22,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-15T20:24:38.699691Z",
-     "iopub.status.busy": "2021-12-15T20:24:38.699271Z",
-     "iopub.status.idle": "2021-12-15T20:24:40.675206Z",
-     "shell.execute_reply": "2021-12-15T20:24:40.676183Z"
     },
-    "pycharm": {
-     "is_executing": false
-    }
-   },
-   "outputs": [
     {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>AvgTicketPrice</th>\n",
-       "      <th>Cancelled</th>\n",
-       "      <th>...</th>\n",
-       "      <th>dayOfWeek</th>\n",
-       "      <th>timestamp</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>841.265642</td>\n",
-       "      <td>False</td>\n",
-       "      <td>...</td>\n",
-       "      <td>0</td>\n",
-       "      <td>2018-01-01 00:00:00</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>882.982662</td>\n",
-       "      <td>False</td>\n",
-       "      <td>...</td>\n",
-       "      <td>0</td>\n",
-       "      <td>2018-01-01 18:27:00</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>190.636904</td>\n",
-       "      <td>False</td>\n",
-       "      <td>...</td>\n",
-       "      <td>0</td>\n",
-       "      <td>2018-01-01 17:11:14</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>181.694216</td>\n",
-       "      <td>True</td>\n",
-       "      <td>...</td>\n",
-       "      <td>0</td>\n",
-       "      <td>2018-01-01 10:33:28</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>730.041778</td>\n",
-       "      <td>False</td>\n",
-       "      <td>...</td>\n",
-       "      <td>0</td>\n",
-       "      <td>2018-01-01 05:13:00</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>\n",
-       "<p>5 rows × 27 columns</p>"
+      "cell_type": "code",
+      "execution_count": 1,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2021-12-15T20:24:28.813370Z",
+          "iopub.status.busy": "2021-12-15T20:24:28.802670Z",
+          "iopub.status.idle": "2021-12-15T20:24:30.192643Z",
+          "shell.execute_reply": "2021-12-15T20:24:30.192931Z"
+        },
+        "pycharm": {
+          "is_executing": false
+        },
+        "id": "64Wm8FvSNRFD"
+      },
+      "outputs": [],
+      "source": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Initialize client 🔌\n",
+        "\n",
+        "Next we input credentials with `getpass`. `getpass` is part of the Python standard library and is used to securely prompt for credentials."
       ],
-      "text/plain": [
-       "   AvgTicketPrice  Cancelled  ... dayOfWeek           timestamp\n",
-       "0      841.265642      False  ...         0 2018-01-01 00:00:00\n",
-       "1      882.982662      False  ...         0 2018-01-01 18:27:00\n",
-       "2      190.636904      False  ...         0 2018-01-01 17:11:14\n",
-       "3      181.694216       True  ...         0 2018-01-01 10:33:28\n",
-       "4      730.041778      False  ...         0 2018-01-01 05:13:00\n",
-       "\n",
-       "[5 rows x 27 columns]"
-      ]
-     },
-     "execution_count": 22,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "ed_flights.head()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### DataFrame.tail"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 23,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-15T20:24:40.695639Z",
-     "iopub.status.busy": "2021-12-15T20:24:40.694910Z",
-     "iopub.status.idle": "2021-12-15T20:24:40.698148Z",
-     "shell.execute_reply": "2021-12-15T20:24:40.698704Z"
+      "metadata": {
+        "id": "J9YR-d7OOk0-"
+      }
     },
-    "pycharm": {
-     "is_executing": false
-    }
-   },
-   "outputs": [
     {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>AvgTicketPrice</th>\n",
-       "      <th>Cancelled</th>\n",
-       "      <th>...</th>\n",
-       "      <th>dayOfWeek</th>\n",
-       "      <th>timestamp</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>13054</th>\n",
-       "      <td>1080.446279</td>\n",
-       "      <td>False</td>\n",
-       "      <td>...</td>\n",
-       "      <td>6</td>\n",
-       "      <td>2018-02-11 20:42:25</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>13055</th>\n",
-       "      <td>646.612941</td>\n",
-       "      <td>False</td>\n",
-       "      <td>...</td>\n",
-       "      <td>6</td>\n",
-       "      <td>2018-02-11 01:41:57</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>13056</th>\n",
-       "      <td>997.751876</td>\n",
-       "      <td>False</td>\n",
-       "      <td>...</td>\n",
-       "      <td>6</td>\n",
-       "      <td>2018-02-11 04:09:27</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>13057</th>\n",
-       "      <td>1102.814465</td>\n",
-       "      <td>False</td>\n",
-       "      <td>...</td>\n",
-       "      <td>6</td>\n",
-       "      <td>2018-02-11 08:28:21</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>13058</th>\n",
-       "      <td>858.144337</td>\n",
-       "      <td>False</td>\n",
-       "      <td>...</td>\n",
-       "      <td>6</td>\n",
-       "      <td>2018-02-11 14:54:34</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "<p>5 rows × 27 columns</p>\n",
-       "</div>"
+      "cell_type": "code",
+      "source": [
+        "from getpass import getpass\n",
+        "\n",
+        "ELASTIC_HOST = getpass(\"Elasticsearch hostname: \")\n",
+        "ELASTIC_PORT = int(input(\"Elasticsearch HTTP port:\"))\n",
+        "ELASTIC_USERNAME = getpass(\"Elasticsearch username: \")\n",
+        "ELASTIC_PASSWORD = getpass(\"Elasticsearch password: \")\n",
+        "\n",
+        "ELASTICSEARCH_URL = f\"https://{ELASTIC_USERNAME}:{ELASTIC_PASSWORD}@{ELASTIC_HOST}:{ELASTIC_PORT}\"\n"
       ],
-      "text/plain": [
-       "       AvgTicketPrice  Cancelled  ... dayOfWeek           timestamp\n",
-       "13054     1080.446279      False  ...         6 2018-02-11 20:42:25\n",
-       "13055      646.612941      False  ...         6 2018-02-11 01:41:57\n",
-       "13056      997.751876      False  ...         6 2018-02-11 04:09:27\n",
-       "13057     1102.814465      False  ...         6 2018-02-11 08:28:21\n",
-       "13058      858.144337      False  ...         6 2018-02-11 14:54:34\n",
-       "\n",
-       "[5 rows x 27 columns]"
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "DARo7JpKOsdW",
+        "outputId": "6497646e-a535-4994-a26a-8aea1caae28c"
+      },
+      "execution_count": 2,
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Elasticsearch host: ··········\n",
+            "Elasticsearch HTTP port:443\n",
+            "Elasticsearch username: ··········\n",
+            "Elasticsearch password: ··········\n"
+          ]
+        }
       ]
-     },
-     "execution_count": 23,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "pd_flights.tail()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 24,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-15T20:24:40.703670Z",
-     "iopub.status.busy": "2021-12-15T20:24:40.702923Z",
-     "iopub.status.idle": "2021-12-15T20:24:42.789898Z",
-     "shell.execute_reply": "2021-12-15T20:24:42.789460Z"
     },
-    "pycharm": {
-     "is_executing": false
-    }
-   },
-   "outputs": [
     {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>AvgTicketPrice</th>\n",
-       "      <th>Cancelled</th>\n",
-       "      <th>...</th>\n",
-       "      <th>dayOfWeek</th>\n",
-       "      <th>timestamp</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>13054</th>\n",
-       "      <td>1080.446279</td>\n",
-       "      <td>False</td>\n",
-       "      <td>...</td>\n",
-       "      <td>6</td>\n",
-       "      <td>2018-02-11 20:42:25</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>13055</th>\n",
-       "      <td>646.612941</td>\n",
-       "      <td>False</td>\n",
-       "      <td>...</td>\n",
-       "      <td>6</td>\n",
-       "      <td>2018-02-11 01:41:57</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>13056</th>\n",
-       "      <td>997.751876</td>\n",
-       "      <td>False</td>\n",
-       "      <td>...</td>\n",
-       "      <td>6</td>\n",
-       "      <td>2018-02-11 04:09:27</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>13057</th>\n",
-       "      <td>1102.814465</td>\n",
-       "      <td>False</td>\n",
-       "      <td>...</td>\n",
-       "      <td>6</td>\n",
-       "      <td>2018-02-11 08:28:21</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>13058</th>\n",
-       "      <td>858.144337</td>\n",
-       "      <td>False</td>\n",
-       "      <td>...</td>\n",
-       "      <td>6</td>\n",
-       "      <td>2018-02-11 14:54:34</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>\n",
-       "<p>5 rows × 27 columns</p>"
+      "cell_type": "markdown",
+      "source": [
+        "## Load and process documents 📄\n",
+        "\n",
+        "Time to load some data! We'll be using the Eland test data, which is a fake flights dataset."
       ],
-      "text/plain": [
-       "       AvgTicketPrice  Cancelled  ... dayOfWeek           timestamp\n",
-       "13054     1080.446279      False  ...         6 2018-02-11 20:42:25\n",
-       "13055      646.612941      False  ...         6 2018-02-11 01:41:57\n",
-       "13056      997.751876      False  ...         6 2018-02-11 04:09:27\n",
-       "13057     1102.814465      False  ...         6 2018-02-11 08:28:21\n",
-       "13058      858.144337      False  ...         6 2018-02-11 14:54:34\n",
-       "\n",
-       "[5 rows x 27 columns]"
-      ]
-     },
-     "execution_count": 24,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "ed_flights.tail()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### DataFrame.keys"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 25,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-15T20:24:42.793363Z",
-     "iopub.status.busy": "2021-12-15T20:24:42.791765Z",
-     "iopub.status.idle": "2021-12-15T20:24:42.796116Z",
-     "shell.execute_reply": "2021-12-15T20:24:42.795742Z"
+      "metadata": {
+        "id": "4m9amNr6OxKr"
+      }
     },
-    "pycharm": {
-     "is_executing": false
-    }
-   },
-   "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "Index(['AvgTicketPrice', 'Cancelled', 'Carrier', 'Dest', 'DestAirportID', 'DestCityName',\n",
-       "       'DestCountry', 'DestLocation', 'DestRegion', 'DestWeather', 'DistanceKilometers',\n",
-       "       'DistanceMiles', 'FlightDelay', 'FlightDelayMin', 'FlightDelayType', 'FlightNum',\n",
-       "       'FlightTimeHour', 'FlightTimeMin', 'Origin', 'OriginAirportID', 'OriginCityName',\n",
-       "       'OriginCountry', 'OriginLocation', 'OriginRegion', 'OriginWeather', 'dayOfWeek',\n",
-       "       'timestamp'],\n",
-       "      dtype='object')"
-      ]
-     },
-     "execution_count": 25,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "pd_flights.keys()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 26,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-15T20:24:42.799972Z",
-     "iopub.status.busy": "2021-12-15T20:24:42.799336Z",
-     "iopub.status.idle": "2021-12-15T20:24:42.802144Z",
-     "shell.execute_reply": "2021-12-15T20:24:42.801772Z"
-    },
-    "pycharm": {
-     "is_executing": false
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Index(['AvgTicketPrice', 'Cancelled', 'Carrier', 'Dest', 'DestAirportID', 'DestCityName',\n",
-       "       'DestCountry', 'DestLocation', 'DestRegion', 'DestWeather', 'DistanceKilometers',\n",
-       "       'DistanceMiles', 'FlightDelay', 'FlightDelayMin', 'FlightDelayType', 'FlightNum',\n",
-       "       'FlightTimeHour', 'FlightTimeMin', 'Origin', 'OriginAirportID', 'OriginCityName',\n",
-       "       'OriginCountry', 'OriginLocation', 'OriginRegion', 'OriginWeather', 'dayOfWeek',\n",
-       "       'timestamp'],\n",
-       "      dtype='object')"
-      ]
-     },
-     "execution_count": 26,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "ed_flights.keys()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### DataFrame.get"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 27,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-15T20:24:42.807664Z",
-     "iopub.status.busy": "2021-12-15T20:24:42.807137Z",
-     "iopub.status.idle": "2021-12-15T20:24:42.809592Z",
-     "shell.execute_reply": "2021-12-15T20:24:42.809225Z"
-    },
-    "pycharm": {
-     "is_executing": false
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "0         Kibana Airlines\n",
-       "1        Logstash Airways\n",
-       "2        Logstash Airways\n",
-       "3         Kibana Airlines\n",
-       "4         Kibana Airlines\n",
-       "               ...       \n",
-       "13054    Logstash Airways\n",
-       "13055    Logstash Airways\n",
-       "13056    Logstash Airways\n",
-       "13057            JetBeats\n",
-       "13058            JetBeats\n",
-       "Name: Carrier, Length: 13059, dtype: object"
-      ]
-     },
-     "execution_count": 27,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "pd_flights.get('Carrier')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 28,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-15T20:24:42.813306Z",
-     "iopub.status.busy": "2021-12-15T20:24:42.812951Z",
-     "iopub.status.idle": "2021-12-15T20:24:44.238665Z",
-     "shell.execute_reply": "2021-12-15T20:24:44.239468Z"
-    },
-    "pycharm": {
-     "is_executing": false
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "0         Kibana Airlines\n",
-       "1        Logstash Airways\n",
-       "2        Logstash Airways\n",
-       "3         Kibana Airlines\n",
-       "4         Kibana Airlines\n",
-       "               ...       \n",
-       "13054    Logstash Airways\n",
-       "13055    Logstash Airways\n",
-       "13056    Logstash Airways\n",
-       "13057            JetBeats\n",
-       "13058            JetBeats\n",
-       "Name: Carrier, Length: 13059, dtype: object"
-      ]
-     },
-     "execution_count": 28,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "ed_flights.get('Carrier')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 29,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-15T20:24:44.252784Z",
-     "iopub.status.busy": "2021-12-15T20:24:44.244955Z",
-     "iopub.status.idle": "2021-12-15T20:24:44.257030Z",
-     "shell.execute_reply": "2021-12-15T20:24:44.258040Z"
-    },
-    "pycharm": {
-     "is_executing": false
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>Carrier</th>\n",
-       "      <th>Origin</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>Kibana Airlines</td>\n",
-       "      <td>Frankfurt am Main Airport</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>Logstash Airways</td>\n",
-       "      <td>Cape Town International Airport</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>Logstash Airways</td>\n",
-       "      <td>Venice Marco Polo Airport</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>Kibana Airlines</td>\n",
-       "      <td>Naples International Airport</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>Kibana Airlines</td>\n",
-       "      <td>Licenciado Benito Juarez International Airport</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>...</th>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>13054</th>\n",
-       "      <td>Logstash Airways</td>\n",
-       "      <td>Pisa International Airport</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>13055</th>\n",
-       "      <td>Logstash Airways</td>\n",
-       "      <td>Winnipeg / James Armstrong Richardson Internat...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>13056</th>\n",
-       "      <td>Logstash Airways</td>\n",
-       "      <td>Licenciado Benito Juarez International Airport</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>13057</th>\n",
-       "      <td>JetBeats</td>\n",
-       "      <td>Itami Airport</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>13058</th>\n",
-       "      <td>JetBeats</td>\n",
-       "      <td>Adelaide International Airport</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "<p>13059 rows × 2 columns</p>\n",
-       "</div>"
+      "cell_type": "code",
+      "source": [
+        "import os\n",
+        "\n",
+        "es = Elasticsearch(ELASTICSEARCH_URL)\n",
+        "print(es.info())\n",
+        "\n",
+        "os.chdir(\"/content/\")\n",
+        "!rm -rf eland/\n",
+        "!git clone https://github.com/elastic/eland.git\n",
+        "\n",
+        "os.chdir(\"eland\")\n",
+        "import sys\n",
+        "sys.path.insert(0, os.getcwd())\n",
+        "os.environ[\"ELASTICSEARCH_URL\"] = ELASTICSEARCH_URL\n",
+        "\n",
+        "from tests import setup_tests\n",
+        "setup_tests._setup_data(es)"
       ],
-      "text/plain": [
-       "                Carrier                                             Origin\n",
-       "0       Kibana Airlines                          Frankfurt am Main Airport\n",
-       "1      Logstash Airways                    Cape Town International Airport\n",
-       "2      Logstash Airways                          Venice Marco Polo Airport\n",
-       "3       Kibana Airlines                       Naples International Airport\n",
-       "4       Kibana Airlines     Licenciado Benito Juarez International Airport\n",
-       "...                 ...                                                ...\n",
-       "13054  Logstash Airways                         Pisa International Airport\n",
-       "13055  Logstash Airways  Winnipeg / James Armstrong Richardson Internat...\n",
-       "13056  Logstash Airways     Licenciado Benito Juarez International Airport\n",
-       "13057          JetBeats                                      Itami Airport\n",
-       "13058          JetBeats                     Adelaide International Airport\n",
-       "\n",
-       "[13059 rows x 2 columns]"
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "UXLIpuFTO8pq",
+        "outputId": "647afe26-7852-44fa-eb7f-e4184853aca0"
+      },
+      "execution_count": 3,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "{'name': 'instance-0000000000', 'cluster_name': '9fcead8be8d2469fa096128e20496cee', 'cluster_uuid': 'Vb-ose0ZTJah2ikFeONNIA', 'version': {'number': '8.9.1', 'build_flavor': 'default', 'build_type': 'docker', 'build_hash': 'a813d015ef1826148d9d389bd1c0d781c6e349f0', 'build_date': '2023-08-10T05:02:32.517455352Z', 'build_snapshot': False, 'lucene_version': '9.7.0', 'minimum_wire_compatibility_version': '7.17.0', 'minimum_index_compatibility_version': '7.0.0'}, 'tagline': 'You Know, for Search'}\n",
+            "Cloning into 'eland'...\n",
+            "remote: Enumerating objects: 5073, done.\u001b[K\n",
+            "remote: Counting objects: 100% (1719/1719), done.\u001b[K\n",
+            "remote: Compressing objects: 100% (551/551), done.\u001b[K\n",
+            "remote: Total 5073 (delta 1408), reused 1358 (delta 1167), pack-reused 3354\u001b[K\n",
+            "Receiving objects: 100% (5073/5073), 17.37 MiB | 38.67 MiB/s, done.\n",
+            "Resolving deltas: 100% (3573/3573), done.\n",
+            "Deleting index: flights\n",
+            "Creating index: flights\n",
+            "Adding 13059 items to index: flights\n",
+            "Done flights\n",
+            "Deleting index: flights_small\n",
+            "Creating index: flights_small\n",
+            "Adding 48 items to index: flights_small\n",
+            "Done flights_small\n",
+            "Deleting index: ecommerce\n",
+            "Creating index: ecommerce\n",
+            "Adding 4675 items to index: ecommerce\n",
+            "Done ecommerce\n"
+          ]
+        }
       ]
-     },
-     "execution_count": 29,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "pd_flights.get(['Carrier', 'Origin'])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "List input not currently supported by `eland.DataFrame.get`"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 30,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-15T20:24:44.263674Z",
-     "iopub.status.busy": "2021-12-15T20:24:44.261671Z",
-     "iopub.status.idle": "2021-12-15T20:24:44.266564Z",
-     "shell.execute_reply": "2021-12-15T20:24:44.267454Z"
     },
-    "pycharm": {
-     "is_executing": false
-    }
-   },
-   "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "unhashable type: 'list'\n"
-     ]
-    }
-   ],
-   "source": [
-    "try:\n",
-    "    ed_flights.get(['Carrier', 'Origin'])\n",
-    "except TypeError as e:\n",
-    "    print(e)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### DataFrame.query"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 31,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-15T20:24:44.291893Z",
-     "iopub.status.busy": "2021-12-15T20:24:44.279615Z",
-     "iopub.status.idle": "2021-12-15T20:24:44.294715Z",
-     "shell.execute_reply": "2021-12-15T20:24:44.294192Z"
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "c3Af_LIiNRFE"
+      },
+      "source": [
+        "## Compare Eland DataFrame vs pandas DataFrame"
+      ]
     },
-    "pycharm": {
-     "is_executing": false
-    }
-   },
-   "outputs": [
     {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>AvgTicketPrice</th>\n",
-       "      <th>Cancelled</th>\n",
-       "      <th>...</th>\n",
-       "      <th>dayOfWeek</th>\n",
-       "      <th>timestamp</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>8</th>\n",
-       "      <td>960.869736</td>\n",
-       "      <td>True</td>\n",
-       "      <td>...</td>\n",
-       "      <td>0</td>\n",
-       "      <td>2018-01-01 12:09:35</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>26</th>\n",
-       "      <td>975.812632</td>\n",
-       "      <td>True</td>\n",
-       "      <td>...</td>\n",
-       "      <td>0</td>\n",
-       "      <td>2018-01-01 15:38:32</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>311</th>\n",
-       "      <td>946.358410</td>\n",
-       "      <td>True</td>\n",
-       "      <td>...</td>\n",
-       "      <td>0</td>\n",
-       "      <td>2018-01-01 11:51:12</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>651</th>\n",
-       "      <td>975.383864</td>\n",
-       "      <td>True</td>\n",
-       "      <td>...</td>\n",
-       "      <td>2</td>\n",
-       "      <td>2018-01-03 21:13:17</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>950</th>\n",
-       "      <td>907.836523</td>\n",
-       "      <td>True</td>\n",
-       "      <td>...</td>\n",
-       "      <td>2</td>\n",
-       "      <td>2018-01-03 05:14:51</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>...</th>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>12820</th>\n",
-       "      <td>909.973606</td>\n",
-       "      <td>True</td>\n",
-       "      <td>...</td>\n",
-       "      <td>5</td>\n",
-       "      <td>2018-02-10 05:11:35</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>12906</th>\n",
-       "      <td>983.429244</td>\n",
-       "      <td>True</td>\n",
-       "      <td>...</td>\n",
-       "      <td>6</td>\n",
-       "      <td>2018-02-11 06:19:58</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>12918</th>\n",
-       "      <td>1136.678150</td>\n",
-       "      <td>True</td>\n",
-       "      <td>...</td>\n",
-       "      <td>6</td>\n",
-       "      <td>2018-02-11 16:03:10</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>12919</th>\n",
-       "      <td>1105.211803</td>\n",
-       "      <td>True</td>\n",
-       "      <td>...</td>\n",
-       "      <td>6</td>\n",
-       "      <td>2018-02-11 05:36:05</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>13013</th>\n",
-       "      <td>1055.350213</td>\n",
-       "      <td>True</td>\n",
-       "      <td>...</td>\n",
-       "      <td>6</td>\n",
-       "      <td>2018-02-11 13:20:16</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "<p>68 rows × 27 columns</p>\n",
-       "</div>"
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "bNs9FbAgNRFE"
+      },
+      "source": [
+        "Create an eland.DataFrame from a `flights` index"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 4,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2021-12-15T20:24:30.195931Z",
+          "iopub.status.busy": "2021-12-15T20:24:30.195563Z",
+          "iopub.status.idle": "2021-12-15T20:24:30.668077Z",
+          "shell.execute_reply": "2021-12-15T20:24:30.667531Z"
+        },
+        "pycharm": {
+          "is_executing": false
+        },
+        "id": "7_rgLmsLNRFF"
+      },
+      "outputs": [],
+      "source": [
+        "ed_flights = ed.DataFrame(es, 'flights')"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 5,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2021-12-15T20:24:30.673583Z",
+          "iopub.status.busy": "2021-12-15T20:24:30.673088Z",
+          "iopub.status.idle": "2021-12-15T20:24:30.677254Z",
+          "shell.execute_reply": "2021-12-15T20:24:30.677676Z"
+        },
+        "pycharm": {
+          "is_executing": false
+        },
+        "id": "ickl9aGUNRFH",
+        "outputId": "1039176a-2b64-4a01-ee7f-bacd6ca1a0bf",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
+      },
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "eland.dataframe.DataFrame"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 5
+        }
       ],
-      "text/plain": [
-       "       AvgTicketPrice  Cancelled  ... dayOfWeek           timestamp\n",
-       "8          960.869736       True  ...         0 2018-01-01 12:09:35\n",
-       "26         975.812632       True  ...         0 2018-01-01 15:38:32\n",
-       "311        946.358410       True  ...         0 2018-01-01 11:51:12\n",
-       "651        975.383864       True  ...         2 2018-01-03 21:13:17\n",
-       "950        907.836523       True  ...         2 2018-01-03 05:14:51\n",
-       "...               ...        ...  ...       ...                 ...\n",
-       "12820      909.973606       True  ...         5 2018-02-10 05:11:35\n",
-       "12906      983.429244       True  ...         6 2018-02-11 06:19:58\n",
-       "12918     1136.678150       True  ...         6 2018-02-11 16:03:10\n",
-       "12919     1105.211803       True  ...         6 2018-02-11 05:36:05\n",
-       "13013     1055.350213       True  ...         6 2018-02-11 13:20:16\n",
-       "\n",
-       "[68 rows x 27 columns]"
+      "source": [
+        "type(ed_flights)"
       ]
-     },
-     "execution_count": 31,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "pd_flights.query('Carrier == \"Kibana Airlines\" & AvgTicketPrice > 900.0 & Cancelled == True')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "`eland.DataFrame.query` requires qualifier on bool i.e.\n",
-    "\n",
-    "`ed_flights.query('Carrier == \"Kibana Airlines\" & AvgTicketPrice > 900.0 & Cancelled')` fails"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 32,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-15T20:24:44.317223Z",
-     "iopub.status.busy": "2021-12-15T20:24:44.316680Z",
-     "iopub.status.idle": "2021-12-15T20:24:46.365286Z",
-     "shell.execute_reply": "2021-12-15T20:24:46.366706Z"
     },
-    "pycharm": {
-     "is_executing": false
-    }
-   },
-   "outputs": [
     {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>AvgTicketPrice</th>\n",
-       "      <th>Cancelled</th>\n",
-       "      <th>...</th>\n",
-       "      <th>dayOfWeek</th>\n",
-       "      <th>timestamp</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>8</th>\n",
-       "      <td>960.869736</td>\n",
-       "      <td>True</td>\n",
-       "      <td>...</td>\n",
-       "      <td>0</td>\n",
-       "      <td>2018-01-01 12:09:35</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>26</th>\n",
-       "      <td>975.812632</td>\n",
-       "      <td>True</td>\n",
-       "      <td>...</td>\n",
-       "      <td>0</td>\n",
-       "      <td>2018-01-01 15:38:32</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>311</th>\n",
-       "      <td>946.358410</td>\n",
-       "      <td>True</td>\n",
-       "      <td>...</td>\n",
-       "      <td>0</td>\n",
-       "      <td>2018-01-01 11:51:12</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>651</th>\n",
-       "      <td>975.383864</td>\n",
-       "      <td>True</td>\n",
-       "      <td>...</td>\n",
-       "      <td>2</td>\n",
-       "      <td>2018-01-03 21:13:17</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>950</th>\n",
-       "      <td>907.836523</td>\n",
-       "      <td>True</td>\n",
-       "      <td>...</td>\n",
-       "      <td>2</td>\n",
-       "      <td>2018-01-03 05:14:51</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>...</th>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>12820</th>\n",
-       "      <td>909.973606</td>\n",
-       "      <td>True</td>\n",
-       "      <td>...</td>\n",
-       "      <td>5</td>\n",
-       "      <td>2018-02-10 05:11:35</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>12906</th>\n",
-       "      <td>983.429244</td>\n",
-       "      <td>True</td>\n",
-       "      <td>...</td>\n",
-       "      <td>6</td>\n",
-       "      <td>2018-02-11 06:19:58</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>12918</th>\n",
-       "      <td>1136.678150</td>\n",
-       "      <td>True</td>\n",
-       "      <td>...</td>\n",
-       "      <td>6</td>\n",
-       "      <td>2018-02-11 16:03:10</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>12919</th>\n",
-       "      <td>1105.211803</td>\n",
-       "      <td>True</td>\n",
-       "      <td>...</td>\n",
-       "      <td>6</td>\n",
-       "      <td>2018-02-11 05:36:05</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>13013</th>\n",
-       "      <td>1055.350213</td>\n",
-       "      <td>True</td>\n",
-       "      <td>...</td>\n",
-       "      <td>6</td>\n",
-       "      <td>2018-02-11 13:20:16</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>\n",
-       "<p>68 rows × 27 columns</p>"
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "8Y39fj7rNRFI"
+      },
+      "source": [
+        "Compare to pandas DataFrame (created from the same data)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 6,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2021-12-15T20:24:30.682438Z",
+          "iopub.status.busy": "2021-12-15T20:24:30.681925Z",
+          "iopub.status.idle": "2021-12-15T20:24:35.046707Z",
+          "shell.execute_reply": "2021-12-15T20:24:35.046060Z"
+        },
+        "pycharm": {
+          "is_executing": false
+        },
+        "id": "Qxz7lZ7zNRFI"
+      },
+      "outputs": [],
+      "source": [
+        "pd_flights = ed.eland_to_pandas(ed_flights)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 7,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2021-12-15T20:24:35.050698Z",
+          "iopub.status.busy": "2021-12-15T20:24:35.050158Z",
+          "iopub.status.idle": "2021-12-15T20:24:35.053100Z",
+          "shell.execute_reply": "2021-12-15T20:24:35.052560Z"
+        },
+        "pycharm": {
+          "is_executing": false
+        },
+        "id": "0f9qCkT3NRFJ",
+        "outputId": "eb8dd3b7-bc09-45a2-fded-7be827977190",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
+      },
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "pandas.core.frame.DataFrame"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 7
+        }
       ],
-      "text/plain": [
-       "       AvgTicketPrice  Cancelled  ... dayOfWeek           timestamp\n",
-       "8          960.869736       True  ...         0 2018-01-01 12:09:35\n",
-       "26         975.812632       True  ...         0 2018-01-01 15:38:32\n",
-       "311        946.358410       True  ...         0 2018-01-01 11:51:12\n",
-       "651        975.383864       True  ...         2 2018-01-03 21:13:17\n",
-       "950        907.836523       True  ...         2 2018-01-03 05:14:51\n",
-       "...               ...        ...  ...       ...                 ...\n",
-       "12820      909.973606       True  ...         5 2018-02-10 05:11:35\n",
-       "12906      983.429244       True  ...         6 2018-02-11 06:19:58\n",
-       "12918     1136.678150       True  ...         6 2018-02-11 16:03:10\n",
-       "12919     1105.211803       True  ...         6 2018-02-11 05:36:05\n",
-       "13013     1055.350213       True  ...         6 2018-02-11 13:20:16\n",
-       "\n",
-       "[68 rows x 27 columns]"
+      "source": [
+        "type(pd_flights)"
       ]
-     },
-     "execution_count": 32,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "ed_flights.query('Carrier == \"Kibana Airlines\" & AvgTicketPrice > 900.0 & Cancelled == True')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "#### Boolean indexing query"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 33,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-15T20:24:46.417274Z",
-     "iopub.status.busy": "2021-12-15T20:24:46.416156Z",
-     "iopub.status.idle": "2021-12-15T20:24:46.421120Z",
-     "shell.execute_reply": "2021-12-15T20:24:46.421781Z"
     },
-    "pycharm": {
-     "is_executing": false
-    }
-   },
-   "outputs": [
     {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>AvgTicketPrice</th>\n",
-       "      <th>Cancelled</th>\n",
-       "      <th>...</th>\n",
-       "      <th>dayOfWeek</th>\n",
-       "      <th>timestamp</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>8</th>\n",
-       "      <td>960.869736</td>\n",
-       "      <td>True</td>\n",
-       "      <td>...</td>\n",
-       "      <td>0</td>\n",
-       "      <td>2018-01-01 12:09:35</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>26</th>\n",
-       "      <td>975.812632</td>\n",
-       "      <td>True</td>\n",
-       "      <td>...</td>\n",
-       "      <td>0</td>\n",
-       "      <td>2018-01-01 15:38:32</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>311</th>\n",
-       "      <td>946.358410</td>\n",
-       "      <td>True</td>\n",
-       "      <td>...</td>\n",
-       "      <td>0</td>\n",
-       "      <td>2018-01-01 11:51:12</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>651</th>\n",
-       "      <td>975.383864</td>\n",
-       "      <td>True</td>\n",
-       "      <td>...</td>\n",
-       "      <td>2</td>\n",
-       "      <td>2018-01-03 21:13:17</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>950</th>\n",
-       "      <td>907.836523</td>\n",
-       "      <td>True</td>\n",
-       "      <td>...</td>\n",
-       "      <td>2</td>\n",
-       "      <td>2018-01-03 05:14:51</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>...</th>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>12820</th>\n",
-       "      <td>909.973606</td>\n",
-       "      <td>True</td>\n",
-       "      <td>...</td>\n",
-       "      <td>5</td>\n",
-       "      <td>2018-02-10 05:11:35</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>12906</th>\n",
-       "      <td>983.429244</td>\n",
-       "      <td>True</td>\n",
-       "      <td>...</td>\n",
-       "      <td>6</td>\n",
-       "      <td>2018-02-11 06:19:58</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>12918</th>\n",
-       "      <td>1136.678150</td>\n",
-       "      <td>True</td>\n",
-       "      <td>...</td>\n",
-       "      <td>6</td>\n",
-       "      <td>2018-02-11 16:03:10</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>12919</th>\n",
-       "      <td>1105.211803</td>\n",
-       "      <td>True</td>\n",
-       "      <td>...</td>\n",
-       "      <td>6</td>\n",
-       "      <td>2018-02-11 05:36:05</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>13013</th>\n",
-       "      <td>1055.350213</td>\n",
-       "      <td>True</td>\n",
-       "      <td>...</td>\n",
-       "      <td>6</td>\n",
-       "      <td>2018-02-11 13:20:16</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "<p>68 rows × 27 columns</p>\n",
-       "</div>"
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "idu_eqdsNRFK"
+      },
+      "source": [
+        "## Attributes and underlying data"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "bltr_0r-NRFL"
+      },
+      "source": [
+        "### DataFrame.columns"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 8,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2021-12-15T20:24:35.057245Z",
+          "iopub.status.busy": "2021-12-15T20:24:35.056812Z",
+          "iopub.status.idle": "2021-12-15T20:24:35.059852Z",
+          "shell.execute_reply": "2021-12-15T20:24:35.059182Z"
+        },
+        "pycharm": {
+          "is_executing": false
+        },
+        "id": "ZLVUimn_NRFL",
+        "outputId": "ce814e44-2c16-452d-f9f0-76acaee67940",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
+      },
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "Index(['AvgTicketPrice', 'Cancelled', 'Carrier', 'Dest', 'DestAirportID', 'DestCityName',\n",
+              "       'DestCountry', 'DestLocation', 'DestRegion', 'DestWeather', 'DistanceKilometers',\n",
+              "       'DistanceMiles', 'FlightDelay', 'FlightDelayMin', 'FlightDelayType', 'FlightNum',\n",
+              "       'FlightTimeHour', 'FlightTimeMin', 'Origin', 'OriginAirportID', 'OriginCityName',\n",
+              "       'OriginCountry', 'OriginLocation', 'OriginRegion', 'OriginWeather', 'dayOfWeek',\n",
+              "       'timestamp'],\n",
+              "      dtype='object')"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 8
+        }
       ],
-      "text/plain": [
-       "       AvgTicketPrice  Cancelled  ... dayOfWeek           timestamp\n",
-       "8          960.869736       True  ...         0 2018-01-01 12:09:35\n",
-       "26         975.812632       True  ...         0 2018-01-01 15:38:32\n",
-       "311        946.358410       True  ...         0 2018-01-01 11:51:12\n",
-       "651        975.383864       True  ...         2 2018-01-03 21:13:17\n",
-       "950        907.836523       True  ...         2 2018-01-03 05:14:51\n",
-       "...               ...        ...  ...       ...                 ...\n",
-       "12820      909.973606       True  ...         5 2018-02-10 05:11:35\n",
-       "12906      983.429244       True  ...         6 2018-02-11 06:19:58\n",
-       "12918     1136.678150       True  ...         6 2018-02-11 16:03:10\n",
-       "12919     1105.211803       True  ...         6 2018-02-11 05:36:05\n",
-       "13013     1055.350213       True  ...         6 2018-02-11 13:20:16\n",
-       "\n",
-       "[68 rows x 27 columns]"
+      "source": [
+        "pd_flights.columns"
       ]
-     },
-     "execution_count": 33,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "pd_flights[(pd_flights.Carrier==\"Kibana Airlines\") & \n",
-    "           (pd_flights.AvgTicketPrice > 900.0) &\n",
-    "           (pd_flights.Cancelled == True)]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 34,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-15T20:24:46.431697Z",
-     "iopub.status.busy": "2021-12-15T20:24:46.431114Z",
-     "iopub.status.idle": "2021-12-15T20:24:48.414684Z",
-     "shell.execute_reply": "2021-12-15T20:24:48.415148Z"
     },
-    "pycharm": {
-     "is_executing": false
-    }
-   },
-   "outputs": [
     {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>AvgTicketPrice</th>\n",
-       "      <th>Cancelled</th>\n",
-       "      <th>...</th>\n",
-       "      <th>dayOfWeek</th>\n",
-       "      <th>timestamp</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>8</th>\n",
-       "      <td>960.869736</td>\n",
-       "      <td>True</td>\n",
-       "      <td>...</td>\n",
-       "      <td>0</td>\n",
-       "      <td>2018-01-01 12:09:35</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>26</th>\n",
-       "      <td>975.812632</td>\n",
-       "      <td>True</td>\n",
-       "      <td>...</td>\n",
-       "      <td>0</td>\n",
-       "      <td>2018-01-01 15:38:32</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>311</th>\n",
-       "      <td>946.358410</td>\n",
-       "      <td>True</td>\n",
-       "      <td>...</td>\n",
-       "      <td>0</td>\n",
-       "      <td>2018-01-01 11:51:12</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>651</th>\n",
-       "      <td>975.383864</td>\n",
-       "      <td>True</td>\n",
-       "      <td>...</td>\n",
-       "      <td>2</td>\n",
-       "      <td>2018-01-03 21:13:17</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>950</th>\n",
-       "      <td>907.836523</td>\n",
-       "      <td>True</td>\n",
-       "      <td>...</td>\n",
-       "      <td>2</td>\n",
-       "      <td>2018-01-03 05:14:51</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>...</th>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>12820</th>\n",
-       "      <td>909.973606</td>\n",
-       "      <td>True</td>\n",
-       "      <td>...</td>\n",
-       "      <td>5</td>\n",
-       "      <td>2018-02-10 05:11:35</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>12906</th>\n",
-       "      <td>983.429244</td>\n",
-       "      <td>True</td>\n",
-       "      <td>...</td>\n",
-       "      <td>6</td>\n",
-       "      <td>2018-02-11 06:19:58</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>12918</th>\n",
-       "      <td>1136.678150</td>\n",
-       "      <td>True</td>\n",
-       "      <td>...</td>\n",
-       "      <td>6</td>\n",
-       "      <td>2018-02-11 16:03:10</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>12919</th>\n",
-       "      <td>1105.211803</td>\n",
-       "      <td>True</td>\n",
-       "      <td>...</td>\n",
-       "      <td>6</td>\n",
-       "      <td>2018-02-11 05:36:05</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>13013</th>\n",
-       "      <td>1055.350213</td>\n",
-       "      <td>True</td>\n",
-       "      <td>...</td>\n",
-       "      <td>6</td>\n",
-       "      <td>2018-02-11 13:20:16</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>\n",
-       "<p>68 rows × 27 columns</p>"
+      "cell_type": "code",
+      "execution_count": 9,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2021-12-15T20:24:35.063057Z",
+          "iopub.status.busy": "2021-12-15T20:24:35.062660Z",
+          "iopub.status.idle": "2021-12-15T20:24:35.065130Z",
+          "shell.execute_reply": "2021-12-15T20:24:35.064757Z"
+        },
+        "pycharm": {
+          "is_executing": false
+        },
+        "id": "UcFhMhhFNRFM",
+        "outputId": "14e25022-c0dd-4856-e586-9060ed775744",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
+      },
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "Index(['AvgTicketPrice', 'Cancelled', 'Carrier', 'Dest', 'DestAirportID', 'DestCityName',\n",
+              "       'DestCountry', 'DestLocation', 'DestRegion', 'DestWeather', 'DistanceKilometers',\n",
+              "       'DistanceMiles', 'FlightDelay', 'FlightDelayMin', 'FlightDelayType', 'FlightNum',\n",
+              "       'FlightTimeHour', 'FlightTimeMin', 'Origin', 'OriginAirportID', 'OriginCityName',\n",
+              "       'OriginCountry', 'OriginLocation', 'OriginRegion', 'OriginWeather', 'dayOfWeek',\n",
+              "       'timestamp'],\n",
+              "      dtype='object')"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 9
+        }
       ],
-      "text/plain": [
-       "       AvgTicketPrice  Cancelled  ... dayOfWeek           timestamp\n",
-       "8          960.869736       True  ...         0 2018-01-01 12:09:35\n",
-       "26         975.812632       True  ...         0 2018-01-01 15:38:32\n",
-       "311        946.358410       True  ...         0 2018-01-01 11:51:12\n",
-       "651        975.383864       True  ...         2 2018-01-03 21:13:17\n",
-       "950        907.836523       True  ...         2 2018-01-03 05:14:51\n",
-       "...               ...        ...  ...       ...                 ...\n",
-       "12820      909.973606       True  ...         5 2018-02-10 05:11:35\n",
-       "12906      983.429244       True  ...         6 2018-02-11 06:19:58\n",
-       "12918     1136.678150       True  ...         6 2018-02-11 16:03:10\n",
-       "12919     1105.211803       True  ...         6 2018-02-11 05:36:05\n",
-       "13013     1055.350213       True  ...         6 2018-02-11 13:20:16\n",
-       "\n",
-       "[68 rows x 27 columns]"
+      "source": [
+        "ed_flights.columns"
       ]
-     },
-     "execution_count": 34,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "ed_flights[(ed_flights.Carrier==\"Kibana Airlines\") & \n",
-    "           (ed_flights.AvgTicketPrice > 900.0) &\n",
-    "           (ed_flights.Cancelled == True)]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Function application, GroupBy & window"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### DataFrame.aggs"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 35,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-15T20:24:48.421015Z",
-     "iopub.status.busy": "2021-12-15T20:24:48.420431Z",
-     "iopub.status.idle": "2021-12-15T20:24:48.428382Z",
-     "shell.execute_reply": "2021-12-15T20:24:48.428690Z"
     },
-    "pycharm": {
-     "is_executing": false
-    }
-   },
-   "outputs": [
     {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>DistanceKilometers</th>\n",
-       "      <th>AvgTicketPrice</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>sum</th>\n",
-       "      <td>9.261629e+07</td>\n",
-       "      <td>8.204365e+06</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>min</th>\n",
-       "      <td>0.000000e+00</td>\n",
-       "      <td>1.000205e+02</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>std</th>\n",
-       "      <td>4.578438e+03</td>\n",
-       "      <td>2.663969e+02</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "NPoDKfjYNRFM"
+      },
+      "source": [
+        "### DataFrame.dtypes"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 10,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2021-12-15T20:24:35.076896Z",
+          "iopub.status.busy": "2021-12-15T20:24:35.076493Z",
+          "iopub.status.idle": "2021-12-15T20:24:35.079007Z",
+          "shell.execute_reply": "2021-12-15T20:24:35.078592Z"
+        },
+        "pycharm": {
+          "is_executing": false
+        },
+        "id": "b0Xh8p_nNRFN",
+        "outputId": "2b12440d-05f4-4e31-ea1b-c09ae4f0f058",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
+      },
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "AvgTicketPrice           float64\n",
+              "Cancelled                   bool\n",
+              "Carrier                   object\n",
+              "Dest                      object\n",
+              "DestAirportID             object\n",
+              "                       ...      \n",
+              "OriginLocation            object\n",
+              "OriginRegion              object\n",
+              "OriginWeather             object\n",
+              "dayOfWeek                  int64\n",
+              "timestamp         datetime64[ns]\n",
+              "Length: 27, dtype: object"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 10
+        }
       ],
-      "text/plain": [
-       "     DistanceKilometers  AvgTicketPrice\n",
-       "sum        9.261629e+07    8.204365e+06\n",
-       "min        0.000000e+00    1.000205e+02\n",
-       "std        4.578438e+03    2.663969e+02"
+      "source": [
+        "pd_flights.dtypes"
       ]
-     },
-     "execution_count": 35,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "pd_flights[['DistanceKilometers', 'AvgTicketPrice']].aggregate(['sum', 'min', 'std'])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "`eland.DataFrame.aggregate` currently only supported numeric columns"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 36,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-15T20:24:48.433082Z",
-     "iopub.status.busy": "2021-12-15T20:24:48.432716Z",
-     "iopub.status.idle": "2021-12-15T20:24:48.541272Z",
-     "shell.execute_reply": "2021-12-15T20:24:48.542346Z"
     },
-    "pycharm": {
-     "is_executing": false
-    }
-   },
-   "outputs": [
     {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>DistanceKilometers</th>\n",
-       "      <th>AvgTicketPrice</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>sum</th>\n",
-       "      <td>9.261629e+07</td>\n",
-       "      <td>8.204365e+06</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>min</th>\n",
-       "      <td>0.000000e+00</td>\n",
-       "      <td>1.000205e+02</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>std</th>\n",
-       "      <td>4.578614e+03</td>\n",
-       "      <td>2.664071e+02</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
+      "cell_type": "code",
+      "execution_count": 11,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2021-12-15T20:24:35.083103Z",
+          "iopub.status.busy": "2021-12-15T20:24:35.082693Z",
+          "iopub.status.idle": "2021-12-15T20:24:35.085336Z",
+          "shell.execute_reply": "2021-12-15T20:24:35.084836Z"
+        },
+        "pycharm": {
+          "is_executing": false
+        },
+        "id": "IrDE-STnNRFN",
+        "outputId": "e6c2861e-ea3d-481c-d771-5e7cb30db622",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
+      },
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "AvgTicketPrice           float64\n",
+              "Cancelled                   bool\n",
+              "Carrier                   object\n",
+              "Dest                      object\n",
+              "DestAirportID             object\n",
+              "                       ...      \n",
+              "OriginLocation            object\n",
+              "OriginRegion              object\n",
+              "OriginWeather             object\n",
+              "dayOfWeek                  int64\n",
+              "timestamp         datetime64[ns]\n",
+              "Length: 27, dtype: object"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 11
+        }
       ],
-      "text/plain": [
-       "     DistanceKilometers  AvgTicketPrice\n",
-       "sum        9.261629e+07    8.204365e+06\n",
-       "min        0.000000e+00    1.000205e+02\n",
-       "std        4.578614e+03    2.664071e+02"
+      "source": [
+        "ed_flights.dtypes"
       ]
-     },
-     "execution_count": 36,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "ed_flights[['DistanceKilometers', 'AvgTicketPrice']].aggregate(['sum', 'min', 'std'])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Computations / descriptive stats"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### DataFrame.count"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 37,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-15T20:24:48.574692Z",
-     "iopub.status.busy": "2021-12-15T20:24:48.574008Z",
-     "iopub.status.idle": "2021-12-15T20:24:48.580240Z",
-     "shell.execute_reply": "2021-12-15T20:24:48.579845Z"
     },
-    "pycharm": {
-     "is_executing": false
-    }
-   },
-   "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "AvgTicketPrice    13059\n",
-       "Cancelled         13059\n",
-       "Carrier           13059\n",
-       "Dest              13059\n",
-       "DestAirportID     13059\n",
-       "                  ...  \n",
-       "OriginLocation    13059\n",
-       "OriginRegion      13059\n",
-       "OriginWeather     13059\n",
-       "dayOfWeek         13059\n",
-       "timestamp         13059\n",
-       "Length: 27, dtype: int64"
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "b4KBN1iQNRFN"
+      },
+      "source": [
+        "### DataFrame.select_dtypes"
       ]
-     },
-     "execution_count": 37,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "pd_flights.count()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 38,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-15T20:24:48.583948Z",
-     "iopub.status.busy": "2021-12-15T20:24:48.583565Z",
-     "iopub.status.idle": "2021-12-15T20:24:50.642201Z",
-     "shell.execute_reply": "2021-12-15T20:24:50.643158Z"
     },
-    "pycharm": {
-     "is_executing": false
-    }
-   },
-   "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "AvgTicketPrice    13059\n",
-       "Cancelled         13059\n",
-       "Carrier           13059\n",
-       "Dest              13059\n",
-       "DestAirportID     13059\n",
-       "                  ...  \n",
-       "OriginLocation    13059\n",
-       "OriginRegion      13059\n",
-       "OriginWeather     13059\n",
-       "dayOfWeek         13059\n",
-       "timestamp         13059\n",
-       "Length: 27, dtype: int64"
-      ]
-     },
-     "execution_count": 38,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "ed_flights.count()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### DataFrame.describe"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 39,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-15T20:24:50.655939Z",
-     "iopub.status.busy": "2021-12-15T20:24:50.654654Z",
-     "iopub.status.idle": "2021-12-15T20:24:50.702251Z",
-     "shell.execute_reply": "2021-12-15T20:24:50.701757Z"
-    },
-    "pycharm": {
-     "is_executing": false
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>AvgTicketPrice</th>\n",
-       "      <th>DistanceKilometers</th>\n",
-       "      <th>...</th>\n",
-       "      <th>FlightTimeMin</th>\n",
-       "      <th>dayOfWeek</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>count</th>\n",
-       "      <td>13059.000000</td>\n",
-       "      <td>13059.000000</td>\n",
-       "      <td>...</td>\n",
-       "      <td>13059.000000</td>\n",
-       "      <td>13059.000000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>mean</th>\n",
-       "      <td>628.253689</td>\n",
-       "      <td>7092.142455</td>\n",
-       "      <td>...</td>\n",
-       "      <td>511.127842</td>\n",
-       "      <td>2.835975</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>std</th>\n",
-       "      <td>266.396861</td>\n",
-       "      <td>4578.438497</td>\n",
-       "      <td>...</td>\n",
-       "      <td>334.753952</td>\n",
-       "      <td>1.939439</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>min</th>\n",
-       "      <td>100.020528</td>\n",
-       "      <td>0.000000</td>\n",
-       "      <td>...</td>\n",
-       "      <td>0.000000</td>\n",
-       "      <td>0.000000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>25%</th>\n",
-       "      <td>409.893816</td>\n",
-       "      <td>2459.705673</td>\n",
-       "      <td>...</td>\n",
-       "      <td>252.333192</td>\n",
-       "      <td>1.000000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>50%</th>\n",
-       "      <td>640.556668</td>\n",
-       "      <td>7610.330866</td>\n",
-       "      <td>...</td>\n",
-       "      <td>503.045170</td>\n",
-       "      <td>3.000000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>75%</th>\n",
-       "      <td>842.185470</td>\n",
-       "      <td>9736.637600</td>\n",
-       "      <td>...</td>\n",
-       "      <td>720.416036</td>\n",
-       "      <td>4.000000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>max</th>\n",
-       "      <td>1199.729053</td>\n",
-       "      <td>19881.482315</td>\n",
-       "      <td>...</td>\n",
-       "      <td>1902.902032</td>\n",
-       "      <td>6.000000</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "<p>8 rows × 7 columns</p>\n",
-       "</div>"
+      "cell_type": "code",
+      "execution_count": 12,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2021-12-15T20:24:35.090387Z",
+          "iopub.status.busy": "2021-12-15T20:24:35.089910Z",
+          "iopub.status.idle": "2021-12-15T20:24:35.113517Z",
+          "shell.execute_reply": "2021-12-15T20:24:35.113801Z"
+        },
+        "pycharm": {
+          "is_executing": false
+        },
+        "id": "MOAMAU4DNRFO",
+        "outputId": "7a3afb74-3259-4e5a-b0d7-af9201348346",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 424
+        }
+      },
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "       AvgTicketPrice  DistanceKilometers  ...  FlightTimeMin  dayOfWeek\n",
+              "0          841.265642        16492.326654  ...    1030.770416          0\n",
+              "1          882.982662         8823.400140  ...     464.389481          0\n",
+              "2          190.636904            0.000000  ...       0.000000          0\n",
+              "3          181.694216          555.737767  ...     222.749059          0\n",
+              "4          730.041778        13358.244200  ...     785.779071          0\n",
+              "...               ...                 ...  ...            ...        ...\n",
+              "13054     1080.446279         8058.581753  ...     402.929088          6\n",
+              "13055      646.612941         7088.598322  ...     644.418029          6\n",
+              "13056      997.751876        10920.652972  ...     937.540811          6\n",
+              "13057     1102.814465        18748.859647  ...    1697.404971          6\n",
+              "13058      858.144337        16809.141923  ...    1610.761827          6\n",
+              "\n",
+              "[13059 rows x 7 columns]"
+            ],
+            "text/html": [
+              "\n",
+              "  <div id=\"df-5769e971-1862-4e81-af6c-1664d699208d\" class=\"colab-df-container\">\n",
+              "    <div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>AvgTicketPrice</th>\n",
+              "      <th>DistanceKilometers</th>\n",
+              "      <th>...</th>\n",
+              "      <th>FlightTimeMin</th>\n",
+              "      <th>dayOfWeek</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>841.265642</td>\n",
+              "      <td>16492.326654</td>\n",
+              "      <td>...</td>\n",
+              "      <td>1030.770416</td>\n",
+              "      <td>0</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>1</th>\n",
+              "      <td>882.982662</td>\n",
+              "      <td>8823.400140</td>\n",
+              "      <td>...</td>\n",
+              "      <td>464.389481</td>\n",
+              "      <td>0</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>2</th>\n",
+              "      <td>190.636904</td>\n",
+              "      <td>0.000000</td>\n",
+              "      <td>...</td>\n",
+              "      <td>0.000000</td>\n",
+              "      <td>0</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>3</th>\n",
+              "      <td>181.694216</td>\n",
+              "      <td>555.737767</td>\n",
+              "      <td>...</td>\n",
+              "      <td>222.749059</td>\n",
+              "      <td>0</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>4</th>\n",
+              "      <td>730.041778</td>\n",
+              "      <td>13358.244200</td>\n",
+              "      <td>...</td>\n",
+              "      <td>785.779071</td>\n",
+              "      <td>0</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>...</th>\n",
+              "      <td>...</td>\n",
+              "      <td>...</td>\n",
+              "      <td>...</td>\n",
+              "      <td>...</td>\n",
+              "      <td>...</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>13054</th>\n",
+              "      <td>1080.446279</td>\n",
+              "      <td>8058.581753</td>\n",
+              "      <td>...</td>\n",
+              "      <td>402.929088</td>\n",
+              "      <td>6</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>13055</th>\n",
+              "      <td>646.612941</td>\n",
+              "      <td>7088.598322</td>\n",
+              "      <td>...</td>\n",
+              "      <td>644.418029</td>\n",
+              "      <td>6</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>13056</th>\n",
+              "      <td>997.751876</td>\n",
+              "      <td>10920.652972</td>\n",
+              "      <td>...</td>\n",
+              "      <td>937.540811</td>\n",
+              "      <td>6</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>13057</th>\n",
+              "      <td>1102.814465</td>\n",
+              "      <td>18748.859647</td>\n",
+              "      <td>...</td>\n",
+              "      <td>1697.404971</td>\n",
+              "      <td>6</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>13058</th>\n",
+              "      <td>858.144337</td>\n",
+              "      <td>16809.141923</td>\n",
+              "      <td>...</td>\n",
+              "      <td>1610.761827</td>\n",
+              "      <td>6</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "<p>13059 rows × 7 columns</p>\n",
+              "</div>\n",
+              "    <div class=\"colab-df-buttons\">\n",
+              "\n",
+              "  <div class=\"colab-df-container\">\n",
+              "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-5769e971-1862-4e81-af6c-1664d699208d')\"\n",
+              "            title=\"Convert this dataframe to an interactive table.\"\n",
+              "            style=\"display:none;\">\n",
+              "\n",
+              "  <svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\" viewBox=\"0 -960 960 960\">\n",
+              "    <path d=\"M120-120v-720h720v720H120Zm60-500h600v-160H180v160Zm220 220h160v-160H400v160Zm0 220h160v-160H400v160ZM180-400h160v-160H180v160Zm440 0h160v-160H620v160ZM180-180h160v-160H180v160Zm440 0h160v-160H620v160Z\"/>\n",
+              "  </svg>\n",
+              "    </button>\n",
+              "\n",
+              "  <style>\n",
+              "    .colab-df-container {\n",
+              "      display:flex;\n",
+              "      gap: 12px;\n",
+              "    }\n",
+              "\n",
+              "    .colab-df-convert {\n",
+              "      background-color: #E8F0FE;\n",
+              "      border: none;\n",
+              "      border-radius: 50%;\n",
+              "      cursor: pointer;\n",
+              "      display: none;\n",
+              "      fill: #1967D2;\n",
+              "      height: 32px;\n",
+              "      padding: 0 0 0 0;\n",
+              "      width: 32px;\n",
+              "    }\n",
+              "\n",
+              "    .colab-df-convert:hover {\n",
+              "      background-color: #E2EBFA;\n",
+              "      box-shadow: 0px 1px 2px rgba(60, 64, 67, 0.3), 0px 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
+              "      fill: #174EA6;\n",
+              "    }\n",
+              "\n",
+              "    .colab-df-buttons div {\n",
+              "      margin-bottom: 4px;\n",
+              "    }\n",
+              "\n",
+              "    [theme=dark] .colab-df-convert {\n",
+              "      background-color: #3B4455;\n",
+              "      fill: #D2E3FC;\n",
+              "    }\n",
+              "\n",
+              "    [theme=dark] .colab-df-convert:hover {\n",
+              "      background-color: #434B5C;\n",
+              "      box-shadow: 0px 1px 3px 1px rgba(0, 0, 0, 0.15);\n",
+              "      filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.3));\n",
+              "      fill: #FFFFFF;\n",
+              "    }\n",
+              "  </style>\n",
+              "\n",
+              "    <script>\n",
+              "      const buttonEl =\n",
+              "        document.querySelector('#df-5769e971-1862-4e81-af6c-1664d699208d button.colab-df-convert');\n",
+              "      buttonEl.style.display =\n",
+              "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
+              "\n",
+              "      async function convertToInteractive(key) {\n",
+              "        const element = document.querySelector('#df-5769e971-1862-4e81-af6c-1664d699208d');\n",
+              "        const dataTable =\n",
+              "          await google.colab.kernel.invokeFunction('convertToInteractive',\n",
+              "                                                    [key], {});\n",
+              "        if (!dataTable) return;\n",
+              "\n",
+              "        const docLinkHtml = 'Like what you see? Visit the ' +\n",
+              "          '<a target=\"_blank\" href=https://colab.research.google.com/notebooks/data_table.ipynb>data table notebook</a>'\n",
+              "          + ' to learn more about interactive tables.';\n",
+              "        element.innerHTML = '';\n",
+              "        dataTable['output_type'] = 'display_data';\n",
+              "        await google.colab.output.renderOutput(dataTable, element);\n",
+              "        const docLink = document.createElement('div');\n",
+              "        docLink.innerHTML = docLinkHtml;\n",
+              "        element.appendChild(docLink);\n",
+              "      }\n",
+              "    </script>\n",
+              "  </div>\n",
+              "\n",
+              "\n",
+              "<div id=\"df-8c144ffe-aaab-4cdd-8ab4-c7f4562aa310\">\n",
+              "  <button class=\"colab-df-quickchart\" onclick=\"quickchart('df-8c144ffe-aaab-4cdd-8ab4-c7f4562aa310')\"\n",
+              "            title=\"Suggest charts.\"\n",
+              "            style=\"display:none;\">\n",
+              "\n",
+              "<svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\"viewBox=\"0 0 24 24\"\n",
+              "     width=\"24px\">\n",
+              "    <g>\n",
+              "        <path d=\"M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zM9 17H7v-7h2v7zm4 0h-2V7h2v10zm4 0h-2v-4h2v4z\"/>\n",
+              "    </g>\n",
+              "</svg>\n",
+              "  </button>\n",
+              "\n",
+              "<style>\n",
+              "  .colab-df-quickchart {\n",
+              "      --bg-color: #E8F0FE;\n",
+              "      --fill-color: #1967D2;\n",
+              "      --hover-bg-color: #E2EBFA;\n",
+              "      --hover-fill-color: #174EA6;\n",
+              "      --disabled-fill-color: #AAA;\n",
+              "      --disabled-bg-color: #DDD;\n",
+              "  }\n",
+              "\n",
+              "  [theme=dark] .colab-df-quickchart {\n",
+              "      --bg-color: #3B4455;\n",
+              "      --fill-color: #D2E3FC;\n",
+              "      --hover-bg-color: #434B5C;\n",
+              "      --hover-fill-color: #FFFFFF;\n",
+              "      --disabled-bg-color: #3B4455;\n",
+              "      --disabled-fill-color: #666;\n",
+              "  }\n",
+              "\n",
+              "  .colab-df-quickchart {\n",
+              "    background-color: var(--bg-color);\n",
+              "    border: none;\n",
+              "    border-radius: 50%;\n",
+              "    cursor: pointer;\n",
+              "    display: none;\n",
+              "    fill: var(--fill-color);\n",
+              "    height: 32px;\n",
+              "    padding: 0;\n",
+              "    width: 32px;\n",
+              "  }\n",
+              "\n",
+              "  .colab-df-quickchart:hover {\n",
+              "    background-color: var(--hover-bg-color);\n",
+              "    box-shadow: 0 1px 2px rgba(60, 64, 67, 0.3), 0 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
+              "    fill: var(--button-hover-fill-color);\n",
+              "  }\n",
+              "\n",
+              "  .colab-df-quickchart-complete:disabled,\n",
+              "  .colab-df-quickchart-complete:disabled:hover {\n",
+              "    background-color: var(--disabled-bg-color);\n",
+              "    fill: var(--disabled-fill-color);\n",
+              "    box-shadow: none;\n",
+              "  }\n",
+              "\n",
+              "  .colab-df-spinner {\n",
+              "    border: 2px solid var(--fill-color);\n",
+              "    border-color: transparent;\n",
+              "    border-bottom-color: var(--fill-color);\n",
+              "    animation:\n",
+              "      spin 1s steps(1) infinite;\n",
+              "  }\n",
+              "\n",
+              "  @keyframes spin {\n",
+              "    0% {\n",
+              "      border-color: transparent;\n",
+              "      border-bottom-color: var(--fill-color);\n",
+              "      border-left-color: var(--fill-color);\n",
+              "    }\n",
+              "    20% {\n",
+              "      border-color: transparent;\n",
+              "      border-left-color: var(--fill-color);\n",
+              "      border-top-color: var(--fill-color);\n",
+              "    }\n",
+              "    30% {\n",
+              "      border-color: transparent;\n",
+              "      border-left-color: var(--fill-color);\n",
+              "      border-top-color: var(--fill-color);\n",
+              "      border-right-color: var(--fill-color);\n",
+              "    }\n",
+              "    40% {\n",
+              "      border-color: transparent;\n",
+              "      border-right-color: var(--fill-color);\n",
+              "      border-top-color: var(--fill-color);\n",
+              "    }\n",
+              "    60% {\n",
+              "      border-color: transparent;\n",
+              "      border-right-color: var(--fill-color);\n",
+              "    }\n",
+              "    80% {\n",
+              "      border-color: transparent;\n",
+              "      border-right-color: var(--fill-color);\n",
+              "      border-bottom-color: var(--fill-color);\n",
+              "    }\n",
+              "    90% {\n",
+              "      border-color: transparent;\n",
+              "      border-bottom-color: var(--fill-color);\n",
+              "    }\n",
+              "  }\n",
+              "</style>\n",
+              "\n",
+              "  <script>\n",
+              "    async function quickchart(key) {\n",
+              "      const quickchartButtonEl =\n",
+              "        document.querySelector('#' + key + ' button');\n",
+              "      quickchartButtonEl.disabled = true;  // To prevent multiple clicks.\n",
+              "      quickchartButtonEl.classList.add('colab-df-spinner');\n",
+              "      try {\n",
+              "        const charts = await google.colab.kernel.invokeFunction(\n",
+              "            'suggestCharts', [key], {});\n",
+              "      } catch (error) {\n",
+              "        console.error('Error during call to suggestCharts:', error);\n",
+              "      }\n",
+              "      quickchartButtonEl.classList.remove('colab-df-spinner');\n",
+              "      quickchartButtonEl.classList.add('colab-df-quickchart-complete');\n",
+              "    }\n",
+              "    (() => {\n",
+              "      let quickchartButtonEl =\n",
+              "        document.querySelector('#df-8c144ffe-aaab-4cdd-8ab4-c7f4562aa310 button');\n",
+              "      quickchartButtonEl.style.display =\n",
+              "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
+              "    })();\n",
+              "  </script>\n",
+              "</div>\n",
+              "    </div>\n",
+              "  </div>\n"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 12
+        }
       ],
-      "text/plain": [
-       "       AvgTicketPrice  DistanceKilometers  ...  FlightTimeMin     dayOfWeek\n",
-       "count    13059.000000        13059.000000  ...   13059.000000  13059.000000\n",
-       "mean       628.253689         7092.142455  ...     511.127842      2.835975\n",
-       "std        266.396861         4578.438497  ...     334.753952      1.939439\n",
-       "min        100.020528            0.000000  ...       0.000000      0.000000\n",
-       "25%        409.893816         2459.705673  ...     252.333192      1.000000\n",
-       "50%        640.556668         7610.330866  ...     503.045170      3.000000\n",
-       "75%        842.185470         9736.637600  ...     720.416036      4.000000\n",
-       "max       1199.729053        19881.482315  ...    1902.902032      6.000000\n",
-       "\n",
-       "[8 rows x 7 columns]"
+      "source": [
+        "pd_flights.select_dtypes(include=np.number)"
       ]
-     },
-     "execution_count": 39,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "pd_flights.describe()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Values returned from `eland.DataFrame.describe` may vary due to results of Elasticsearch aggregations."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 40,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-15T20:24:50.710321Z",
-     "iopub.status.busy": "2021-12-15T20:24:50.709905Z",
-     "iopub.status.idle": "2021-12-15T20:24:50.912876Z",
-     "shell.execute_reply": "2021-12-15T20:24:50.913469Z"
     },
-    "pycharm": {
-     "is_executing": false
-    }
-   },
-   "outputs": [
     {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>AvgTicketPrice</th>\n",
-       "      <th>Cancelled</th>\n",
-       "      <th>...</th>\n",
-       "      <th>FlightTimeMin</th>\n",
-       "      <th>dayOfWeek</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>count</th>\n",
-       "      <td>13059.000000</td>\n",
-       "      <td>13059.000000</td>\n",
-       "      <td>...</td>\n",
-       "      <td>13059.000000</td>\n",
-       "      <td>13059.000000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>mean</th>\n",
-       "      <td>628.253689</td>\n",
-       "      <td>0.128494</td>\n",
-       "      <td>...</td>\n",
-       "      <td>511.127842</td>\n",
-       "      <td>2.835975</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>std</th>\n",
-       "      <td>266.407061</td>\n",
-       "      <td>0.334664</td>\n",
-       "      <td>...</td>\n",
-       "      <td>334.766770</td>\n",
-       "      <td>1.939513</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>min</th>\n",
-       "      <td>100.020531</td>\n",
-       "      <td>0.000000</td>\n",
-       "      <td>...</td>\n",
-       "      <td>0.000000</td>\n",
-       "      <td>0.000000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>25%</th>\n",
-       "      <td>410.008918</td>\n",
-       "      <td>0.000000</td>\n",
-       "      <td>...</td>\n",
-       "      <td>251.938710</td>\n",
-       "      <td>1.000000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>50%</th>\n",
-       "      <td>640.387285</td>\n",
-       "      <td>0.000000</td>\n",
-       "      <td>...</td>\n",
-       "      <td>503.148975</td>\n",
-       "      <td>3.000000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>75%</th>\n",
-       "      <td>842.213490</td>\n",
-       "      <td>0.000000</td>\n",
-       "      <td>...</td>\n",
-       "      <td>720.505705</td>\n",
-       "      <td>4.000000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>max</th>\n",
-       "      <td>1199.729004</td>\n",
-       "      <td>1.000000</td>\n",
-       "      <td>...</td>\n",
-       "      <td>1902.901978</td>\n",
-       "      <td>6.000000</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "<p>8 rows × 9 columns</p>\n",
-       "</div>"
+      "cell_type": "code",
+      "execution_count": 13,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2021-12-15T20:24:35.131083Z",
+          "iopub.status.busy": "2021-12-15T20:24:35.130699Z",
+          "iopub.status.idle": "2021-12-15T20:24:38.362018Z",
+          "shell.execute_reply": "2021-12-15T20:24:38.360520Z"
+        },
+        "pycharm": {
+          "is_executing": false
+        },
+        "id": "QyaBzEf-NRFO",
+        "outputId": "c71e7496-7564-4881-c272-3eede3536d34",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 424
+        }
+      },
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "       AvgTicketPrice  DistanceKilometers  ...  FlightTimeMin  dayOfWeek\n",
+              "0          841.265642        16492.326654  ...    1030.770416          0\n",
+              "1          882.982662         8823.400140  ...     464.389481          0\n",
+              "2          190.636904            0.000000  ...       0.000000          0\n",
+              "3          181.694216          555.737767  ...     222.749059          0\n",
+              "4          730.041778        13358.244200  ...     785.779071          0\n",
+              "...               ...                 ...  ...            ...        ...\n",
+              "13054     1080.446279         8058.581753  ...     402.929088          6\n",
+              "13055      646.612941         7088.598322  ...     644.418029          6\n",
+              "13056      997.751876        10920.652972  ...     937.540811          6\n",
+              "13057     1102.814465        18748.859647  ...    1697.404971          6\n",
+              "13058      858.144337        16809.141923  ...    1610.761827          6\n",
+              "\n",
+              "[13059 rows x 7 columns]"
+            ],
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>AvgTicketPrice</th>\n",
+              "      <th>DistanceKilometers</th>\n",
+              "      <th>...</th>\n",
+              "      <th>FlightTimeMin</th>\n",
+              "      <th>dayOfWeek</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>841.265642</td>\n",
+              "      <td>16492.326654</td>\n",
+              "      <td>...</td>\n",
+              "      <td>1030.770416</td>\n",
+              "      <td>0</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>1</th>\n",
+              "      <td>882.982662</td>\n",
+              "      <td>8823.400140</td>\n",
+              "      <td>...</td>\n",
+              "      <td>464.389481</td>\n",
+              "      <td>0</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>2</th>\n",
+              "      <td>190.636904</td>\n",
+              "      <td>0.000000</td>\n",
+              "      <td>...</td>\n",
+              "      <td>0.000000</td>\n",
+              "      <td>0</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>3</th>\n",
+              "      <td>181.694216</td>\n",
+              "      <td>555.737767</td>\n",
+              "      <td>...</td>\n",
+              "      <td>222.749059</td>\n",
+              "      <td>0</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>4</th>\n",
+              "      <td>730.041778</td>\n",
+              "      <td>13358.244200</td>\n",
+              "      <td>...</td>\n",
+              "      <td>785.779071</td>\n",
+              "      <td>0</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>...</th>\n",
+              "      <td>...</td>\n",
+              "      <td>...</td>\n",
+              "      <td>...</td>\n",
+              "      <td>...</td>\n",
+              "      <td>...</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>13054</th>\n",
+              "      <td>1080.446279</td>\n",
+              "      <td>8058.581753</td>\n",
+              "      <td>...</td>\n",
+              "      <td>402.929088</td>\n",
+              "      <td>6</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>13055</th>\n",
+              "      <td>646.612941</td>\n",
+              "      <td>7088.598322</td>\n",
+              "      <td>...</td>\n",
+              "      <td>644.418029</td>\n",
+              "      <td>6</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>13056</th>\n",
+              "      <td>997.751876</td>\n",
+              "      <td>10920.652972</td>\n",
+              "      <td>...</td>\n",
+              "      <td>937.540811</td>\n",
+              "      <td>6</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>13057</th>\n",
+              "      <td>1102.814465</td>\n",
+              "      <td>18748.859647</td>\n",
+              "      <td>...</td>\n",
+              "      <td>1697.404971</td>\n",
+              "      <td>6</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>13058</th>\n",
+              "      <td>858.144337</td>\n",
+              "      <td>16809.141923</td>\n",
+              "      <td>...</td>\n",
+              "      <td>1610.761827</td>\n",
+              "      <td>6</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>\n",
+              "<p>13059 rows × 7 columns</p>"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 13
+        }
       ],
-      "text/plain": [
-       "       AvgTicketPrice     Cancelled  ...  FlightTimeMin     dayOfWeek\n",
-       "count    13059.000000  13059.000000  ...   13059.000000  13059.000000\n",
-       "mean       628.253689      0.128494  ...     511.127842      2.835975\n",
-       "std        266.407061      0.334664  ...     334.766770      1.939513\n",
-       "min        100.020531      0.000000  ...       0.000000      0.000000\n",
-       "25%        410.008918      0.000000  ...     251.938710      1.000000\n",
-       "50%        640.387285      0.000000  ...     503.148975      3.000000\n",
-       "75%        842.213490      0.000000  ...     720.505705      4.000000\n",
-       "max       1199.729004      1.000000  ...    1902.901978      6.000000\n",
-       "\n",
-       "[8 rows x 9 columns]"
+      "source": [
+        "ed_flights.select_dtypes(include=np.number)"
       ]
-     },
-     "execution_count": 40,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# NBVAL_IGNORE_OUTPUT\n",
-    "ed_flights.describe()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### DataFrame.info"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 41,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-15T20:24:50.944997Z",
-     "iopub.status.busy": "2021-12-15T20:24:50.918277Z",
-     "iopub.status.idle": "2021-12-15T20:24:50.958394Z",
-     "shell.execute_reply": "2021-12-15T20:24:50.958030Z"
     },
-    "pycharm": {
-     "is_executing": false
-    }
-   },
-   "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "<class 'pandas.core.frame.DataFrame'>\n",
-      "Index: 13059 entries, 0 to 13058\n",
-      "Data columns (total 27 columns):\n",
-      " #   Column              Non-Null Count  Dtype         \n",
-      "---  ------              --------------  -----         \n",
-      " 0   AvgTicketPrice      13059 non-null  float64       \n",
-      " 1   Cancelled           13059 non-null  bool          \n",
-      " 2   Carrier             13059 non-null  object        \n",
-      " 3   Dest                13059 non-null  object        \n",
-      " 4   DestAirportID       13059 non-null  object        \n",
-      " 5   DestCityName        13059 non-null  object        \n",
-      " 6   DestCountry         13059 non-null  object        \n",
-      " 7   DestLocation        13059 non-null  object        \n",
-      " 8   DestRegion          13059 non-null  object        \n",
-      " 9   DestWeather         13059 non-null  object        \n",
-      " 10  DistanceKilometers  13059 non-null  float64       \n",
-      " 11  DistanceMiles       13059 non-null  float64       \n",
-      " 12  FlightDelay         13059 non-null  bool          \n",
-      " 13  FlightDelayMin      13059 non-null  int64         \n",
-      " 14  FlightDelayType     13059 non-null  object        \n",
-      " 15  FlightNum           13059 non-null  object        \n",
-      " 16  FlightTimeHour      13059 non-null  float64       \n",
-      " 17  FlightTimeMin       13059 non-null  float64       \n",
-      " 18  Origin              13059 non-null  object        \n",
-      " 19  OriginAirportID     13059 non-null  object        \n",
-      " 20  OriginCityName      13059 non-null  object        \n",
-      " 21  OriginCountry       13059 non-null  object        \n",
-      " 22  OriginLocation      13059 non-null  object        \n",
-      " 23  OriginRegion        13059 non-null  object        \n",
-      " 24  OriginWeather       13059 non-null  object        \n",
-      " 25  dayOfWeek           13059 non-null  int64         \n",
-      " 26  timestamp           13059 non-null  datetime64[ns]\n",
-      "dtypes: bool(2), datetime64[ns](1), float64(5), int64(2), object(17)\n",
-      "memory usage: 3.1+ MB\n"
-     ]
-    }
-   ],
-   "source": [
-    "pd_flights.info()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 42,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-15T20:24:50.961762Z",
-     "iopub.status.busy": "2021-12-15T20:24:50.961398Z",
-     "iopub.status.idle": "2021-12-15T20:24:55.507758Z",
-     "shell.execute_reply": "2021-12-15T20:24:55.507382Z"
-    },
-    "pycharm": {
-     "is_executing": false
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "<class 'eland.dataframe.DataFrame'>\n",
-      "Index: 13059 entries, 0 to 13058\n",
-      "Data columns (total 27 columns):\n",
-      " #   Column              Non-Null Count  Dtype         \n",
-      "---  ------              --------------  -----         \n",
-      " 0   AvgTicketPrice      13059 non-null  float64       \n",
-      " 1   Cancelled           13059 non-null  bool          \n",
-      " 2   Carrier             13059 non-null  object        \n",
-      " 3   Dest                13059 non-null  object        \n",
-      " 4   DestAirportID       13059 non-null  object        \n",
-      " 5   DestCityName        13059 non-null  object        \n",
-      " 6   DestCountry         13059 non-null  object        \n",
-      " 7   DestLocation        13059 non-null  object        \n",
-      " 8   DestRegion          13059 non-null  object        \n",
-      " 9   DestWeather         13059 non-null  object        \n",
-      " 10  DistanceKilometers  13059 non-null  float64       \n",
-      " 11  DistanceMiles       13059 non-null  float64       \n",
-      " 12  FlightDelay         13059 non-null  bool          \n",
-      " 13  FlightDelayMin      13059 non-null  int64         \n",
-      " 14  FlightDelayType     13059 non-null  object        \n",
-      " 15  FlightNum           13059 non-null  object        \n",
-      " 16  FlightTimeHour      13059 non-null  float64       \n",
-      " 17  FlightTimeMin       13059 non-null  float64       \n",
-      " 18  Origin              13059 non-null  object        \n",
-      " 19  OriginAirportID     13059 non-null  object        \n",
-      " 20  OriginCityName      13059 non-null  object        \n",
-      " 21  OriginCountry       13059 non-null  object        \n",
-      " 22  OriginLocation      13059 non-null  object        \n",
-      " 23  OriginRegion        13059 non-null  object        \n",
-      " 24  OriginWeather       13059 non-null  object        \n",
-      " 25  dayOfWeek           13059 non-null  int64         \n",
-      " 26  timestamp           13059 non-null  datetime64[ns]\n",
-      "dtypes: bool(2), datetime64[ns](1), float64(5), int64(2), object(17)\n",
-      "memory usage: 64.000 bytes\n",
-      "Elasticsearch storage usage: 5.786 MB\n"
-     ]
-    }
-   ],
-   "source": [
-    "ed_flights.info()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### DataFrame.max, DataFrame.min, DataFrame.mean, DataFrame.sum"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "#### max"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 43,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-15T20:24:55.511067Z",
-     "iopub.status.busy": "2021-12-15T20:24:55.510706Z",
-     "iopub.status.idle": "2021-12-15T20:24:55.515166Z",
-     "shell.execute_reply": "2021-12-15T20:24:55.514795Z"
-    },
-    "pycharm": {
-     "is_executing": false
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "AvgTicketPrice         1199.729053\n",
-       "Cancelled                     True\n",
-       "DistanceKilometers    19881.482315\n",
-       "DistanceMiles         12353.780369\n",
-       "FlightDelay                   True\n",
-       "FlightDelayMin                 360\n",
-       "FlightTimeHour           31.715034\n",
-       "FlightTimeMin          1902.902032\n",
-       "dayOfWeek                        6\n",
-       "dtype: object"
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "E9hPiMkPNRFP"
+      },
+      "source": [
+        "### DataFrame.empty"
       ]
-     },
-     "execution_count": 43,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "pd_flights.max(numeric_only=True)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "`eland.DataFrame.max,min,mean,sum` only aggregate numeric columns"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 44,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-15T20:24:55.521502Z",
-     "iopub.status.busy": "2021-12-15T20:24:55.521124Z",
-     "iopub.status.idle": "2021-12-15T20:24:55.615898Z",
-     "shell.execute_reply": "2021-12-15T20:24:55.614418Z"
     },
-    "pycharm": {
-     "is_executing": false
-    }
-   },
-   "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "AvgTicketPrice         1199.729004\n",
-       "Cancelled                 1.000000\n",
-       "DistanceKilometers    19881.482422\n",
-       "DistanceMiles         12353.780273\n",
-       "FlightDelay               1.000000\n",
-       "FlightDelayMin          360.000000\n",
-       "FlightTimeHour           31.715034\n",
-       "FlightTimeMin          1902.901978\n",
-       "dayOfWeek                 6.000000\n",
-       "dtype: float64"
-      ]
-     },
-     "execution_count": 44,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "ed_flights.max(numeric_only=True)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "#### min"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 45,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-15T20:24:55.629444Z",
-     "iopub.status.busy": "2021-12-15T20:24:55.627340Z",
-     "iopub.status.idle": "2021-12-15T20:24:55.638818Z",
-     "shell.execute_reply": "2021-12-15T20:24:55.637856Z"
-    },
-    "pycharm": {
-     "is_executing": false
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "AvgTicketPrice        100.020528\n",
-       "Cancelled                  False\n",
-       "DistanceKilometers           0.0\n",
-       "DistanceMiles                0.0\n",
-       "FlightDelay                False\n",
-       "FlightDelayMin                 0\n",
-       "FlightTimeHour               0.0\n",
-       "FlightTimeMin                0.0\n",
-       "dayOfWeek                      0\n",
-       "dtype: object"
-      ]
-     },
-     "execution_count": 45,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "pd_flights.min(numeric_only=True)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 46,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-15T20:24:55.649953Z",
-     "iopub.status.busy": "2021-12-15T20:24:55.644304Z",
-     "iopub.status.idle": "2021-12-15T20:24:55.731911Z",
-     "shell.execute_reply": "2021-12-15T20:24:55.731393Z"
-    },
-    "pycharm": {
-     "is_executing": false
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "AvgTicketPrice        100.020531\n",
-       "Cancelled               0.000000\n",
-       "DistanceKilometers      0.000000\n",
-       "DistanceMiles           0.000000\n",
-       "FlightDelay             0.000000\n",
-       "FlightDelayMin          0.000000\n",
-       "FlightTimeHour          0.000000\n",
-       "FlightTimeMin           0.000000\n",
-       "dayOfWeek               0.000000\n",
-       "dtype: float64"
-      ]
-     },
-     "execution_count": 46,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "ed_flights.min(numeric_only=True)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "#### mean"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 47,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-15T20:24:55.735976Z",
-     "iopub.status.busy": "2021-12-15T20:24:55.735398Z",
-     "iopub.status.idle": "2021-12-15T20:24:55.740446Z",
-     "shell.execute_reply": "2021-12-15T20:24:55.740037Z"
-    },
-    "pycharm": {
-     "is_executing": false
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "AvgTicketPrice         628.253689\n",
-       "Cancelled                0.128494\n",
-       "DistanceKilometers    7092.142455\n",
-       "DistanceMiles         4406.853013\n",
-       "FlightDelay              0.251168\n",
-       "FlightDelayMin          47.335171\n",
-       "FlightTimeHour           8.518797\n",
-       "FlightTimeMin          511.127842\n",
-       "dayOfWeek                2.835975\n",
-       "dtype: float64"
-      ]
-     },
-     "execution_count": 47,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "pd_flights.mean(numeric_only=True)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 48,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-15T20:24:55.746976Z",
-     "iopub.status.busy": "2021-12-15T20:24:55.746605Z",
-     "iopub.status.idle": "2021-12-15T20:24:55.852359Z",
-     "shell.execute_reply": "2021-12-15T20:24:55.850558Z"
-    },
-    "pycharm": {
-     "is_executing": false
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "AvgTicketPrice         628.253689\n",
-       "Cancelled                0.128494\n",
-       "DistanceKilometers    7092.142457\n",
-       "DistanceMiles         4406.853010\n",
-       "FlightDelay              0.251168\n",
-       "FlightDelayMin          47.335171\n",
-       "FlightTimeHour           8.518797\n",
-       "FlightTimeMin          511.127842\n",
-       "dayOfWeek                2.835975\n",
-       "dtype: float64"
-      ]
-     },
-     "execution_count": 48,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "ed_flights.mean(numeric_only=True)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "#### sum"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 49,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-15T20:24:55.867747Z",
-     "iopub.status.busy": "2021-12-15T20:24:55.865996Z",
-     "iopub.status.idle": "2021-12-15T20:24:55.882127Z",
-     "shell.execute_reply": "2021-12-15T20:24:55.883534Z"
-    },
-    "pycharm": {
-     "is_executing": false
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "AvgTicketPrice        8.204365e+06\n",
-       "Cancelled             1.678000e+03\n",
-       "DistanceKilometers    9.261629e+07\n",
-       "DistanceMiles         5.754909e+07\n",
-       "FlightDelay           3.280000e+03\n",
-       "FlightDelayMin        6.181500e+05\n",
-       "FlightTimeHour        1.112470e+05\n",
-       "FlightTimeMin         6.674818e+06\n",
-       "dayOfWeek             3.703500e+04\n",
-       "dtype: float64"
-      ]
-     },
-     "execution_count": 49,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "pd_flights.sum(numeric_only=True)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 50,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-15T20:24:55.906057Z",
-     "iopub.status.busy": "2021-12-15T20:24:55.904964Z",
-     "iopub.status.idle": "2021-12-15T20:24:55.997011Z",
-     "shell.execute_reply": "2021-12-15T20:24:55.997419Z"
-    },
-    "pycharm": {
-     "is_executing": false
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "AvgTicketPrice        8.204365e+06\n",
-       "Cancelled             1.678000e+03\n",
-       "DistanceKilometers    9.261629e+07\n",
-       "DistanceMiles         5.754909e+07\n",
-       "FlightDelay           3.280000e+03\n",
-       "FlightDelayMin        6.181500e+05\n",
-       "FlightTimeHour        1.112470e+05\n",
-       "FlightTimeMin         6.674818e+06\n",
-       "dayOfWeek             3.703500e+04\n",
-       "dtype: float64"
-      ]
-     },
-     "execution_count": 50,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "ed_flights.sum(numeric_only=True)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### DataFrame.nunique"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 51,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-15T20:24:56.003863Z",
-     "iopub.status.busy": "2021-12-15T20:24:56.003311Z",
-     "iopub.status.idle": "2021-12-15T20:24:56.012352Z",
-     "shell.execute_reply": "2021-12-15T20:24:56.012798Z"
-    },
-    "pycharm": {
-     "is_executing": false
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Carrier      4\n",
-       "Origin     156\n",
-       "Dest       156\n",
-       "dtype: int64"
-      ]
-     },
-     "execution_count": 51,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "pd_flights[['Carrier', 'Origin', 'Dest']].nunique()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 52,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-15T20:24:56.018633Z",
-     "iopub.status.busy": "2021-12-15T20:24:56.018038Z",
-     "iopub.status.idle": "2021-12-15T20:24:56.109194Z",
-     "shell.execute_reply": "2021-12-15T20:24:56.108015Z"
-    },
-    "pycharm": {
-     "is_executing": false
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Carrier      4\n",
-       "Origin     156\n",
-       "Dest       156\n",
-       "dtype: int64"
-      ]
-     },
-     "execution_count": 52,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "ed_flights[['Carrier', 'Origin', 'Dest']].nunique()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### DataFrame.drop"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 53,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-15T20:24:56.124377Z",
-     "iopub.status.busy": "2021-12-15T20:24:56.123206Z",
-     "iopub.status.idle": "2021-12-15T20:24:56.145226Z",
-     "shell.execute_reply": "2021-12-15T20:24:56.145628Z"
-    },
-    "pycharm": {
-     "is_executing": false
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>Carrier</th>\n",
-       "      <th>DestRegion</th>\n",
-       "      <th>...</th>\n",
-       "      <th>dayOfWeek</th>\n",
-       "      <th>timestamp</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>Kibana Airlines</td>\n",
-       "      <td>SE-BD</td>\n",
-       "      <td>...</td>\n",
-       "      <td>0</td>\n",
-       "      <td>2018-01-01 00:00:00</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>Logstash Airways</td>\n",
-       "      <td>IT-34</td>\n",
-       "      <td>...</td>\n",
-       "      <td>0</td>\n",
-       "      <td>2018-01-01 18:27:00</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>Logstash Airways</td>\n",
-       "      <td>IT-34</td>\n",
-       "      <td>...</td>\n",
-       "      <td>0</td>\n",
-       "      <td>2018-01-01 17:11:14</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>Kibana Airlines</td>\n",
-       "      <td>IT-34</td>\n",
-       "      <td>...</td>\n",
-       "      <td>0</td>\n",
-       "      <td>2018-01-01 10:33:28</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>Kibana Airlines</td>\n",
-       "      <td>SE-BD</td>\n",
-       "      <td>...</td>\n",
-       "      <td>0</td>\n",
-       "      <td>2018-01-01 05:13:00</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>...</th>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>13054</th>\n",
-       "      <td>Logstash Airways</td>\n",
-       "      <td>SE-BD</td>\n",
-       "      <td>...</td>\n",
-       "      <td>6</td>\n",
-       "      <td>2018-02-11 20:42:25</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>13055</th>\n",
-       "      <td>Logstash Airways</td>\n",
-       "      <td>CH-ZH</td>\n",
-       "      <td>...</td>\n",
-       "      <td>6</td>\n",
-       "      <td>2018-02-11 01:41:57</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>13056</th>\n",
-       "      <td>Logstash Airways</td>\n",
-       "      <td>RU-AMU</td>\n",
-       "      <td>...</td>\n",
-       "      <td>6</td>\n",
-       "      <td>2018-02-11 04:09:27</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>13057</th>\n",
-       "      <td>JetBeats</td>\n",
-       "      <td>SE-BD</td>\n",
-       "      <td>...</td>\n",
-       "      <td>6</td>\n",
-       "      <td>2018-02-11 08:28:21</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>13058</th>\n",
-       "      <td>JetBeats</td>\n",
-       "      <td>US-DC</td>\n",
-       "      <td>...</td>\n",
-       "      <td>6</td>\n",
-       "      <td>2018-02-11 14:54:34</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "<p>13059 rows × 20 columns</p>\n",
-       "</div>"
+      "cell_type": "code",
+      "execution_count": 14,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2021-12-15T20:24:38.376647Z",
+          "iopub.status.busy": "2021-12-15T20:24:38.374422Z",
+          "iopub.status.idle": "2021-12-15T20:24:38.382068Z",
+          "shell.execute_reply": "2021-12-15T20:24:38.383242Z"
+        },
+        "pycharm": {
+          "is_executing": false
+        },
+        "id": "fLMm3FGpNRFP",
+        "outputId": "d4158c9b-6d8f-4b05-bfdd-921832113278",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
+      },
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "False"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 14
+        }
       ],
-      "text/plain": [
-       "                Carrier DestRegion  ... dayOfWeek           timestamp\n",
-       "0       Kibana Airlines      SE-BD  ...         0 2018-01-01 00:00:00\n",
-       "1      Logstash Airways      IT-34  ...         0 2018-01-01 18:27:00\n",
-       "2      Logstash Airways      IT-34  ...         0 2018-01-01 17:11:14\n",
-       "3       Kibana Airlines      IT-34  ...         0 2018-01-01 10:33:28\n",
-       "4       Kibana Airlines      SE-BD  ...         0 2018-01-01 05:13:00\n",
-       "...                 ...        ...  ...       ...                 ...\n",
-       "13054  Logstash Airways      SE-BD  ...         6 2018-02-11 20:42:25\n",
-       "13055  Logstash Airways      CH-ZH  ...         6 2018-02-11 01:41:57\n",
-       "13056  Logstash Airways     RU-AMU  ...         6 2018-02-11 04:09:27\n",
-       "13057          JetBeats      SE-BD  ...         6 2018-02-11 08:28:21\n",
-       "13058          JetBeats      US-DC  ...         6 2018-02-11 14:54:34\n",
-       "\n",
-       "[13059 rows x 20 columns]"
+      "source": [
+        "pd_flights.empty"
       ]
-     },
-     "execution_count": 53,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "pd_flights.drop(columns=['AvgTicketPrice', \n",
-    "                         'Cancelled', \n",
-    "                         'DestLocation',\n",
-    "                         'Dest', \n",
-    "                         'DestAirportID', \n",
-    "                         'DestCityName', \n",
-    "                         'DestCountry'])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 54,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-15T20:24:56.151182Z",
-     "iopub.status.busy": "2021-12-15T20:24:56.150754Z",
-     "iopub.status.idle": "2021-12-15T20:25:00.584497Z",
-     "shell.execute_reply": "2021-12-15T20:25:00.583176Z"
     },
-    "pycharm": {
-     "is_executing": false
-    }
-   },
-   "outputs": [
     {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>Carrier</th>\n",
-       "      <th>DestRegion</th>\n",
-       "      <th>...</th>\n",
-       "      <th>dayOfWeek</th>\n",
-       "      <th>timestamp</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>Kibana Airlines</td>\n",
-       "      <td>SE-BD</td>\n",
-       "      <td>...</td>\n",
-       "      <td>0</td>\n",
-       "      <td>2018-01-01 00:00:00</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>Logstash Airways</td>\n",
-       "      <td>IT-34</td>\n",
-       "      <td>...</td>\n",
-       "      <td>0</td>\n",
-       "      <td>2018-01-01 18:27:00</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>Logstash Airways</td>\n",
-       "      <td>IT-34</td>\n",
-       "      <td>...</td>\n",
-       "      <td>0</td>\n",
-       "      <td>2018-01-01 17:11:14</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>Kibana Airlines</td>\n",
-       "      <td>IT-34</td>\n",
-       "      <td>...</td>\n",
-       "      <td>0</td>\n",
-       "      <td>2018-01-01 10:33:28</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>Kibana Airlines</td>\n",
-       "      <td>SE-BD</td>\n",
-       "      <td>...</td>\n",
-       "      <td>0</td>\n",
-       "      <td>2018-01-01 05:13:00</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>...</th>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>13054</th>\n",
-       "      <td>Logstash Airways</td>\n",
-       "      <td>SE-BD</td>\n",
-       "      <td>...</td>\n",
-       "      <td>6</td>\n",
-       "      <td>2018-02-11 20:42:25</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>13055</th>\n",
-       "      <td>Logstash Airways</td>\n",
-       "      <td>CH-ZH</td>\n",
-       "      <td>...</td>\n",
-       "      <td>6</td>\n",
-       "      <td>2018-02-11 01:41:57</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>13056</th>\n",
-       "      <td>Logstash Airways</td>\n",
-       "      <td>RU-AMU</td>\n",
-       "      <td>...</td>\n",
-       "      <td>6</td>\n",
-       "      <td>2018-02-11 04:09:27</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>13057</th>\n",
-       "      <td>JetBeats</td>\n",
-       "      <td>SE-BD</td>\n",
-       "      <td>...</td>\n",
-       "      <td>6</td>\n",
-       "      <td>2018-02-11 08:28:21</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>13058</th>\n",
-       "      <td>JetBeats</td>\n",
-       "      <td>US-DC</td>\n",
-       "      <td>...</td>\n",
-       "      <td>6</td>\n",
-       "      <td>2018-02-11 14:54:34</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>\n",
-       "<p>13059 rows × 20 columns</p>"
+      "cell_type": "code",
+      "execution_count": 15,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2021-12-15T20:24:38.391560Z",
+          "iopub.status.busy": "2021-12-15T20:24:38.390590Z",
+          "iopub.status.idle": "2021-12-15T20:24:38.463948Z",
+          "shell.execute_reply": "2021-12-15T20:24:38.463507Z"
+        },
+        "pycharm": {
+          "is_executing": false
+        },
+        "id": "cdaA4nkdNRFP",
+        "outputId": "248e88d9-92ca-442a-b5b9-e3b8cd0957ec",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
+      },
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "False"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 15
+        }
       ],
-      "text/plain": [
-       "                Carrier DestRegion  ... dayOfWeek           timestamp\n",
-       "0       Kibana Airlines      SE-BD  ...         0 2018-01-01 00:00:00\n",
-       "1      Logstash Airways      IT-34  ...         0 2018-01-01 18:27:00\n",
-       "2      Logstash Airways      IT-34  ...         0 2018-01-01 17:11:14\n",
-       "3       Kibana Airlines      IT-34  ...         0 2018-01-01 10:33:28\n",
-       "4       Kibana Airlines      SE-BD  ...         0 2018-01-01 05:13:00\n",
-       "...                 ...        ...  ...       ...                 ...\n",
-       "13054  Logstash Airways      SE-BD  ...         6 2018-02-11 20:42:25\n",
-       "13055  Logstash Airways      CH-ZH  ...         6 2018-02-11 01:41:57\n",
-       "13056  Logstash Airways     RU-AMU  ...         6 2018-02-11 04:09:27\n",
-       "13057          JetBeats      SE-BD  ...         6 2018-02-11 08:28:21\n",
-       "13058          JetBeats      US-DC  ...         6 2018-02-11 14:54:34\n",
-       "\n",
-       "[13059 rows x 20 columns]"
+      "source": [
+        "ed_flights.empty"
       ]
-     },
-     "execution_count": 54,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "ed_flights.drop(columns=['AvgTicketPrice', \n",
-    "                         'Cancelled', \n",
-    "                         'DestLocation',\n",
-    "                         'Dest', \n",
-    "                         'DestAirportID', \n",
-    "                         'DestCityName', \n",
-    "                         'DestCountry'])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Plotting"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 55,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-15T20:25:00.608502Z",
-     "iopub.status.busy": "2021-12-15T20:25:00.607311Z",
-     "iopub.status.idle": "2021-12-15T20:25:01.255494Z",
-     "shell.execute_reply": "2021-12-15T20:25:01.255790Z"
     },
-    "pycharm": {
-     "is_executing": false
-    }
-   },
-   "outputs": [
     {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAmIAAAJOCAYAAAAUOGurAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/MnkTPAAAACXBIWXMAAAsTAAALEwEAmpwYAABZyUlEQVR4nO3dfbwcdXn38c/X8CAGJEHwNIRIsEYrmAp4ClitPYqEANpgqxSkEpA22kKrd9PWqL1vUKR37F2ggBQNEgkYjalIk0IUInKKtvIUREJAzDEEkxgSISEQUPTgdf8xvwPDYfc87Nndmd39vl+vfe3sb2Znrtmz19lr5jcPigjMzMzMrPleUnQAZmZmZp3KhZiZmZlZQVyImZmZmRXEhZiZmZlZQVyImZmZmRXEhZiZmZlZQVyItSBJn5f0v0cwXa+kP29GTIOW+ypJOyWNa/ayrTgj/V62AkmnSrop9zokvabImMygvfIsT9IaST1p+FxJXy42ouZxIVZHqfDZLmn3Mc7nm6mQ2Snp15J+lXv9+Yj4cEScV6+4Kyz/RQVc+iF6KsWwSdKF1QqtiPhpROwZEc82KkZrPknrJf1C0pOSHpf0P5I+LOklACP9Xqb5vLPxEQ8Zw9T0nd4lvZakSyX9SNLkiFgcETMKjrFH0sYiY7Dma9M8+8Gg9n3T79r6gbaIOCQiepsdYxm4EKsTSVOBPwAC+KOxzCsijkuFzJ7AYuCfB15HxIfHHm3N3phiOhp4P/AXgycY+GGztvXuiNgLOBCYD3wMuLLYkMYm/cB9AegB/jAiNhUbUX04F1tau+XZyyS9Iff6/cBDRQVTNi7E6uc04DbgKmC2pN3T1sxzXz5J+6UtnVem1/8gabOkn0n685F2f0i6StJncq9nSbpH0hOSfiJpZoX3TJJ0r6S/T6+PSltaj0v6YW6X8PlkBeXn0t6vzw2eV0T8CPgu8IbcFs+Zkn4KfKfC3oZ9JH0pred2Sf+Ri+tdKfaBLb/fHf6jtqJFxI6IWA78Kdn3/Q3572Xa4r0+/V23SfqupJdIugZ4FfCf6fv1D2n6f5f0iKQdkm6VdMjAstJ8L5N0Q9pLcLuk386NP0TSyrScLZI+kdpfImleyonHJC2VtM+gVRkHfAnoBnoiYkt67+mSvldp3SXtLelqST+X9LCkfxzYW5He99+SLkrrvk7S76f2DZK2Spqdm9fukv5F0k9T7J+XtIek8cA3gf31/N7w/Ydapyq5+FJJX07TPi7pTkldY/jTWxO1UZ5dA8zOvT4NuDo/gYbYg6cqv1dp3Okpz56U9JCkU0f7ORfNhVj9nEa292oxcCwwAfgGcEpumpOA/4qIrcqKpb8F3gm8hmxrfNQkHUH2hf77tMy3AesHTXMQ8F/A5yLi/0maDNwAfAbYB/g74FpJ+0XEJ8mKrLPTHrizKyzzYLJiLb+7+Q+B16d1H+wa4GXAIcArgYvSfA4DFgIfAl5BtldiucbYtWvNExF3ABvJvg95c1P7fkAX8Ils8vgA8FOyLf49I+Kf0/TfBKaRfT/uJsujvJOBTwETgT7gfABJewHfBr4F7E+WSzen9/w1cCLZd3N/YDtw2aD5LgZeB7wjIh4b4WpfCuwNvDrN+zTgjNz4I4F7yb7TXwGWAL+XYvszso2cPdO084HXAoem8ZOB/xMRTwHHAT/L7Q3/2QjXKZ+Ls1OsU1I8HwZ+McL1tJJogzz7MnCypHHp92NP4PaRrPtQv1dpg+US4Li0B/H3gXtGMt8ycSFWB5LeSrYLeWlErAJ+Qrbr9StkX+wBA22QFWVfiog1EfE0cG6Niz8TWBgRKyPiNxGxKe2xGnAwcAtwTkQsSG1/BqyIiBXpPSuBu4Djh1nW3ZK2A/8JfJFsT8KAcyPiqYh4wT95SZPIflA+HBHbI+LXEfFfafQc4AsRcXtEPBsRi4BngKNG/SlYkX5G9g8y79fAJODA9Df/bgxxY9uIWBgRT0bEM2S58EZJe+cmuS4i7oiIfrIfj0NT+7uARyLigoj4ZZrHwD/4DwOfjIiNufm+Vy/sspsB/HtEPD6SFVV2XOTJwMfTstYDFwAfyE32UER8KR0j+TWyIujTEfFMRNwE/Ap4jSSR5cD/iohtEfEk8E+88H/GYCNZp3wu/pqsAHtNyrFVEfHESNbVSqeV82wj8CDZjofTyDbOR2q436vfkPXO7BERmyNizSjmXQouxOpjNnBTRDyaXn8ltd1C1jd+pLJjyA4FrkvT7A9syM0jPzwaU8gKv2pOBTYBX8+1HQi8L+3mfVzS48BbyRJ6KIdHxMSI+O2I+MeI+E1uXLX4pwDbImJ7hXEHAnMHxTGF7LOx1jEZ2Dao7f+RbVHflLoN5lV7c9pKnp+6Np7g+T26++YmeyQ3/DTZFjUM/f0/ELgu9916AHiWbM/BgHcB50j6YLX4BtkX2BV4ONf2MNlnMGBLbvgXAANdnrm2Pcn2YrwMWJWL8VupvZqRrFM+F68BbgSWKDs04J8l7TrcSloptXKeQdZzczpZL9FoCrGqv1dpz/GfkhWDm1O36u+MYt6l4EJsjCTtQbZ36w9T3/sjwP8C3gi8AVhK9sU7Bbg+bfUCbAYOyM1qSo0hbAB+e4jx5wKPAl/R82c5bgCuiYgJucf4iJifxlfdohpCtfdsAPaRNKHKuPMHxfGyiPhqDcu3Akj6PbIfiBccT5W2mOdGxKvJTl75W0lHD4weNJv3A7PItpb3BqYOzH4EIWwg6yKsNu64Qd+vl8YLD8b/H+DdwMWS3j+C5T1KthfiwFzbq8g2dkbrUbKi7JBcfHtHdkIMVM6pkazTc+9Le0k+FREHk3XbvItsj4S1kDbIM4BrgROAdRHx0xEsMz//qr9XEXFjRBxDtiPhR8AVo5h3KbgQG7sTyar/g8n2eB1KdnzGd8n+4X2FrGI/lee7JSEr0M6Q9HpJLwNqvS7MlWk+R6eDJicP2iL4NfA+YDxwtbKDir8MvFvSsWkr6aXKTpUfKAy3UD3pRiUiNpMdl/BvkiZK2lXS29LoK4APpz2GkjRe0gnpeAQrMUkvl/QusuOfvhwRqweNf5ekge63HWQ5MrAHdfD3ay+yLunHyPYQ/dMoQrkemCTpo8oOfN9L0pFp3OeB8yUdmGLaT9KswTNIXeV/DCyQ9CdDLSx1Ny5N890rzftvyXJqVNIe5SuAi/T8CTyTJQ0cZ7kFeMWgrqMRrdMASW+XND1thD1B9v/gN9Wmt3Jpszx7CngHMNprW1b9vZLUpexktfFp3XbSgt9vF2JjN5vsWK+fRsQjAw/gc2TF1yrgKbLutm8OvCkivkl2kOEtZLuWb0ujnhnNwiM7iPMMsgPgd5AdlH/goGl+RfZD00V2cPwmsi2jTwA/J9vi+Hue/z5cTNbHv13SJaOJp4oPkP0A/AjYCnw0xXUX2SUwPkd2gGcf2a5rK6//lPQk2Xfmk8CFvPBA9QHTyA7u3Ql8H/i3iLgljfu/wD+mboa/I+uyeJjse3k/z+fCsNIe5mPI9mo9AqwF3p5GXwwsJ+u2eTLN98gq81lJtsG0SNK7h1nsX5Pl9DqyPRRfIcurWnyMlP+pu+jbZCcPDJyd/FVgXfqs9h/NOiW/RXZYwhNkXUb/xei6hawY7Zpnd0XEUIfSVHrPBqr/Xr2EbEPoZ2Tdtn8I/OVo5l8GGuK4PmsiSa8H7gN2TwdKmpmZWZvzHrECSXpP2s07Efgs8J8uwszMzDqHC7FifYisq+4nZH37LbdL1czMzGrnrkkzMzOzgniPmJmZmVlBWvamsPvuu29MnTq14ct56qmnGD9+fMOX4+WXd/k/+tGPHo2IoS6yWUpD5UjRn+tgZYrHsVRXLZ5Vq1a1ZI5Aa+VJI3gdm6dqnkRESz7e9KY3RTPccsstTVmOl1/e5QN3RQm+86N9DJUjRX+ug5UpHsdSXbV4WjVHosXypBG8js1TLU/cNWnWQOnig3dI+qGkNZI+ldoPknS7pD5JX5O0W2rfPb3uS+On5ub18dT+YO6in2YtzTlinc6FmFljPQO8IyLeSHbXhZmSjiK7XMlFEfEasovZnpmmPxPYntovStMh6WCym0EfAswku1PBOMxan3PEOpoLMbMGSnukd6aXu6ZHkN3qY+BG7IvIbpUF2RWkF6XhrwNHp9uXzAKWRMQzEfEQ2dXYj2j8Gpg1lnPEOl3LHqxv1irSVvkq4DXAZWTXjXs8nr9470ayG/qSnjcARES/pB3AK1J7/pYk+ffklzUHmAPQ1dVFb29vxZh27txZdVwRyhSPY6muUfE0M0fS8loyTxrB61g8F2JmDRbZjaIPlTQBuA74naHfMaZlLQAWAHR3d0dPT0/F6Xp7e6k2rghlisexVNeoeJqZI2l5LZknjeB1LJ4LMRvW1Hk31PS+9fNPqHMkrS0iHpd0C/BmYIKkXdIW/wFkN+IlPU8BNkraBdgbeCzXPiD/nlFbvWkHp9fwd/Xf1BqpTDkCzhNrDhdiZg0kaT/g1+kHZg/gGLKDi28B3gssAWYDy9JblqfX30/jvxMRIWk58BVJFwL7A9OAO5q6Mi2k1o0HgKtmFn+9oU7iHCnO1Hk3MHd6/6iLTRea9eVCzKyxJgGL0jEwLwGWRsT1ku4Hlkj6DPAD4Mo0/ZXANZL6gG1kZ4EREWskLQXuB/qBs1J3jlmrc45YR3MhZtZAEXEvcFiF9nVUOKMrIn4JvK/KvM4Hzq93jGZFco5Yp3Mh1kFq6a6ZO70ff03MzMwaw9cRMzMzMyuICzEzMzOzgrgQMzMzMyuICzEzMzOzgrgQMzMzMyuICzEzMzOzgvi6BNYwvjWSmZnZ0LxHzMzMzKwg3iPWgsZyHz0zMzMrD+8RMzMzMyuI94iZWWl576/Z8Jwnrc17xMzMzMwK4kLMzMzMrCAuxMzMzMwK4kLMzMzMrCAuxMwaSNIUSbdIul/SGkkfSe3nStok6Z70OD73no9L6pP0oKRjc+0zU1ufpHlFrI9ZvTlHrNP5rEmzxuoH5kbE3ZL2AlZJWpnGXRQR/5KfWNLBwMnAIcD+wLclvTaNvgw4BtgI3ClpeUTc35S1MGsc54h1tJoLMUkLgXcBWyPiDantXOAvgJ+nyT4RESvSuI8DZwLPAn8TETem9pnAxcA44IsRMb/WmFrNSE45nju9n9N9anLLiojNwOY0/KSkB4DJQ7xlFrAkIp4BHpLUBxyRxvVFxDoASUvStP6RsZbmHLFON5Y9YlcBnwOuHtTuLRizCiRNBQ4DbgfeApwt6TTgLrI9AtvJfoBuy71tI8//KG0Y1H5khWXMAeYAdHV10dvbWzGWrj2yIn+0qs1vrHbu3Flx3rXE2KhYilCmWKDx8TQjR9JyWjJPqhlLntSyjmX6To5E2fJosJoLsYi4NSXNSHgLxjqapD2Ba4GPRsQTki4HzgMiPV8AfHCsy4mIBcACgO7u7ujp6ak43aWLl3HB6tGn//pTK89vrHp7e6kUaxF7g6+aOb5iLEWo9rkUpZHxNCtHoHXzpJqx5Mnc6f2jXsdmr99YlS2PBmvEMWIN2YKBkW/F1FMjK+mRbIXUukVWL0UsP/95F70ls3PnzjHPQ9KuZD8wiyPiGwARsSU3/grg+vRyEzAl9/YDUhtDtJu1NOeIdbJ6F2IN24KBkW/F1FMjK+mRbMXUsrVST0UsP7+1VfSWzFiLQEkCrgQeiIgLc+2T0rExAO8B7kvDy4GvSLqQrBt/GnAHIGCapIPIflxOBt4/puDMSsA5Yp2urr+w3oIxe5G3AB8AVku6J7V9AjhF0qFkGy3rgQ8BRMQaSUvJuuf7gbMi4lkASWcDN5Kd2LIwItY0bzXMGsY5Yh2troWYt2DMXigivkf2PR9sxRDvOR84v0L7iqHeZ9aKnCPW6cZy+YqvAj3AvpI2AucAPd6CMTMzMxuZsZw1eUqF5iuHmN5bMGZmZmY5vrJ+HYzkwqxmZmZmg/lek2ZmZmYFcSFmZmZmVhAXYmZmZmYFcSFmZmZmVhAXYmZmZmYFcSFmZmZmVhAXYmZmZmYFcSFmZmZmVhAXYmZmZmYFcSFmZmZmVhAXYmZmZmYFcSFmZmZmVhAXYmYNJGmKpFsk3S9pjaSPpPZ9JK2UtDY9T0ztknSJpD5J90o6PDev2Wn6tZJmF7VOZvXkHLFOt0vRAZTJ1Hk3vKht7vR+Tq/QbjZC/cDciLhb0l7AKkkrgdOBmyNivqR5wDzgY8BxwLT0OBK4HDhS0j7AOUA3EGk+yyNie9PXyKy+nCPW0bxHzKyBImJzRNydhp8EHgAmA7OARWmyRcCJaXgWcHVkbgMmSJoEHAusjIht6YdlJTCzeWti1hjOEet03iNm1iSSpgKHAbcDXRGxOY16BOhKw5OBDbm3bUxt1doHL2MOMAegq6uL3t7eirF07ZHt7R2tavMbq507d1acdy0xNiqWIpQpFmh8PM3IkbSclsyTasaSJ7WsY5m+kyNRtjwazIWYWRNI2hO4FvhoRDwh6blxERGSoh7LiYgFwAKA7u7u6OnpqTjdpYuXccHq0af/+lMrz2+sent7qRRrEYcFXDVzfMVYilDtcylKI+NpVo6k+bVknlQzljyZO71/1OvY7PUbq7Ll0WDumjRrMEm7kv3ALI6Ib6TmLak7hfS8NbVvAqbk3n5AaqvWbtbynCPWyVyImTWQss36K4EHIuLC3KjlwMBZXbOBZbn209KZYUcBO1L3zI3ADEkT09ljM1KbWUtzjlinc9ekWWO9BfgAsFrSPantE8B8YKmkM4GHgZPSuBXA8UAf8DRwBkBEbJN0HnBnmu7TEbGtKWtg1ljOEetoLsTMGigivgeoyuijK0wfwFlV5rUQWFi/6MyK5xyxTueuSTMzM7OCuBAzMzMzK4gLMTMzM7OCuBAzMzMzK4gLMTMzM7OCuBAzMzMzK4gLMTMzM7OCuBAzMzMzK8iYCjFJCyVtlXRfrm0fSSslrU3PE1O7JF0iqU/SvZIOz71ndpp+raTZlZZlZmZm1m7GukfsKmDmoLZ5wM0RMQ24Ob0GOA6Ylh5zgMshK9yAc4AjgSOAcwaKNzMzM7N2NqZCLCJuBQbfy2sWsCgNLwJOzLVfHZnbgAmSJgHHAisjYltEbAdW8uLizszMzKztNOJek10RsTkNPwJ0peHJwIbcdBtTW7X2F5E0h2xvGl1dXfT29tYvamDu9P4XtXXtUbm9WTpx+fm/686dO+v+dx6NnTt3FrZsMzNrfw296XdEhKSo4/wWAAsAuru7o6enp16zBuD0eTe8qG3u9H4uWF3cvdE7cfnrT+15bri3t5d6/51Ho8gi0MzM2l8jzprckrocSc9bU/smYEpuugNSW7V2MzMzs7bWiEJsOTBw5uNsYFmu/bR09uRRwI7UhXkjMEPSxHSQ/ozUZmZmZtbWxnr5iq8C3wdeJ2mjpDOB+cAxktYC70yvAVYA64A+4ArgrwAiYhtwHnBnenw6tZm1vCqXeDlX0iZJ96TH8blxH0+XeHlQ0rG59pmprU/SvMHLMWtVzhHrdGM6+CciTqky6ugK0wZwVpX5LAQWjiUWs5K6CvgccPWg9osi4l/yDZIOBk4GDgH2B74t6bVp9GXAMWQns9wpaXlE3N/IwM2a5CqcI9bBijsK3KwDRMStkqaOcPJZwJKIeAZ4SFIf2bX1APoiYh2ApCVpWv/IWMtzjlincyFmVoyzJZ0G3AXMTdfQmwzclpsmfymXwZd4ObLSTEd6iZdaL0vSqLNIq12mpIhLtxR9yZS8MsUCTY+nITkCrZsn1YwlT2pZxzJ9J0eibHk0mAsxs+a7nOy4yEjPFwAfrMeMR3qJl0sXL6vpsiT5S4vUU7XLlFS6pEyjXTVzfKGXTMkr+vItgzUxnoblCLRunlQzljyp5RJFzV6/sSpbHg3mQsysySJiy8CwpCuA69PLoS7l4ku8WMdwjlgnacTlK8xsCAPX2UveAwycLbYcOFnS7pIOIrsv6x1kZxNPk3SQpN3IDlZe3syYzZrJOWKdxHvEzBooXeKlB9hX0kayG9z3SDqUrNtlPfAhgIhYI2kp2QHG/cBZEfFsms/ZZNfXGwcsjIg1zV0Ts8ZwjlincyFm1kBVLvFy5RDTnw+cX6F9Bdm1+MzainPEOp27Js3MzMwK0pZ7xKYWcKaVmZmZ2Wh5j5iZmZlZQdpyj5iZWa1Wb9pR03WZ1s8/oQHRmJVPrb1OzpHKvEfMzMzMrCAuxMzMzMwK4kLMzMzMrCAuxMzMzMwK4kLMzMzMrCAuxMzMzMwK4stXWOnkT42eO71/xJcS8KnRZmbWarxHzMzMzKwgLsTMzMzMCuJCzMzMzKwgLsTMzMzMCuJCzMzMzKwgLsTMGkjSQklbJd2Xa9tH0kpJa9PzxNQuSZdI6pN0r6TDc++ZnaZfK2l2Eeti1ijOE+tkLsTMGusqYOagtnnAzRExDbg5vQY4DpiWHnOAyyH7QQLOAY4EjgDOGfhRMmsTV+E8sQ7lQsysgSLiVmDboOZZwKI0vAg4Mdd+dWRuAyZImgQcC6yMiG0RsR1YyYt/tMxalvPEOpkv6GrWfF0RsTkNPwJ0peHJwIbcdBtTW7X2F5E0h2wvAV1dXfT29lYOYI/sYrmjVW1+Y7Vz586K864lxrEq02dT7XMpSpPjcZ6M0FjypNZ1rEVR3+Wy5dFgLsTMChQRISnqOL8FwAKA7u7u6OnpqTjdpYuXccHq0af/+lMrz2+sent7qRTrSO+qUE9zp/eX5rOp9rkUpah4nCdDG0ue1Pp9r0WzP5cBZcujwdw1adZ8W1JXCul5a2rfBEzJTXdAaqvWbtbOnCfWEVyImTXfcmDgjK7ZwLJc+2nprLCjgB2pa+ZGYIakieng4xmpzaydOU+sI7hr0qyBJH0V6AH2lbSR7Kyu+cBSSWcCDwMnpclXAMcDfcDTwBkAEbFN0nnAnWm6T0fE4AObzVqW88Q6WcMKMUnrgSeBZ4H+iOhOpxd/DZgKrAdOiojtkgRcTJZcTwOnR8TdjYrNrFki4pQqo46uMG0AZ1WZz0JgYR1DMysN54l1skZ3Tb49Ig6NiO70elTXhTEzMzNrZ80+Rmy014UxMzMza1uNPEYsgJvSKcdfSKcLj/a6MJtzbSO+9ks9r4nSzGusePljW36jruNkZmbWKI0sxN4aEZskvRJYKelH+ZG1XBdmpNd+qee1h5p5jRUvf2zLb9R1nMzMzBqlYV2TEbEpPW8FriO799dorwtjZmZm1rYasqtD0njgJRHxZBqeAXya568LM58XXxfmbElLyG7YuiPXhWlmJTG1xr3N6+efUOdIzMrLeWKj0ag+py7guuyqFOwCfCUiviXpTkZxXRgzMzOzdtaQQiwi1gFvrND+GKO8LoyZtb7h9hDMnd5fyH0lzcqk1j1p1tp8ZX1rG2P5J+YuATMzK4LvNWlmZmZWEBdiZmZmZgVx16SZWR34TDmzoTlHKvMeMTMzM7OCuBAzMzMzK4gLMTMzM7OCuBAzK4ik9ZJWS7pH0l2pbR9JKyWtTc8TU7skXSKpT9K9kg4vNnqz5nCeWLvzwfpmxXp7RDyaez0PuDki5kual15/DDgOmJYeRwKXp2drcUMdwDzUhW7b/QDmQZwnHazdD/L3HjGzcpkFLErDi4ATc+1XR+Y2YIKkSQXEZ1YGzhNrG94jZlacAG6SFMAXImIB0JW74f0jZPdtBZgMbMi9d2Nq25xrQ9IcYA5AV1cXvb29FRfctUe2t6UsyhRPq8RS7W/bSDt37ixiuc6TBmrndRz4uxb0vR0xF2JmxXlrRGyS9EpgpaQf5UdGRKQfnxFLP1ILALq7u6Onp6fidJcuXsYFq8uT/nOn95cmnlaJZf2pPc0NhuyHrdp3qoGcJw1Upu97vQ3kSEHf2xFz16RZQSJiU3reClwHHAFsGehKSc9b0+SbgCm5tx+Q2szamvPE2l17lsFmJSdpPPCSiHgyDc8APg0sB2YD89PzsvSW5cDZkpaQHXy8I9c1Yx2o3Q9gBueJjc1Ajgx10kslzc4RF2JmxegCrpMEWR5+JSK+JelOYKmkM4GHgZPS9CuA44E+4GngjOaHbNZ0zhNrey7EzAoQEeuAN1Zofww4ukJ7AGc1ITSz0nCeWCfwMWJmZmZmBXEhZmZmZlYQF2JmZmZmBXEhZmZmZlYQF2JmZmZmBXEhZmZmZlYQF2JmZmZmBXEhZmZmZlYQF2JmZmZmBXEhZmZmZlYQF2JmZmZmBXEhZmZmZlYQF2JmZmZmBdml6ADMzKx5ps67oab3rZ9/Qp0jMSunWnMEassT7xEzMzMzK0hpCjFJMyU9KKlP0ryi4zErG+eI2fCcJ9ZqSlGISRoHXAYcBxwMnCLp4GKjMisP54jZ8Jwn1opKUYgBRwB9EbEuIn4FLAFmFRyTWZk4R8yG5zyxlqOIKDoGJL0XmBkRf55efwA4MiLOHjTdHGBOevk64MEmhLcv8GgTluPll3f54yNivwJjaESOFP25DlameBxLddXiObDoHIGOyJNG8Do2T8U8aamzJiNiAbCgmcuUdFdEdDdzmV5+6ZY/tajlj9ZIc6Toz3WwMsXjWKorWzy1atU8aQSvY/HK0jW5CZiSe31AajOzjHPEbHjOE2s5ZSnE7gSmSTpI0m7AycDygmMyKxPniNnwnCfWckrRNRkR/ZLOBm4ExgELI2JNwWENaGpXqJfv5VfSgBwpxXrllCkex1Jd2eJ5gQ7Ik0bwOhasFAfrm5mZmXWisnRNmpmZmXUcF2JmZmZmBenoQkzSFEm3SLpf0hpJH0nt50raJOme9Dg+956Pp1tnPCjp2DrEsF7S6rScu1LbPpJWSlqbniemdkm6JC3/XkmHj3HZr8ut4z2SnpD00Uavv6SFkrZKui/XNup1ljQ7Tb9W0uwxLPv/SfpRmv91kiak9qmSfpH7HD6fe8+b0t+tL8WnWj6LIqhJt4Cp13e7jn/nui17tH//KvGMOs+q/e2UHZx+e2r/mrID1avFUu3/XmGfT9k0K0capcjca5Sy5XRdRUTHPoBJwOFpeC/gx2S3xTgX+LsK0x8M/BDYHTgI+AkwbowxrAf2HdT2z8C8NDwP+GwaPh74JiDgKOD2On4W44BHgAMbvf7A24DDgftqXWdgH2Bdep6YhifWuOwZwC5p+LO5ZU/NTzdoPnekeJTiO67o7/Mo/s4/AV4N7Jb+ngc3aFlj/m7X+e9ct2WP9u9fJZ5R5dlQfztgKXByGv488JdDxFLt/15hn0+ZHs3MkQauQ2G518B1KlVO1/PR0XvEImJzRNydhp8EHgAmD/GWWcCSiHgmIh4C+shuqVFvs4BFaXgRcGKu/erI3AZMkDSpTss8GvhJRDw8TFxjXv+IuBXYVmHeo1nnY4GVEbEtIrYDK4GZtSw7Im6KiP708jayaw9VlZb/8oi4LbIMvjoXb9kVfQuYwv7O9Vp2LX//KvFUUy3PKv7t0pb7O4CvV1i3SrFU+79X2OdTMkXnSKM0JfcapWw5XU8dXYjlSZoKHAbcnprOTrs0Fw7s7iT7Z7Uh97aNDF24jUQAN0lapey2GwBdEbE5DT8CdDVw+QNOBr6ae92s9R8w2nVuVCwfJNsaGnCQpB9I+i9Jf5CLaWMDlt0MjfwbDlaP73Y9463Xsuv59x9NnlVrfwXweG5jYsTxDPq/V8bPpwjNzJFGKVvuNUpbfGddiAGS9gSuBT4aEU8AlwO/DRwKbAYuaODi3xoRhwPHAWdJelt+ZKrOG3qNkXQ8yR8B/56amrn+L9KMda5E0ieBfmBxatoMvCoiDgP+FviKpJc3O64WVvh3u5oil51TaJ5V+L/3nJJ8Pla70uZeo7TyOnV8ISZpV7J/Rosj4hsAEbElIp6NiN8AV/B891vdb58REZvS81bgurSsLQNdjul5a6OWnxwH3B0RW1IsTVv/nNGuc11jkXQ68C7g1JTQpK6hx9LwKrLjRl6blpPvvmyl26g07RYwdfpu1zPeei27Ln//GvKsWvtjZF0vuwxqr6rS/z1K9vkUqOVvk1TC3GuUtvjOdnQhlo6tuBJ4ICIuzLXnj7t6DzBwlsZy4GRJu0s6CJhGdoBfrcsfL2mvgWGyg8bvS8sZOJtjNrAst/zT0hkhRwE7crtlx+IUct2SzVr/QUa7zjcCMyRNTF06M1LbqEmaCfwD8EcR8XSufT9J49Lwq8nWd11a/hOSjkrfodNy8ZZdU24BU8fvdt3+zvVadr3+/jXkWcW/XdpwuAV4b4V1q7Tciv/3KNnnU6CWvk1SSXOvUdrjOxslOMOjqAfwVrJdmfcC96TH8cA1wOrUvhyYlHvPJ8n2jDzIGM+qIDsr54fpsQb4ZGp/BXAzsBb4NrBPahdwWVr+aqC7Dp/BeLIt6r1zbQ1df7KibzPwa7K++DNrWWey47n60uOMMSy7j+y4gYHvwOfTtH+S/i73AHcD787Np5vsn9tPgM+R7lLRCo/0Hf9xiv2TDVpG3b7bdfw7123Zo/37V4ln1HlW7W+XPu87Upz/Duw+RCzV/u8V9vmU7dGMHGlg7IXmXgPXq1Q5Xc+Hb3FkZmZmVpCO7po0MzMzK5ILMTMzM7OCuBAzMzMzK4gLMTMzM7OCuBAzMzMzK4gLMTMzM7OCuBAzMzMzK4gLMTMzM7OCuBAzMzMzK4gLMTMzM7OCuBAzMzMzK4gLMTMzM7OCuBAzMzMzK4gLsQaQNFVSSNolvf6mpNkjfG+vpD9vbITFLlPSJyR9sVnLs3IpS35IOlXSTfWYl1kjOWdeEMPnJf3vImOoNxdiYyRpvaRfSNo58AD2z08TEcdFxKI6LOsFyZjaTpf0bG75D0n6kqTXjnV5NcTXm+J746D261J7D0BE/FNENLXYtGIUmR+p4B9Y7i8H5cmaiFgcETPGutwqsayX9M5BbadL+l4jlmfto8Nz5leS9h3U/oMU41SAiPhwRJzXiBiK4kKsPt4dEXsOPICfNXn530/L3Rt4J/ALYJWkNzQ5DoAfA6cNvJD0CuDNwM8LiMXKoZD8SAX/wDI/TMqT9DikGTE0Q37DzNpGp+bMQ8ApAy8kTQde1oTlFsqFWBPkdw1LGifpAkmPpr1XZw/eywUcKOm/JT0p6abcFsKt6fnxtIXy5vxyIuLZiPhJRPwV8F/AubkYjpL0P5Iel/TDgb1TFWL9bUnfkfRYinGxpAlp3N9LunbQ9JdIujjXtBj4U0nj0utTgOuAX+Xec66kL6fhgS2y2ZJ+mpb5yeE+U2sfzcqPCst9wR6qtJy/krQ2zfu8lA//I+kJSUsl7Zab/l2S7kk59T+SfneU6/36tO6PS1oj6Y8qfSZDxHqWpLXA2tEs11pfG+fMNeQ25IHZwNWDYrhK0mfScI+kjZLmStoqabOkM0bwEZaKC7Hm+wvgOOBQ4HDgxArTvB84A3glsBvwd6n9bel5QtpC+f4Qy/kG8AcAkiYDNwCfAfZJ87tW0n4V3ifg/5LtCn89MIXnC7ovAzNzhdkuwMm8MFF+BtwPDOy+Pm3Q+GreCrwOOBr4P5JeP4L3WPtpVn5UcyzwJuAo4B+ABcCfkeXBG0hb65IOAxYCHwJeAXwBWC5p95EsRNKuwH8CN6X1+GtgsaTXjSLWE4EjgYNH8R5rP+2UM7cBL08bKePIfl++PMzyf4usN2gycCZwmaSJNaxHYVyI1cd/pAr/cUn/Mcy0JwEXR8TGiNgOzK8wzZci4scR8QtgKVmCjdbPyIouyJJiRUSsiIjfRMRK4C7g+MFvioi+iFgZEc9ExM+BC4E/TOM2k21BvS9NPhN4NCJWDZrN1cBpkn6HLMFHktyfiohfRMQPgR8CbxzuDdYyypgf1fxzRDwREWuA+4CbImJdROwAvgkclqabA3whIm5Pe6IXAc+Q/RgNyK/348C/5cYdBewJzI+IX0XEd4DryXXLjMD/jYht6XOw9tKpOQPP7xU7BngA2DTM8n8NfDoifh0RK4CdZBv1LcOFWH2cGBET0uPEYabdH9iQe72hwjSP5IafJvuHPVqTgW1p+EDgfYN+FN4KTBr8JkldkpZI2iTpCbKtkfzBk4vICjvS8zUVlv0N4B3A2VXGV1KPdbZyKmN+VLMlN/yLCq8HlnUgMHdQTk3hhQdV59d7AvBXuXH7Axsi4je5tofJ8nakKn021h46NWcg+814P3A6I+tNeSwi+nOvW+73w4VY820GDsi9njKK98Yopn0P8N00vAG4Jv+jEBHjI6LSltM/peVMj4iXkxVbyo3/D+B3lZ0I8C6yY8JeGGTE02RbQn/JyAsxM2hefozVBuD8QTn1soj46gjf/zNgiqT8/+BX8fzW/1O88CDl36owj2aur5VXW+VMRDxMdtD+8WQb9W3PhVjzLQU+ImlyOtbqY6N478+B3wCvrjQyHbR5kKRLgR7gU2nUl4F3Szo2TfPSdJDjARVmsxfZrt0d6diyv8+PjIhfAl8HvgLcERE/rRLrJ4A/jIj1o1g/s4blR51dAXxY0pHKjJd0gqS9Rvj+28m23P9B0q7KTp55N7Akjb8H+GNJL5P0GrJjX8wqacecORN4R0Q81YS4CudCrPmuIDtA917gB8AKoB94drg3pj1N5wP/nXbtDvStv1nZtWaeAHqBlwO/FxGr0/s2ALPIiqOfk22Z/D2V//6fIjvgcwfZAf6VtkgWAdMZYm9XRPwsInzNJButRuRH3UXEXWQHSX8O2A70kXWljPT9vyIrvI4DHiU7fuy0iPhRmuQisjONt5Dl24v2PJslbZcz6ez/uxoVS9kownu3iyTpOODzEXFg0bGMlKRXAT8Cfisinig6HmtfrZgfZkVyzrQe7xFrMkl7SDpe0i6p6+8csutstYR0TMvfAktchFm9tXp+mDWbc6b1eY9Yk0l6GdnFVn+H7IySG4CPtEJRI2k8WVfJw8DM1OVpVjetnB9mRXDOtD4XYmZmZmYFcdekmZmZWUFciJmZmZkVZJfhJymnfffdN6ZOnVpx3FNPPcX48eObG9AIObbaFBnbqlWrHo2ISvflLLVWzZFqWi3mToq3VXMEWi9PHNPIlDGmqnkSES35eNOb3hTV3HLLLVXHFc2x1abI2IC7ogTf+dE+WjVHqmm1mDsp3lbNkWjBPHFMI1PGmKrlibsmzczMzAriQszMzMysIC7EzMzMzAoybCEmaaGkrZLuy7XtI2mlpLXpeWJql6RLJPVJulfS4bn3zE7Tr5U0O9f+Jkmr03sukaR6r6SZmZlZGY1kj9hVwMxBbfOAmyNiGnBzeg3ZDWynpccc4HLICjey2y4cCRwBnDNQvKVp/iL3vsHLMjMzM2tLw16+IiJulTR1UPMsoCcNLwJ6gY+l9qvT2QG3SZogaVKadmVEbAOQtBKYKakXeHlE3JbarwZOBL45lpVavWkHp8+7YdTvWz//hLEs1syqmFpDPoJz0jrLSPJk7vT+F/2+OU9aW63XEeuKiM1p+BGgKw1PBvL3H9yY2oZq31ihvSJJc8j2tNHV1UVvb2/l4PbIvqyjVW1+9bRz586mLKcWjs3MzKy5xnxB14gISU25YWVELAAWAHR3d0dPT0/F6S5dvIwLVo9+1dafWnl+9dTb20u1uIvm2MzMzJqr1rMmt6QuR9Lz1tS+CZiSm+6A1DZU+wEV2s3MzMzaXq2F2HJg4MzH2cCyXPtp6ezJo4AdqQvzRmCGpInpIP0ZwI1p3BOSjkpnS56Wm5eZmZlZWxu2/07SV8kOtt9X0kaysx/nA0slnQk8DJyUJl8BHA/0AU8DZwBExDZJ5wF3puk+PXDgPvBXZGdm7kF2kP6YDtQ3MzMzaxUjOWvylCqjjq4wbQBnVZnPQmBhhfa7gDcMF4eZmZlZu/GV9c0aSNJLJd0h6YeS1kj6VGo/SNLt6ULGX5O0W2rfPb3uS+On5ub18dT+oKRjC1ols7pyjlincyFm1ljPAO+IiDcCh5JdP+8o4LPARRHxGmA7cGaa/kxge2q/KE2HpIOBk4FDyC56/G+SxjVzRcwaxDliHc2FmFkDRWZnerlregTwDuDrqX0R2YWMIbso8qI0/HXg6HQiyyxgSUQ8ExEPkR2HeUTj18CssZwj1unGfB0xMxta2ipfBbwGuAz4CfB4RAxcdTh/IePnLn4cEf2SdgCvSO235WZb8eLHI73ocbMvkFvLBZbhhRdZbrWL+jrekWtmjqTltWyeVLpgedHfszJ+18sYUzUuxMwaLCKeBQ6VNAG4DvidBi5rRBc9bvYFcmu55Ri88CLLrXZRX8c7cs3MkbS8ls2TudP7X3TB8mZcjHwoZfyulzGmatw1adYkEfE4cAvwZmCCpIH/pvkLGT938eM0fm/gMapfFNmsbThHrBO5EDNrIEn7pa18JO0BHAM8QPZj89402eCLIg9cLPm9wHfSZWGWAyenM8YOAqYBdzRlJcwayDlinc5dk2aNNQlYlI6BeQmwNCKul3Q/sETSZ4AfAFem6a8ErpHUB2wjOwuMiFgjaSlwP9APnJW6c8xanXPEOpoLMbMGioh7gcMqtK+jwhldEfFL4H1V5nU+cH69YzQrknPEOp0LMbMOtHrTjpoOoF8//4QGRGNWTs4TawYfI2ZmZmZWEBdiZmZmZgVxIWZmZmZWEBdiZmZmZgVxIWZmZmZWEBdiZmZmZgVxIWZmZmZWEBdiZmZmZgVxIWZmZmZWkDEVYpL+l6Q1ku6T9FVJL5V0kKTbJfVJ+pqk3dK0u6fXfWn81Nx8Pp7aH5R07BjXyczMzKwl1FyISZoM/A3QHRFvAMaR3Xz1s8BFEfEaYDtwZnrLmcD21H5Rmg5JB6f3HQLMBP4t3fzVzMzMrK2NtWtyF2APSbsALwM2A+8Avp7GLwJOTMOz0mvS+KMlKbUviYhnIuIhoI8KN3o1MzMzazc13/Q7IjZJ+hfgp8AvgJuAVcDjEdGfJtsITE7Dk4EN6b39knYAr0jtt+VmnX/PC0iaA8wB6Orqore3t2JsXXvA3On9FccNpdr86mnnzp1NWU4tHFv9SZoCXA10AQEsiIiLJZ0L/AXw8zTpJyJiRXrPx8n2ID8L/E1E3JjaZwIXk+19/mJEzG/muhRhau6Gy3On94/4Bsy+6XLrcI6M3dQabkwOzpOyqLkQkzSRbG/WQcDjwL+TdS02TEQsABYAdHd3R09PT8XpLl28jAtWj37V1p9aeX711NvbS7W4i+bYGqIfmBsRd0vaC1glaWUad1FE/Et+4kFd9fsD35b02jT6MuAYso2VOyUtj4j7m7IWZo3jHLGOVnMhBrwTeCgifg4g6RvAW4AJknZJe8UOADal6TcBU4CNqStzb+CxXPuA/HvMWlpEbCbrsicinpT0AFX2+CbPddUDD0nKd9X3RcQ6AElL0rT+kbGW5hyxTjeWQuynwFGSXkbWNXk0cBdwC/BeYAkwG1iWpl+eXn8/jf9ORISk5cBXJF1ItnUzDbhjDHGZlVI6U/gw4HayjZazJZ1GljdzI2I7Q3fVbxjUfmSFZZSy+76WZQ02mpjL0I3dat3pZYi3GTmSltOyeVJrTJXU6+9dhu/OYGWMqZqxHCN2u6SvA3eT7Vr+AVm34Q3AEkmfSW1XprdcCVyTtl62ke1aJiLWSFpKttXSD5wVEc/WGpdZGUnaE7gW+GhEPCHpcuA8smNizgMuAD441uWUtft+pMd2DWXu9P4Rx9yMwwyG02rd6UXH26wcgdbOk9HkwXDqlSdFf3cqKWNM1YzprxkR5wDnDGpeR4WzHiPil8D7qsznfOD8scRiVlaSdiX7gVkcEd8AiIgtufFXANenl0N11bsL39qSc8Q6ma+sb9ZA6RItVwIPRMSFufZJucneA9yXhpcDJ6cLIB/E8131dwLT0gWTdyPbo7y8Getg1kjOEet09dm/aWbVvAX4ALBa0j2p7RPAKZIOJet2WQ98CIbuqpd0NnAj2an5CyNiTfNWw6xhnCPW0VyImTVQRHwPUIVRK4Z4T8Wu+nQNparvM2tFzhHrdO6aNDMzMyuICzEzMzOzgrgQMzMzMyuICzEzMzOzgrgQMzMzMyuICzEzMzOzgrgQMzMzMyuICzEzMzOzgrgQMzMzMyuICzEzMzOzgrgQMzMzMyuICzEzMzOzgrgQMzMzMyuICzGzBpI0RdItku6XtEbSR1L7PpJWSlqbniemdkm6RFKfpHslHZ6b1+w0/VpJs4taJ7N6co5Yp3MhZtZY/cDciDgYOAo4S9LBwDzg5oiYBtycXgMcB0xLjznA5ZD9KAHnAEcCRwDnDPwwmbU454h1NBdiZg0UEZsj4u40/CTwADAZmAUsSpMtAk5Mw7OAqyNzGzBB0iTgWGBlRGyLiO3ASmBm89bErDGcI9bpdik6ALNOIWkqcBhwO9AVEZvTqEeArjQ8GdiQe9vG1FatffAy5pDtJaCrq4ve3t6KsXTtAXOn9496HarNbzi1LGuw0cRca5z1tHPnzlLEMVJliLcZOZKW07J5UmtMldTr712G785gZYypmjEVYpImAF8E3gAE8EHgQeBrwFRgPXBSRGyXJOBi4HjgaeD0ga2g1Jf/j2m2n4mIRZi1EUl7AtcCH42IJ7J0yERESIp6LCciFgALALq7u6Onp6fidJcuXsYFq0ef/utPrTy/4Zw+74aa3pc3d3r/iGOuNc566u3tpdrnX0ZFx9usHEnza9k8GU0eDKdeeVL0d6eSMsZUzVi7Ji8GvhURvwO8kWyXsvv1zXIk7Ur2A7M4Ir6Rmrek7hTS89bUvgmYknv7AamtWrtZy3OOWCeruRCTtDfwNuBKgIj4VUQ8jvv1zZ6T9gRfCTwQERfmRi0HBs7qmg0sy7Wfls4MOwrYkbpnbgRmSJqYNlRmpDazluYcsU43lv2bBwE/B74k6Y3AKuAjdGC//miUud/asTXEW4APAKsl3ZPaPgHMB5ZKOhN4GDgpjVtB1n3fR9aFfwZARGyTdB5wZ5ru0xGxrSlrYNZYzhHraGMpxHYBDgf+OiJul3Qxz3dDAp3Trz8aZe63dmz1FxHfA1Rl9NEVpg/grCrzWggsrF90ZsVzjlinG8sxYhuBjRFxe3r9dbLCzP36ZmZmZiNQcyEWEY8AGyS9LjUdDdyP+/XNzMzMRmSs58D+NbBY0m7AOrK++pfgfn0zMzOzYY2pEIuIe4DuCqPcr29mZmY2DN/iyMzMzKwgLsTMzMzMCuJCzMzMzKwgLsTMzMzMCuJCzMzMzKwgLsTMzMzMCuJCzMzMzKwgY72gq5l1kKnzbig6BLPSc57YaHiPmJmZmVlBXIiZmZmZFcSFmFkDSVooaauk+3Jt50raJOme9Dg+N+7jkvokPSjp2Fz7zNTWJ2les9fDrFGcI9bpfIyYWWNdBXwOuHpQ+0UR8S/5BkkHAycDhwD7A9+W9No0+jLgGGAjcKek5RFxfyMDb2VjOUZn/fwT6hiJjcBVOEcKUWueOEfqy4WYWQNFxK2Spo5w8lnAkoh4BnhIUh9wRBrXFxHrACQtSdP6R8ZannPEOp0LMbNinC3pNOAuYG5EbAcmA7flptmY2gA2DGo/stJMJc0B5gB0dXXR29tbceFde8Dc6f1jib/pmhVztc9stHbu3Fm3eTVDCeNtSI5Aa+dJGWIa/HmV8LtTypiqcSFm1nyXA+cBkZ4vAD5YjxlHxAJgAUB3d3f09PRUnO7Sxcu4YHVrpf/c6f1NiXn9qT11mU9vby/VPv8yKlm8DcsRaO08aVYeDGVwjpTsuwOUM6ZqyvUNM+sAEbFlYFjSFcD16eUmYEpu0gNSG0O0m7Ud54h1Ep81adZkkiblXr4HGDhbbDlwsqTdJR0ETAPuAO4Epkk6SNJuZAcrL29mzGbN5ByxTuI9YmYNJOmrQA+wr6SNwDlAj6RDybpd1gMfAoiINZKWkh1g3A+cFRHPpvmcDdwIjAMWRsSa5q6JWWM4R6zTuRAza6CIOKVC85VDTH8+cH6F9hXAijqGZlYKzhHrdGPumpQ0TtIPJF2fXh8k6fZ0Ub2vpd3EpF3JX0vtt+dPV652gT4zMzOzdlaPY8Q+AjyQe/1ZsgvxvQbYDpyZ2s8Etqf2i9J0gy/QNxP4N0nj6hCXmZmZWamNqRCTdABwAvDF9FrAO4Cvp0kWASem4VnpNWn80Wn65y7QFxEPAfkL9JmZmZm1rbEeI/avwD8Ae6XXrwAej4iBq83lL7Y3mXTBvYjol7QjTT/UBfpeoNEX4WvGxd/KfJE5x2ZmZtZcNRdikt4FbI2IVZJ66hbREBp9Eb56XchxKGW+yJxjMzMza66x7BF7C/BHko4HXgq8HLgYmCBpl7RXLH9RvYEL8W2UtAuwN/AYQ1+gz8zMzKxt1XyMWER8PCIOiIipZAfbfyciTgVuAd6bJpsNLEvDy9Nr0vjvRERQ/QJ9ZmZmZm2tEdcR+xiwRNJngB/w/PVgrgSukdQHbCMr3oa8QJ+ZmZlZO6tLIRYRvUBvGl5HhbMeI+KXwPuqvL/iBfrMzMzM2pnvNWlmZmZWEBdiZmZmZgVxIWZmZmZWEBdiZmZmZgVxIWbWQJIWStoq6b5c2z6SVkpam54npnZJukRSn6R7JR2ee8/sNP1aSbMrLcusVTlPrJO5EDNrrKvIbmafNw+4OSKmATen1wDHkV1HbxrZrbwuh+wHCTgHOJLsjORzBn6UzNrEVThPrEO5EDNroIi4ley6eXmzgEVpeBFwYq796sjcRnaXiknAscDKiNgWEduBlbz4R8usZTlPrJM14oKuZja0rojYnIYfAbrS8GRgQ266jamtWvuLSJpDtpeArq6uqjdK79oD5k7vrzH8YjQr5nrdXL7VblRfwnidJxWUIabBn1cJvzuljKkaF2JmBYqIkBR1nN8CYAFAd3d3VLtR+qWLl3HB6tZK/7nT+5sS8/pTe+oyn1a7UX2Z43WePK9ZeTCUwTlSxu9OGWOqxl2TZs23JXWlkJ63pvZNwJTcdAektmrtZu3MeWIdwYWYWfMtBwbO6JoNLMu1n5bOCjsK2JG6Zm4EZkiamA4+npHazNqZ88Q6Qrn2uZq1GUlfBXqAfSVtJDuraz6wVNKZwMPASWnyFcDxQB/wNHAGQERsk3QecGea7tMRMfjAZrOW5TyxTuZCzKyBIuKUKqOOrjBtAGdVmc9CYGEdQzMrDeeJdTJ3TZqZmZkVxIWYmZmZWUFciJmZmZkVxIWYmZmZWUFciJmZmZkVxIWYmZmZWUF8+Qozs5yp826o6X3r559Q50jMymlwjsyd3s/pI8gb50hlNe8RkzRF0i2S7pe0RtJHUvs+klZKWpueJ6Z2SbpEUp+keyUdnpvX7DT9Wkmzqy3TzMzMrJ2MpWuyH5gbEQcDRwFnSToYmAfcHBHTgJvTa4DjgGnpMQe4HLLCjewqykcCRwDnDBRvZmZmZu2s5kIsIjZHxN1p+EngAWAyMAtYlCZbBJyYhmcBV0fmNmBCupHrscDKiNgWEduBlcDMWuMyMzMzaxV1OUZM0lTgMOB2oCvdgBXgEaArDU8GNuTetjG1VWuvtJw5ZHvT6Orqore3t2I8XXtkfdajVW1+9bRz586mLKcWjs3MzKy5xlyISdoTuBb4aEQ8Iem5cRERkmKsy8jNbwGwAKC7uzt6enoqTnfp4mVcsHr0q7b+1Mrzq6fe3l6qxV00x2ZmZtZcY7p8haRdyYqwxRHxjdS8JXU5kp63pvZNwJTc2w9IbdXazczMzNraWM6aFHAl8EBEXJgbtRwYOPNxNrAs135aOnvyKGBH6sK8EZghaWI6SH9GajNra5LWS1ot6R5Jd6W2UZ91bNbOnCfW7sayR+wtwAeAd6QEuUfS8cB84BhJa4F3ptcAK4B1QB9wBfBXABGxDTgPuDM9Pp3azDrB2yPi0IjoTq9HddaxWYdwnljbqvkYsYj4HqAqo4+uMH0AZ1WZ10JgYa2xmLWRWUBPGl4E9AIfI3fWMXCbpAmSJuVOjDHrJM4Taxu+sr5ZcQK4KZ3Q8oV0Mspozzp+wQ9Mo88sLlLZYx78Wbfamb4ljtd5ktPKMTXz+1Xi7/OLuBAzK85bI2KTpFcCKyX9KD+ylrOOG31mcZHmTu8vdcyDz7putTN9Sxyv8ySnjHkw0piacWWCASX+Pr+Ib/ptVpCI2JSetwLXkd1ZYrRnHZu1NeeJtTsXYmYFkDRe0l4Dw2RnC9/H6M86NmtbzhPrBOXav2nWObqA69IFkHcBvhIR35J0J7BU0pnAw8BJafoVwPFkZx0/DZzR/JDNms55Ym3PhZhZASJiHfDGCu2PMcqzjs3alfPEOoG7Js3MzMwK4kLMzMzMrCAuxMzMzMwK4mPEzMzqYOq8G17weu70fk4f1FbJ+vknNCoks1IZnCMj1e454j1iZmZmZgVxIWZmZmZWEBdiZmZmZgVxIWZmZmZWEBdiZmZmZgXxWZNmZgXymWRmQ6slR+ZO76en/qE0hAsxaxj/wJiZmQ3NhVgdjKbgyF9bqNkFx3BxVrvuUasURrUWftA662hmZu3FhZgNaywFjpmZmVVXmkJM0kzgYmAc8MWImN/sGJpdcLjAqazS5zLSq5S3szLkiFnZOU+s1ZSiEJM0DrgMOAbYCNwpaXlE3F9sZGbl4ByxwXwM5os5TyyvVXKkLJevOALoi4h1EfErYAkwq+CYzMrEOWI2POeJtZxS7BEDJgMbcq83AkcWFItZGTlHrC6q7SUYrvu/RfakOU9szJp94ldZCrERkTQHmJNe7pT0YJVJ9wUebU5Uo/M3jq0mjY5Nnx1y9IGNWm69tUOOVFPm72cl7RZvu+QItHaelPF75ZieV0uelKUQ2wRMyb0+ILW9QEQsABYMNzNJd0VEd/3Cqx/HVpsyx9YkHZMj1bRazI63EG2fJ45pZMoYUzVlOUbsTmCapIMk7QacDCwvOCazMnGOmA3PeWItpxR7xCKiX9LZwI1kpxwvjIg1BYdlVhrOEbPhOU+sFZWiEAOIiBXAijrNbthdzgVybLUpc2xN0UE5Uk2rxex4C9ABeeKYRqaMMVWkiCg6BjMzM7OOVJZjxMzMzMw6TlsVYpJmSnpQUp+keQUsf6GkrZLuy7XtI2mlpLXpeWJql6RLUqz3Sjq8wbFNkXSLpPslrZH0kbLEJ+mlku6Q9MMU26dS+0GSbk8xfC0dfIuk3dPrvjR+aqNia0dF58lwRpNHZTDa3CqD0eZcpykyRyStl7Ra0j2S7kptTf0/Xa/fMkmz0/RrJc1uQEznStqUPqt7JB2fG/fxFNODko7NtZfv/19EtMWD7MDMnwCvBnYDfggc3OQY3gYcDtyXa/tnYF4angd8Ng0fD3wTEHAUcHuDY5sEHJ6G9wJ+DBxchvjSMvZMw7sCt6dlLgVOTu2fB/4yDf8V8Pk0fDLwtaK/f63yKEOejCDGEedRGR6jza0yPEabc530KDpHgPXAvoPamvp/uh6/ZcA+wLr0PDENT6xzTOcCf1dh2oPT32134KD09xxX9N+22qOd9ogVfmuLiLgV2DaoeRawKA0vAk7MtV8dmduACZImNTC2zRFxdxp+EniA7CrUhceXlrEzvdw1PQJ4B/D1KrENxPx14GhJakRsbajwPBnOKPOocDXkVuFqyLlOUsYcaer/6Tr9lh0LrIyIbRGxHVgJzKxzTNXMApZExDMR8RDQR/Z3LePftq0KsUq3tphcUCx5XRGxOQ0/AnSl4cLiTV15h5FtBZciPknjJN0DbCVL2J8Aj0dEf4XlPxdbGr8DeEWjYmszZc2T4VT7npbKCHOrFEaZc52k6BwJ4CZJq5TdAQDK8X96tDE0K7azU5fowlz3f9ExjUo7FWKlF9k+00JPU5W0J3At8NGIeCI/rsj4IuLZiDiU7ErYRwC/U0QcVn5lyKNKyppb1TjnSuutEXE4cBxwlqS35UeW4btUhhiSy4HfBg4FNgMXFBpNjdqpEBvRrS0KsGVgV3F63pramx6vpF3JfigWR8Q3yhYfQEQ8DtwCvJlsF/fAte7yy38utjR+b+CxRsfWJsqaJ8Op9j0thVHmVqmMMOc6SaE5EhGb0vNW4DqyIrkM/6dHG0PDY4uILWmD4jfAFWSfVaEx1aKdCrGy3tpiOTBwtshsYFmu/bR0xslRwI7cbt+6S8dQXQk8EBEXlik+SftJmpCG9wCOITvO5hbgvVViG4j5vcB30haaDa+seTKcat/TwtWQW4WrIec6SWE5Imm8pL0GhoEZwH2U4P90DTHcCMyQNDF1Gc5IbXUz6Hi495B9VgMxnazsDPuDgGnAHZT1/1+RZwrU+0F29saPyY51+GQBy/8q2e7RX5P1PZ9JduzSzcBa4NvAPmlaAZelWFcD3Q2O7a1ku5LvBe5Jj+PLEB/wu8APUmz3Af8ntb+aLHn6gH8Hdk/tL02v+9L4Vxf93WulR9F5MoL4RpxHZXiMNrfK8BhtznXao6gcSZ//D9NjzcCym/1/ul6/ZcAH03epDzijATFdk5Z5L1lBNSk3/SdTTA8CxxX9tx3q4Svrm5mZmRWknbomzczMzFqKCzEzMzOzgrgQMzMzMyuICzEzMzOzgrgQMzMzMyuICzEzMzOzgrgQMzMzMyuICzEzMzOzgrgQMzMzMyuICzEzMzOzgrgQMzMzMyuICzEzMzOzgrgQMzMzMyuICzEzMzOzgrgQK4ikqyR9pknL+ktJWyTtlPSKJi1zqqSQtEszlmdmZtaKXIi1OEm/L+k7kp6UtEPSf0o6ODd+V+BCYEZE7An8k6TL8+MlPVWl7aimroyZmVmHcSHWwiS9GbgJWAbsDxwE/BD4b0mvTpN1AS8F1qTXtwJvy82mG/gp8AeD2gBWNSZyMzMzAxdiTSPpMEl3pz1XXyMrjpA0UdL1kn4uaXsaPiCNe5+kVYPm87eSlqWX/wxcHREXR8STEbEtIv4RuA04V9JrgQfTtI9L+g5ZIfZ6Sfum9j8AlgDjB7V9PyJ+LWl/Sdem+B6S9De5WF4iaZ6kn0h6TNJSSftUWf8/kbRe0hvG9kmamZm1DxdiTSBpN+A/gGuAfYB/B/4kjX4J8CXgQOBVwC+Az6Vxy4GDJL0+N7sPAFdLehnw+2legy0FjomIHwOHpLYJEfGOiNgAPMzze8DeBnwX+J9BbbdKegnwn2R72SYDRwMflXRsmu6vgROBPyTbI7cduKzC+p8BfBZ4Z0TcV+1zMjMz6zQuxJrjKGBX4F8j4tcR8XXgToCIeCwiro2IpyPiSeB8ssKGiHgG+BrwZwCSDgGmAteTFXQvATZXWN5mYN8K7QP+C3hbKrSOINuD9t1c21vSNL8H7BcRn46IX0XEOuAK4OQ0nw8Dn4yIjSnWc4H3DjpA/6PA3wM9EdE3kg/LzMysU7gQa479gU0REbm2hwEkvUzSFyQ9LOkJsq7DCZLGpekWAe+XJLK9YUtT0bMd+A0wqcLyJgGPDhHPwHFi04F1EfE08L1c2x7A7WR76faX9PjAA/gE2XFnpPHX5cY9ADybGw9ZEXZZRGwc8hMyMzPrQC7EmmMzMDkVUwNelZ7nAq8DjoyIl/P8gfQCiIjbgF+RdRu+n6x7k4h4Cvg+8L4KyzsJuHmIeG4F3gicQLYnDLKD+aektjsj4pfABuChiJiQe+wVEcen92wAjhs0/qURsSm3rBnAP0r6E8zMzOwFXIg1x/eBfuBv0qUh/pisSxBgL7Ljwh5PB7qfU+H9V5MdN/briPhern0eMFvS30jaKx34/xngzcCnqgWTugi3AB8hFWJpb93tqe3WNOkdwJOSPiZpD0njJL1B0u+l8Z8Hzpd0IICk/STNGrS4NcBM4DJJfzTkp2RmZtZhXIg1QUT8Cvhj4HRgG/CnwDfS6H8l6wp8lOxYrW9VmMU1wBuALw+a7/eAY9O8N5N1dx4GvDUi1g4T1q3AfsB/59q+C7wyjSMingXeBRwKPJRi/CKwd5r+YrITCm6S9GSK/8gK6//DNJ8rJB03TFxmZmYdQy88bMnKSNIewFbg8BEUWGZmZtYivEesNfwl2XFbLsLMzMzaiO8DWHKS1pMduH9isZGYmZlZvblr0szMzKwg7po0MzMzK0jLdk3uu+++MXXq1IrjnnrqKcaPH9/cgOrEsRdjqNhXrVr1aETs1+SQzMysA7RsITZ16lTuuuuuiuN6e3vp6elpbkB14tiLMVTskh5ubjRmZtYp3DVpZmZmVhAXYmZmZmYFcSFmZmZmVhAXYmZmZmYFqbkQkzRF0i2S7pe0RtJHUvs+klZKWpueJ6Z2SbpEUp+keyUdnpvX7DT9Wkmzx75aZmZmZuU3lrMm+4G5EXG3pL2AVZJWkt3Y+uaImC9pHjAP+BhwHDAtPY4ELgeOlLQPcA7QDUSaz/KI2F5rYKs37eD0eTeM+n3r559Q6yLNzMzMRq3mPWIRsTki7k7DTwIPAJOBWcCiNNkinr81zyzg6sjcBkyQNAk4FlgZEdtS8bUSmFlrXGZmZmatoi7XEZM0FTgMuB3oiojNadQjQFcangxsyL1tY2qr1l5pOXOAOQBdXV309vZWjKdrD5g7vX/U61Ftfs20c+fOUsSRt3rTjhFN17UHXLp42XOvp0/eu1Eh1V0ZP3czM2t/Yy7EJO0JXAt8NCKekPTcuIgISXW7mWVELAAWAHR3d0e1C3BeungZF6we/aqtP7Xy/JqpjBdFHWk379zp/S/43MvweY5UGT93MzNrf2M6a1LSrmRF2OKI+EZq3pK6HEnPW1P7JmBK7u0HpLZq7WZmZmZtbSxnTQq4EnggIi7MjVoODJz5OBtYlms/LZ09eRSwI3Vh3gjMkDQxnWE5I7WZmZmZtbWxdE2+BfgAsFrSPantE8B8YKmkM4GHgZPSuBXA8UAf8DRwBkBEbJN0HnBnmu7TEbFtDHG1jKkVuvzmTu8ftivQZ3eamZm1h5oLsYj4HqAqo4+uMH0AZ1WZ10JgYa2x1EulwmgkXBiZmZlZLepy1qS1hloLzWZzQWxmZp3CtzgyMzMzK4gLMTMzM7OCuBAzMzMzK4gLMTMzM7OCuBAzMzMzK4gLMTMzM7OCuBAzMzMzK4gLMTMzM7OCuBAzMzMzK4gLMTMzM7OCuBAzMzMzK4gLMTMzM7OCuBAzMzMzK4gLMTMzM7OCuBAzMzMzK4gLMTMzM7OCuBAzMzMzK4gLMTMzM7OCuBAzMzMzK4gLMTMzM7OCuBAzMzMzK4gLMTMzM7OCuBAzMzMzK4gLMTMzM7OCuBAzMzMzK4gLMTMzM7OC1FyISVooaauk+3Jt50raJOme9Dg+N+7jkvokPSjp2Fz7zNTWJ2le7atiZmZm1lrGskfsKmBmhfaLIuLQ9FgBIOlg4GTgkPSef5M0TtI44DLgOOBg4JQ0rZmZmVnb26XWN0bErZKmjnDyWcCSiHgGeEhSH3BEGtcXEesAJC1J095fa1xmZmZmraLmQmwIZ0s6DbgLmBsR24HJwG25aTamNoANg9qPrDZjSXOAOQBdXV309vZWnK5rD5g7vb/W+EetWhzDqRTjSGKv5/LqaXDszY6z1uUB7Ny5c0zvNzMzq0W9C7HLgfOASM8XAB+s18wjYgGwAKC7uzt6enoqTnfp4mVcsLoRNWZl60+tHMdwTp93w4va5k7vHzb2ei6vngbH3uw4a10eZEVcte+TmZlZo9S1WomILQPDkq4Ark8vNwFTcpMekNoYot3MzMysrdX18hWSJuVevgcYOKNyOXCypN0lHQRMA+4A7gSmSTpI0m5kB/Qvr2dMZmZmZmVV8x4xSV8FeoB9JW0EzgF6JB1K1jW5HvgQQESskbSU7CD8fuCsiHg2zeds4EZgHLAwItbUGpOZmZlZKxnLWZOnVGi+cojpzwfOr9C+AlhRaxxmZmZmrcpX1jczMzMriAsxMzMzs4K4EDMzMzMriAsxMzMzs4K4EDMzMzMriAsxMzMzs4K4EDMzMzMrSPNuyGjWYFPHcC/Nq2aOr2MkZmZmI+M9YmZmZmYFcSFmZmZmVhAXYmZmZmYFcSFmZmZmVhAXYmZmZmYFcSFmZmZmVhAXYmZmZmYFcSFmZmZmVhAXYmZmZmYFcSFmZmZmVhAXYmZmZmYFcSFmZmZmVhAXYmZmZmYFcSFmZmZmVhAXYmZmZmYFcSFmZmZmVhAXYmZmZmYFcSFmZmZmVpAxFWKSFkraKum+XNs+klZKWpueJ6Z2SbpEUp+keyUdnnvP7DT9WkmzxxKTmZmZWasY6x6xq4CZg9rmATdHxDTg5vQa4DhgWnrMAS6HrHADzgGOBI4Azhko3szMzMza2ZgKsYi4Fdg2qHkWsCgNLwJOzLVfHZnbgAmSJgHHAisjYltEbAdW8uLizszMzKzt7NKAeXZFxOY0/AjQlYYnAxty021MbdXaX0TSHLK9aXR1ddHb21s5gD1g7vT+GsMfvWpxDKdSjCOJvZ7Lq6fBsZc1zkp27txZc7xmZma1akQh9pyICElRx/ktABYAdHd3R09PT8XpLl28jAtWN3TVXmD9qZXjGM7p8254Udvc6f3Dxl7P5dXT4NjLGmclV80cT7Xvk5mZWaM04qzJLanLkfS8NbVvAqbkpjsgtVVrNzMzM2trjSjElgMDZz7OBpbl2k9LZ08eBexIXZg3AjMkTUwH6c9IbWZmZmZtbUz9d5K+CvQA+0raSHb243xgqaQzgYeBk9LkK4DjgT7gaeAMgIjYJuk84M403acjYvAJAGZmZmZtZ0yFWEScUmXU0RWmDeCsKvNZCCwcSyxmZmZmrcZX1jczMzMriAsxMzMzs4K4EDMzMzMriAsxMzMzs4K4EDMzMzMriAsxMzMzs4K4EDMzMzMriAsxMzMzs4K4EDMzMzMriAsxMzMzs4K4EDMzMzMriAsxMzMzs4K4EDMzMzMriAsxMzMzs4K4EDMzMzMriAsxMzMzs4K4EDMzMzMriAsxMzMzs4K4EDMzMzMriAsxMzMzs4K4EDMzMzMriAsxMzMzs4K4EDMzMzMriAsxMzMzs4K4EDMzMzMriAsxMzMzs4I0rBCTtF7Sakn3SLorte0jaaWktel5YmqXpEsk9Um6V9LhjYrLzMzMrCwavUfs7RFxaER0p9fzgJsjYhpwc3oNcBwwLT3mAJc3OC4zMzOzwjW7a3IWsCgNLwJOzLVfHZnbgAmSJjU5NjMzM7OmUkQ0ZsbSQ8B2IIAvRMQCSY9HxIQ0XsD2iJgg6XpgfkR8L427GfhYRNw1aJ5zyPaY0dXV9aYlS5ZUXPbWbTvY8ouGrFZF0yfvXdP7Vm/a8aK2rj0YNvZ6Lq+eBsde1jgrOWjvcey5554Vx7397W9fldura2ZmVje7NHDeb42ITZJeCayU9KP8yIgISaOqAiNiAbAAoLu7O3p6eipOd+niZVywupGr9kLrT60cx3BOn3fDi9rmTu8fNvZ6Lq+eBsde1jgruWrmeKp9n8zMzBqlYV2TEbEpPW8FrgOOALYMdDmm561p8k3AlNzbD0htZmZmZm2rIYWYpPGS9hoYBmYA9wHLgdlpstnAsjS8HDgtnT15FLAjIjY3IjYzMzOzsmhU/10XcF12GBi7AF+JiG9JuhNYKulM4GHgpDT9CuB4oA94GjijQXGZmZmZlUZDCrGIWAe8sUL7Y8DRFdoDOKsRsZiZmZmVla+sb2ZmZlYQF2JmZmZmBXEhZmZmZlYQF2JmZmZmBXEhZmZmZlYQF2JmZmZmBXEhZmZmZlYQF2JmZmZmBXEhZmZmZlYQF2JmZmZmBXEhZmZmZlYQF2JmZmZmBXEhZmZmZlYQF2JmZmZmBXEhZmZmZlYQF2JmZmZmBXEhZmZmZlYQF2JmZmZmBXEhZmZmZlYQF2JmZmZmBXEhZmZmZlYQF2JmZmZmBXEhZmZmZlYQF2JmZmZmBXEhZmZmZlYQF2JmZmZmBXEhZmZmZlaQ0hRikmZKelBSn6R5RcdjZmZm1milKMQkjQMuA44DDgZOkXRwsVGZmZmZNVYpCjHgCKAvItZFxK+AJcCsgmMyMzMzayhFRNExIOm9wMyI+PP0+gPAkRFx9qDp5gBz0svXAQ9WmeW+wKMNCrfRHHsxhor9wIjYr5nBmJlZZ9il6ABGIyIWAAuGm07SXRHR3YSQ6s6xF6OVYzczs9ZVlq7JTcCU3OsDUpuZmZlZ2ypLIXYnME3SQZJ2A04Glhcck5mZmVlDlaJrMiL6JZ0N3AiMAxZGxJoxzHLY7ssSc+zFaOXYzcysRZXiYH0zMzOzTlSWrkkzMzOzjuNCzMzMzKwgbVWIteptkiRNkXSLpPslrZH0kaJjGi1J4yT9QNL1RccyGpImSPq6pB9JekDSm4uOyczMOkfbHCOWbpP0Y+AYYCPZmZinRMT9hQY2ApImAZMi4m5JewGrgBNbIfYBkv4W6AZeHhHvKjqekZK0CPhuRHwxnbH7soh4vOCwzMysQ7TTHrGWvU1SRGyOiLvT8JPAA8DkYqMaOUkHACcAXyw6ltGQtDfwNuBKgIj4lYswMzNrpnYqxCYDG3KvN9JCxcwASVOBw4DbCw5lNP4V+AfgNwXHMVoHAT8HvpS6Vb8oaXzRQZmZWedop0Ks5UnaE7gW+GhEPFF0PCMh6V3A1ohYVXQsNdgFOBy4PCIOA54CWubYQjMza33tVIi19G2SJO1KVoQtjohvFB3PKLwF+CNJ68m6g98h6cvFhjRiG4GNETGw9/HrZIWZmZlZU7RTIdayt0mSJLLjlB6IiAuLjmc0IuLjEXFAREwl+8y/ExF/VnBYIxIRjwAbJL0uNR0NtMwJEmZm1vpKcYujemjAbZKa6S3AB4DVku5JbZ+IiBXFhdQx/hpYnIr3dcAZBcdjZmYdpG0uX2FmZmbWatqpa9LMzMyspbgQMzMzMyuICzEzMzOzgrgQMzMzMyuICzEzMzOzgrgQMzMzMyuICzEzMzOzgvx/uOvlNtdfgCUAAAAASUVORK5CYII=",
-      "text/plain": [
-       "<Figure size 720x720 with 9 Axes>"
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "oV6j_h4INRFR"
+      },
+      "source": [
+        "### DataFrame.shape"
       ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "pd_flights.select_dtypes(include=np.number).hist(figsize=[10,10])\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 56,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-15T20:25:01.270515Z",
-     "iopub.status.busy": "2021-12-15T20:25:01.269865Z",
-     "iopub.status.idle": "2021-12-15T20:25:02.205574Z",
-     "shell.execute_reply": "2021-12-15T20:25:02.205194Z"
     },
-    "pycharm": {
-     "is_executing": false
-    }
-   },
-   "outputs": [
     {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAmIAAAJOCAYAAAAUOGurAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/MnkTPAAAACXBIWXMAAAsTAAALEwEAmpwYAABZyUlEQVR4nO3dfbwcdXn38c/X8CAGJEHwNIRIsEYrmAp4ClitPYqEANpgqxSkEpA22kKrd9PWqL1vUKR37F2ggBQNEgkYjalIk0IUInKKtvIUREJAzDEEkxgSISEQUPTgdf8xvwPDYfc87Nndmd39vl+vfe3sb2Znrtmz19lr5jcPigjMzMzMrPleUnQAZmZmZp3KhZiZmZlZQVyImZmZmRXEhZiZmZlZQVyImZmZmRXEhZiZmZlZQVyItSBJn5f0v0cwXa+kP29GTIOW+ypJOyWNa/ayrTgj/V62AkmnSrop9zokvabImMygvfIsT9IaST1p+FxJXy42ouZxIVZHqfDZLmn3Mc7nm6mQ2Snp15J+lXv9+Yj4cEScV6+4Kyz/RQVc+iF6KsWwSdKF1QqtiPhpROwZEc82KkZrPknrJf1C0pOSHpf0P5I+LOklACP9Xqb5vLPxEQ8Zw9T0nd4lvZakSyX9SNLkiFgcETMKjrFH0sYiY7Dma9M8+8Gg9n3T79r6gbaIOCQiepsdYxm4EKsTSVOBPwAC+KOxzCsijkuFzJ7AYuCfB15HxIfHHm3N3phiOhp4P/AXgycY+GGztvXuiNgLOBCYD3wMuLLYkMYm/cB9AegB/jAiNhUbUX04F1tau+XZyyS9Iff6/cBDRQVTNi7E6uc04DbgKmC2pN3T1sxzXz5J+6UtnVem1/8gabOkn0n685F2f0i6StJncq9nSbpH0hOSfiJpZoX3TJJ0r6S/T6+PSltaj0v6YW6X8PlkBeXn0t6vzw2eV0T8CPgu8IbcFs+Zkn4KfKfC3oZ9JH0pred2Sf+Ri+tdKfaBLb/fHf6jtqJFxI6IWA78Kdn3/Q3572Xa4r0+/V23SfqupJdIugZ4FfCf6fv1D2n6f5f0iKQdkm6VdMjAstJ8L5N0Q9pLcLuk386NP0TSyrScLZI+kdpfImleyonHJC2VtM+gVRkHfAnoBnoiYkt67+mSvldp3SXtLelqST+X9LCkfxzYW5He99+SLkrrvk7S76f2DZK2Spqdm9fukv5F0k9T7J+XtIek8cA3gf31/N7w/Ydapyq5+FJJX07TPi7pTkldY/jTWxO1UZ5dA8zOvT4NuDo/gYbYg6cqv1dp3Okpz56U9JCkU0f7ORfNhVj9nEa292oxcCwwAfgGcEpumpOA/4qIrcqKpb8F3gm8hmxrfNQkHUH2hf77tMy3AesHTXMQ8F/A5yLi/0maDNwAfAbYB/g74FpJ+0XEJ8mKrLPTHrizKyzzYLJiLb+7+Q+B16d1H+wa4GXAIcArgYvSfA4DFgIfAl5BtldiucbYtWvNExF3ABvJvg95c1P7fkAX8Ils8vgA8FOyLf49I+Kf0/TfBKaRfT/uJsujvJOBTwETgT7gfABJewHfBr4F7E+WSzen9/w1cCLZd3N/YDtw2aD5LgZeB7wjIh4b4WpfCuwNvDrN+zTgjNz4I4F7yb7TXwGWAL+XYvszso2cPdO084HXAoem8ZOB/xMRTwHHAT/L7Q3/2QjXKZ+Ls1OsU1I8HwZ+McL1tJJogzz7MnCypHHp92NP4PaRrPtQv1dpg+US4Li0B/H3gXtGMt8ycSFWB5LeSrYLeWlErAJ+Qrbr9StkX+wBA22QFWVfiog1EfE0cG6Niz8TWBgRKyPiNxGxKe2xGnAwcAtwTkQsSG1/BqyIiBXpPSuBu4Djh1nW3ZK2A/8JfJFsT8KAcyPiqYh4wT95SZPIflA+HBHbI+LXEfFfafQc4AsRcXtEPBsRi4BngKNG/SlYkX5G9g8y79fAJODA9Df/bgxxY9uIWBgRT0bEM2S58EZJe+cmuS4i7oiIfrIfj0NT+7uARyLigoj4ZZrHwD/4DwOfjIiNufm+Vy/sspsB/HtEPD6SFVV2XOTJwMfTstYDFwAfyE32UER8KR0j+TWyIujTEfFMRNwE/Ap4jSSR5cD/iohtEfEk8E+88H/GYCNZp3wu/pqsAHtNyrFVEfHESNbVSqeV82wj8CDZjofTyDbOR2q436vfkPXO7BERmyNizSjmXQouxOpjNnBTRDyaXn8ltd1C1jd+pLJjyA4FrkvT7A9syM0jPzwaU8gKv2pOBTYBX8+1HQi8L+3mfVzS48BbyRJ6KIdHxMSI+O2I+MeI+E1uXLX4pwDbImJ7hXEHAnMHxTGF7LOx1jEZ2Dao7f+RbVHflLoN5lV7c9pKnp+6Np7g+T26++YmeyQ3/DTZFjUM/f0/ELgu9916AHiWbM/BgHcB50j6YLX4BtkX2BV4ONf2MNlnMGBLbvgXAANdnrm2Pcn2YrwMWJWL8VupvZqRrFM+F68BbgSWKDs04J8l7TrcSloptXKeQdZzczpZL9FoCrGqv1dpz/GfkhWDm1O36u+MYt6l4EJsjCTtQbZ36w9T3/sjwP8C3gi8AVhK9sU7Bbg+bfUCbAYOyM1qSo0hbAB+e4jx5wKPAl/R82c5bgCuiYgJucf4iJifxlfdohpCtfdsAPaRNKHKuPMHxfGyiPhqDcu3Akj6PbIfiBccT5W2mOdGxKvJTl75W0lHD4weNJv3A7PItpb3BqYOzH4EIWwg6yKsNu64Qd+vl8YLD8b/H+DdwMWS3j+C5T1KthfiwFzbq8g2dkbrUbKi7JBcfHtHdkIMVM6pkazTc+9Le0k+FREHk3XbvItsj4S1kDbIM4BrgROAdRHx0xEsMz//qr9XEXFjRBxDtiPhR8AVo5h3KbgQG7sTyar/g8n2eB1KdnzGd8n+4X2FrGI/lee7JSEr0M6Q9HpJLwNqvS7MlWk+R6eDJicP2iL4NfA+YDxwtbKDir8MvFvSsWkr6aXKTpUfKAy3UD3pRiUiNpMdl/BvkiZK2lXS29LoK4APpz2GkjRe0gnpeAQrMUkvl/QusuOfvhwRqweNf5ekge63HWQ5MrAHdfD3ay+yLunHyPYQ/dMoQrkemCTpo8oOfN9L0pFp3OeB8yUdmGLaT9KswTNIXeV/DCyQ9CdDLSx1Ny5N890rzftvyXJqVNIe5SuAi/T8CTyTJQ0cZ7kFeMWgrqMRrdMASW+XND1thD1B9v/gN9Wmt3Jpszx7CngHMNprW1b9vZLUpexktfFp3XbSgt9vF2JjN5vsWK+fRsQjAw/gc2TF1yrgKbLutm8OvCkivkl2kOEtZLuWb0ujnhnNwiM7iPMMsgPgd5AdlH/goGl+RfZD00V2cPwmsi2jTwA/J9vi+Hue/z5cTNbHv13SJaOJp4oPkP0A/AjYCnw0xXUX2SUwPkd2gGcf2a5rK6//lPQk2Xfmk8CFvPBA9QHTyA7u3Ql8H/i3iLgljfu/wD+mboa/I+uyeJjse3k/z+fCsNIe5mPI9mo9AqwF3p5GXwwsJ+u2eTLN98gq81lJtsG0SNK7h1nsX5Pl9DqyPRRfIcurWnyMlP+pu+jbZCcPDJyd/FVgXfqs9h/NOiW/RXZYwhNkXUb/xei6hawY7Zpnd0XEUIfSVHrPBqr/Xr2EbEPoZ2Tdtn8I/OVo5l8GGuK4PmsiSa8H7gN2TwdKmpmZWZvzHrECSXpP2s07Efgs8J8uwszMzDqHC7FifYisq+4nZH37LbdL1czMzGrnrkkzMzOzgniPmJmZmVlBWvamsPvuu29MnTq14ct56qmnGD9+fMOX4+WXd/k/+tGPHo2IoS6yWUpD5UjRn+tgZYrHsVRXLZ5Vq1a1ZI5Aa+VJI3gdm6dqnkRESz7e9KY3RTPccsstTVmOl1/e5QN3RQm+86N9DJUjRX+ug5UpHsdSXbV4WjVHosXypBG8js1TLU/cNWnWQOnig3dI+qGkNZI+ldoPknS7pD5JX5O0W2rfPb3uS+On5ub18dT+YO6in2YtzTlinc6FmFljPQO8IyLeSHbXhZmSjiK7XMlFEfEasovZnpmmPxPYntovStMh6WCym0EfAswku1PBOMxan3PEOpoLMbMGSnukd6aXu6ZHkN3qY+BG7IvIbpUF2RWkF6XhrwNHp9uXzAKWRMQzEfEQ2dXYj2j8Gpg1lnPEOl3LHqxv1irSVvkq4DXAZWTXjXs8nr9470ayG/qSnjcARES/pB3AK1J7/pYk+ffklzUHmAPQ1dVFb29vxZh27txZdVwRyhSPY6muUfE0M0fS8loyTxrB61g8F2JmDRbZjaIPlTQBuA74naHfMaZlLQAWAHR3d0dPT0/F6Xp7e6k2rghlisexVNeoeJqZI2l5LZknjeB1LJ4LMRvW1Hk31PS+9fNPqHMkrS0iHpd0C/BmYIKkXdIW/wFkN+IlPU8BNkraBdgbeCzXPiD/nlFbvWkHp9fwd/Xf1BqpTDkCzhNrDhdiZg0kaT/g1+kHZg/gGLKDi28B3gssAWYDy9JblqfX30/jvxMRIWk58BVJFwL7A9OAO5q6Mi2k1o0HgKtmFn+9oU7iHCnO1Hk3MHd6/6iLTRea9eVCzKyxJgGL0jEwLwGWRsT1ku4Hlkj6DPAD4Mo0/ZXANZL6gG1kZ4EREWskLQXuB/qBs1J3jlmrc45YR3MhZtZAEXEvcFiF9nVUOKMrIn4JvK/KvM4Hzq93jGZFco5Yp3Mh1kFq6a6ZO70ff03MzMwaw9cRMzMzMyuICzEzMzOzgrgQMzMzMyuICzEzMzOzgrgQMzMzMyuICzEzMzOzgvi6BNYwvjWSmZnZ0LxHzMzMzKwg3iPWgsZyHz0zMzMrD+8RMzMzMyuI94iZWWl576/Z8Jwnrc17xMzMzMwK4kLMzMzMrCAuxMzMzMwK4kLMzMzMrCAuxMwaSNIUSbdIul/SGkkfSe3nStok6Z70OD73no9L6pP0oKRjc+0zU1ufpHlFrI9ZvTlHrNP5rEmzxuoH5kbE3ZL2AlZJWpnGXRQR/5KfWNLBwMnAIcD+wLclvTaNvgw4BtgI3ClpeUTc35S1MGsc54h1tJoLMUkLgXcBWyPiDantXOAvgJ+nyT4RESvSuI8DZwLPAn8TETem9pnAxcA44IsRMb/WmFrNSE45nju9n9N9anLLiojNwOY0/KSkB4DJQ7xlFrAkIp4BHpLUBxyRxvVFxDoASUvStP6RsZbmHLFON5Y9YlcBnwOuHtTuLRizCiRNBQ4DbgfeApwt6TTgLrI9AtvJfoBuy71tI8//KG0Y1H5khWXMAeYAdHV10dvbWzGWrj2yIn+0qs1vrHbu3Flx3rXE2KhYilCmWKDx8TQjR9JyWjJPqhlLntSyjmX6To5E2fJosJoLsYi4NSXNSHgLxjqapD2Ba4GPRsQTki4HzgMiPV8AfHCsy4mIBcACgO7u7ujp6ak43aWLl3HB6tGn//pTK89vrHp7e6kUaxF7g6+aOb5iLEWo9rkUpZHxNCtHoHXzpJqx5Mnc6f2jXsdmr99YlS2PBmvEMWIN2YKBkW/F1FMjK+mRbIXUukVWL0UsP/95F70ls3PnzjHPQ9KuZD8wiyPiGwARsSU3/grg+vRyEzAl9/YDUhtDtJu1NOeIdbJ6F2IN24KBkW/F1FMjK+mRbMXUsrVST0UsP7+1VfSWzFiLQEkCrgQeiIgLc+2T0rExAO8B7kvDy4GvSLqQrBt/GnAHIGCapIPIflxOBt4/puDMSsA5Yp2urr+w3oIxe5G3AB8AVku6J7V9AjhF0qFkGy3rgQ8BRMQaSUvJuuf7gbMi4lkASWcDN5Kd2LIwItY0bzXMGsY5Yh2troWYt2DMXigivkf2PR9sxRDvOR84v0L7iqHeZ9aKnCPW6cZy+YqvAj3AvpI2AucAPd6CMTMzMxuZsZw1eUqF5iuHmN5bMGZmZmY5vrJ+HYzkwqxmZmZmg/lek2ZmZmYFcSFmZmZmVhAXYmZmZmYFcSFmZmZmVhAXYmZmZmYFcSFmZmZmVhAXYmZmZmYFcSFmZmZmVhAXYmZmZmYFcSFmZmZmVhAXYmZmZmYFcSFmZmZmVhAXYmYNJGmKpFsk3S9pjaSPpPZ9JK2UtDY9T0ztknSJpD5J90o6PDev2Wn6tZJmF7VOZvXkHLFOt0vRAZTJ1Hk3vKht7vR+Tq/QbjZC/cDciLhb0l7AKkkrgdOBmyNivqR5wDzgY8BxwLT0OBK4HDhS0j7AOUA3EGk+yyNie9PXyKy+nCPW0bxHzKyBImJzRNydhp8EHgAmA7OARWmyRcCJaXgWcHVkbgMmSJoEHAusjIht6YdlJTCzeWti1hjOEet03iNm1iSSpgKHAbcDXRGxOY16BOhKw5OBDbm3bUxt1doHL2MOMAegq6uL3t7eirF07ZHt7R2tavMbq507d1acdy0xNiqWIpQpFmh8PM3IkbSclsyTasaSJ7WsY5m+kyNRtjwazIWYWRNI2hO4FvhoRDwh6blxERGSoh7LiYgFwAKA7u7u6OnpqTjdpYuXccHq0af/+lMrz2+sent7qRRrEYcFXDVzfMVYilDtcylKI+NpVo6k+bVknlQzljyZO71/1OvY7PUbq7Ll0WDumjRrMEm7kv3ALI6Ib6TmLak7hfS8NbVvAqbk3n5AaqvWbtbynCPWyVyImTWQss36K4EHIuLC3KjlwMBZXbOBZbn209KZYUcBO1L3zI3ADEkT09ljM1KbWUtzjlinc9ekWWO9BfgAsFrSPantE8B8YKmkM4GHgZPSuBXA8UAf8DRwBkBEbJN0HnBnmu7TEbGtKWtg1ljOEetoLsTMGigivgeoyuijK0wfwFlV5rUQWFi/6MyK5xyxTueuSTMzM7OCuBAzMzMzK4gLMTMzM7OCuBAzMzMzK4gLMTMzM7OCuBAzMzMzK4gLMTMzM7OCuBAzMzMzK8iYCjFJCyVtlXRfrm0fSSslrU3PE1O7JF0iqU/SvZIOz71ndpp+raTZlZZlZmZm1m7GukfsKmDmoLZ5wM0RMQ24Ob0GOA6Ylh5zgMshK9yAc4AjgSOAcwaKNzMzM7N2NqZCLCJuBQbfy2sWsCgNLwJOzLVfHZnbgAmSJgHHAisjYltEbAdW8uLizszMzKztNOJek10RsTkNPwJ0peHJwIbcdBtTW7X2F5E0h2xvGl1dXfT29tYvamDu9P4XtXXtUbm9WTpx+fm/686dO+v+dx6NnTt3FrZsMzNrfw296XdEhKSo4/wWAAsAuru7o6enp16zBuD0eTe8qG3u9H4uWF3cvdE7cfnrT+15bri3t5d6/51Ho8gi0MzM2l8jzprckrocSc9bU/smYEpuugNSW7V2MzMzs7bWiEJsOTBw5uNsYFmu/bR09uRRwI7UhXkjMEPSxHSQ/ozUZmZmZtbWxnr5iq8C3wdeJ2mjpDOB+cAxktYC70yvAVYA64A+4ArgrwAiYhtwHnBnenw6tZm1vCqXeDlX0iZJ96TH8blxH0+XeHlQ0rG59pmprU/SvMHLMWtVzhHrdGM6+CciTqky6ugK0wZwVpX5LAQWjiUWs5K6CvgccPWg9osi4l/yDZIOBk4GDgH2B74t6bVp9GXAMWQns9wpaXlE3N/IwM2a5CqcI9bBijsK3KwDRMStkqaOcPJZwJKIeAZ4SFIf2bX1APoiYh2ApCVpWv/IWMtzjlincyFmVoyzJZ0G3AXMTdfQmwzclpsmfymXwZd4ObLSTEd6iZdaL0vSqLNIq12mpIhLtxR9yZS8MsUCTY+nITkCrZsn1YwlT2pZxzJ9J0eibHk0mAsxs+a7nOy4yEjPFwAfrMeMR3qJl0sXL6vpsiT5S4vUU7XLlFS6pEyjXTVzfKGXTMkr+vItgzUxnoblCLRunlQzljyp5RJFzV6/sSpbHg3mQsysySJiy8CwpCuA69PLoS7l4ku8WMdwjlgnacTlK8xsCAPX2UveAwycLbYcOFnS7pIOIrsv6x1kZxNPk3SQpN3IDlZe3syYzZrJOWKdxHvEzBooXeKlB9hX0kayG9z3SDqUrNtlPfAhgIhYI2kp2QHG/cBZEfFsms/ZZNfXGwcsjIg1zV0Ts8ZwjlincyFm1kBVLvFy5RDTnw+cX6F9Bdm1+MzainPEOp27Js3MzMwK0pZ7xKYWcKaVmZmZ2Wh5j5iZmZlZQdpyj5iZWa1Wb9pR03WZ1s8/oQHRmJVPrb1OzpHKvEfMzMzMrCAuxMzMzMwK4kLMzMzMrCAuxMzMzMwK4kLMzMzMrCAuxMzMzMwK4stXWOnkT42eO71/xJcS8KnRZmbWarxHzMzMzKwgLsTMzMzMCuJCzMzMzKwgLsTMzMzMCuJCzMzMzKwgLsTMGkjSQklbJd2Xa9tH0kpJa9PzxNQuSZdI6pN0r6TDc++ZnaZfK2l2Eeti1ijOE+tkLsTMGusqYOagtnnAzRExDbg5vQY4DpiWHnOAyyH7QQLOAY4EjgDOGfhRMmsTV+E8sQ7lQsysgSLiVmDboOZZwKI0vAg4Mdd+dWRuAyZImgQcC6yMiG0RsR1YyYt/tMxalvPEOpkv6GrWfF0RsTkNPwJ0peHJwIbcdBtTW7X2F5E0h2wvAV1dXfT29lYOYI/sYrmjVW1+Y7Vz586K864lxrEq02dT7XMpSpPjcZ6M0FjypNZ1rEVR3+Wy5dFgLsTMChQRISnqOL8FwAKA7u7u6OnpqTjdpYuXccHq0af/+lMrz2+sent7qRTrSO+qUE9zp/eX5rOp9rkUpah4nCdDG0ue1Pp9r0WzP5cBZcujwdw1adZ8W1JXCul5a2rfBEzJTXdAaqvWbtbOnCfWEVyImTXfcmDgjK7ZwLJc+2nprLCjgB2pa+ZGYIakieng4xmpzaydOU+sI7hr0qyBJH0V6AH2lbSR7Kyu+cBSSWcCDwMnpclXAMcDfcDTwBkAEbFN0nnAnWm6T0fE4AObzVqW88Q6WcMKMUnrgSeBZ4H+iOhOpxd/DZgKrAdOiojtkgRcTJZcTwOnR8TdjYrNrFki4pQqo46uMG0AZ1WZz0JgYR1DMysN54l1skZ3Tb49Ig6NiO70elTXhTEzMzNrZ80+Rmy014UxMzMza1uNPEYsgJvSKcdfSKcLj/a6MJtzbSO+9ks9r4nSzGusePljW36jruNkZmbWKI0sxN4aEZskvRJYKelH+ZG1XBdmpNd+qee1h5p5jRUvf2zLb9R1nMzMzBqlYV2TEbEpPW8FriO799dorwtjZmZm1rYasqtD0njgJRHxZBqeAXya568LM58XXxfmbElLyG7YuiPXhWlmJTG1xr3N6+efUOdIzMrLeWKj0ag+py7guuyqFOwCfCUiviXpTkZxXRgzMzOzdtaQQiwi1gFvrND+GKO8LoyZtb7h9hDMnd5fyH0lzcqk1j1p1tp8ZX1rG2P5J+YuATMzK4LvNWlmZmZWEBdiZmZmZgVx16SZWR34TDmzoTlHKvMeMTMzM7OCuBAzMzMzK4gLMTMzM7OCuBAzK4ik9ZJWS7pH0l2pbR9JKyWtTc8TU7skXSKpT9K9kg4vNnqz5nCeWLvzwfpmxXp7RDyaez0PuDki5kual15/DDgOmJYeRwKXp2drcUMdwDzUhW7b/QDmQZwnHazdD/L3HjGzcpkFLErDi4ATc+1XR+Y2YIKkSQXEZ1YGzhNrG94jZlacAG6SFMAXImIB0JW74f0jZPdtBZgMbMi9d2Nq25xrQ9IcYA5AV1cXvb29FRfctUe2t6UsyhRPq8RS7W/bSDt37ixiuc6TBmrndRz4uxb0vR0xF2JmxXlrRGyS9EpgpaQf5UdGRKQfnxFLP1ILALq7u6Onp6fidJcuXsYFq8uT/nOn95cmnlaJZf2pPc0NhuyHrdp3qoGcJw1Upu97vQ3kSEHf2xFz16RZQSJiU3reClwHHAFsGehKSc9b0+SbgCm5tx+Q2szamvPE2l17lsFmJSdpPPCSiHgyDc8APg0sB2YD89PzsvSW5cDZkpaQHXy8I9c1Yx2o3Q9gBueJjc1Ajgx10kslzc4RF2JmxegCrpMEWR5+JSK+JelOYKmkM4GHgZPS9CuA44E+4GngjOaHbNZ0zhNrey7EzAoQEeuAN1Zofww4ukJ7AGc1ITSz0nCeWCfwMWJmZmZmBXEhZmZmZlYQF2JmZmZmBXEhZmZmZlYQF2JmZmZmBXEhZmZmZlYQF2JmZmZmBXEhZmZmZlYQF2JmZmZmBXEhZmZmZlYQF2JmZmZmBXEhZmZmZlYQF2JmZmZmBdml6ADMzKx5ps67oab3rZ9/Qp0jMSunWnMEassT7xEzMzMzK0hpCjFJMyU9KKlP0ryi4zErG+eI2fCcJ9ZqSlGISRoHXAYcBxwMnCLp4GKjMisP54jZ8Jwn1opKUYgBRwB9EbEuIn4FLAFmFRyTWZk4R8yG5zyxlqOIKDoGJL0XmBkRf55efwA4MiLOHjTdHGBOevk64MEmhLcv8GgTluPll3f54yNivwJjaESOFP25DlameBxLddXiObDoHIGOyJNG8Do2T8U8aamzJiNiAbCgmcuUdFdEdDdzmV5+6ZY/tajlj9ZIc6Toz3WwMsXjWKorWzy1atU8aQSvY/HK0jW5CZiSe31AajOzjHPEbHjOE2s5ZSnE7gSmSTpI0m7AycDygmMyKxPniNnwnCfWckrRNRkR/ZLOBm4ExgELI2JNwWENaGpXqJfv5VfSgBwpxXrllCkex1Jd2eJ5gQ7Ik0bwOhasFAfrm5mZmXWisnRNmpmZmXUcF2JmZmZmBenoQkzSFEm3SLpf0hpJH0nt50raJOme9Dg+956Pp1tnPCjp2DrEsF7S6rScu1LbPpJWSlqbniemdkm6JC3/XkmHj3HZr8ut4z2SnpD00Uavv6SFkrZKui/XNup1ljQ7Tb9W0uwxLPv/SfpRmv91kiak9qmSfpH7HD6fe8+b0t+tL8WnWj6LIqhJt4Cp13e7jn/nui17tH//KvGMOs+q/e2UHZx+e2r/mrID1avFUu3/XmGfT9k0K0capcjca5Sy5XRdRUTHPoBJwOFpeC/gx2S3xTgX+LsK0x8M/BDYHTgI+AkwbowxrAf2HdT2z8C8NDwP+GwaPh74JiDgKOD2On4W44BHgAMbvf7A24DDgftqXWdgH2Bdep6YhifWuOwZwC5p+LO5ZU/NTzdoPnekeJTiO67o7/Mo/s4/AV4N7Jb+ngc3aFlj/m7X+e9ct2WP9u9fJZ5R5dlQfztgKXByGv488JdDxFLt/15hn0+ZHs3MkQauQ2G518B1KlVO1/PR0XvEImJzRNydhp8EHgAmD/GWWcCSiHgmIh4C+shuqVFvs4BFaXgRcGKu/erI3AZMkDSpTss8GvhJRDw8TFxjXv+IuBXYVmHeo1nnY4GVEbEtIrYDK4GZtSw7Im6KiP708jayaw9VlZb/8oi4LbIMvjoXb9kVfQuYwv7O9Vp2LX//KvFUUy3PKv7t0pb7O4CvV1i3SrFU+79X2OdTMkXnSKM0JfcapWw5XU8dXYjlSZoKHAbcnprOTrs0Fw7s7iT7Z7Uh97aNDF24jUQAN0lapey2GwBdEbE5DT8CdDVw+QNOBr6ae92s9R8w2nVuVCwfJNsaGnCQpB9I+i9Jf5CLaWMDlt0MjfwbDlaP73Y9463Xsuv59x9NnlVrfwXweG5jYsTxDPq/V8bPpwjNzJFGKVvuNUpbfGddiAGS9gSuBT4aEU8AlwO/DRwKbAYuaODi3xoRhwPHAWdJelt+ZKrOG3qNkXQ8yR8B/56amrn+L9KMda5E0ieBfmBxatoMvCoiDgP+FviKpJc3O64WVvh3u5oil51TaJ5V+L/3nJJ8Pla70uZeo7TyOnV8ISZpV7J/Rosj4hsAEbElIp6NiN8AV/B891vdb58REZvS81bgurSsLQNdjul5a6OWnxwH3B0RW1IsTVv/nNGuc11jkXQ68C7g1JTQpK6hx9LwKrLjRl6blpPvvmyl26g07RYwdfpu1zPeei27Ln//GvKsWvtjZF0vuwxqr6rS/z1K9vkUqOVvk1TC3GuUtvjOdnQhlo6tuBJ4ICIuzLXnj7t6DzBwlsZy4GRJu0s6CJhGdoBfrcsfL2mvgWGyg8bvS8sZOJtjNrAst/zT0hkhRwE7crtlx+IUct2SzVr/QUa7zjcCMyRNTF06M1LbqEmaCfwD8EcR8XSufT9J49Lwq8nWd11a/hOSjkrfodNy8ZZdU24BU8fvdt3+zvVadr3+/jXkWcW/XdpwuAV4b4V1q7Tciv/3KNnnU6CWvk1SSXOvUdrjOxslOMOjqAfwVrJdmfcC96TH8cA1wOrUvhyYlHvPJ8n2jDzIGM+qIDsr54fpsQb4ZGp/BXAzsBb4NrBPahdwWVr+aqC7Dp/BeLIt6r1zbQ1df7KibzPwa7K++DNrWWey47n60uOMMSy7j+y4gYHvwOfTtH+S/i73AHcD787Np5vsn9tPgM+R7lLRCo/0Hf9xiv2TDVpG3b7bdfw7123Zo/37V4ln1HlW7W+XPu87Upz/Duw+RCzV/u8V9vmU7dGMHGlg7IXmXgPXq1Q5Xc+Hb3FkZmZmVpCO7po0MzMzK5ILMTMzM7OCuBAzMzMzK4gLMTMzM7OCuBAzMzMzK4gLMTMzM7OCuBAzMzMzK4gLMTMzM7OCuBAzMzMzK4gLMTMzM7OCuBAzMzMzK4gLMTMzM7OCuBAzMzMzK4gLsQaQNFVSSNolvf6mpNkjfG+vpD9vbITFLlPSJyR9sVnLs3IpS35IOlXSTfWYl1kjOWdeEMPnJf3vImOoNxdiYyRpvaRfSNo58AD2z08TEcdFxKI6LOsFyZjaTpf0bG75D0n6kqTXjnV5NcTXm+J746D261J7D0BE/FNENLXYtGIUmR+p4B9Y7i8H5cmaiFgcETPGutwqsayX9M5BbadL+l4jlmfto8Nz5leS9h3U/oMU41SAiPhwRJzXiBiK4kKsPt4dEXsOPICfNXn530/L3Rt4J/ALYJWkNzQ5DoAfA6cNvJD0CuDNwM8LiMXKoZD8SAX/wDI/TMqT9DikGTE0Q37DzNpGp+bMQ8ApAy8kTQde1oTlFsqFWBPkdw1LGifpAkmPpr1XZw/eywUcKOm/JT0p6abcFsKt6fnxtIXy5vxyIuLZiPhJRPwV8F/AubkYjpL0P5Iel/TDgb1TFWL9bUnfkfRYinGxpAlp3N9LunbQ9JdIujjXtBj4U0nj0utTgOuAX+Xec66kL6fhgS2y2ZJ+mpb5yeE+U2sfzcqPCst9wR6qtJy/krQ2zfu8lA//I+kJSUsl7Zab/l2S7kk59T+SfneU6/36tO6PS1oj6Y8qfSZDxHqWpLXA2tEs11pfG+fMNeQ25IHZwNWDYrhK0mfScI+kjZLmStoqabOkM0bwEZaKC7Hm+wvgOOBQ4HDgxArTvB84A3glsBvwd6n9bel5QtpC+f4Qy/kG8AcAkiYDNwCfAfZJ87tW0n4V3ifg/5LtCn89MIXnC7ovAzNzhdkuwMm8MFF+BtwPDOy+Pm3Q+GreCrwOOBr4P5JeP4L3WPtpVn5UcyzwJuAo4B+ABcCfkeXBG0hb65IOAxYCHwJeAXwBWC5p95EsRNKuwH8CN6X1+GtgsaTXjSLWE4EjgYNH8R5rP+2UM7cBL08bKePIfl++PMzyf4usN2gycCZwmaSJNaxHYVyI1cd/pAr/cUn/Mcy0JwEXR8TGiNgOzK8wzZci4scR8QtgKVmCjdbPyIouyJJiRUSsiIjfRMRK4C7g+MFvioi+iFgZEc9ExM+BC4E/TOM2k21BvS9NPhN4NCJWDZrN1cBpkn6HLMFHktyfiohfRMQPgR8CbxzuDdYyypgf1fxzRDwREWuA+4CbImJdROwAvgkclqabA3whIm5Pe6IXAc+Q/RgNyK/348C/5cYdBewJzI+IX0XEd4DryXXLjMD/jYht6XOw9tKpOQPP7xU7BngA2DTM8n8NfDoifh0RK4CdZBv1LcOFWH2cGBET0uPEYabdH9iQe72hwjSP5IafJvuHPVqTgW1p+EDgfYN+FN4KTBr8JkldkpZI2iTpCbKtkfzBk4vICjvS8zUVlv0N4B3A2VXGV1KPdbZyKmN+VLMlN/yLCq8HlnUgMHdQTk3hhQdV59d7AvBXuXH7Axsi4je5tofJ8nakKn021h46NWcg+814P3A6I+tNeSwi+nOvW+73w4VY820GDsi9njKK98Yopn0P8N00vAG4Jv+jEBHjI6LSltM/peVMj4iXkxVbyo3/D+B3lZ0I8C6yY8JeGGTE02RbQn/JyAsxM2hefozVBuD8QTn1soj46gjf/zNgiqT8/+BX8fzW/1O88CDl36owj2aur5VXW+VMRDxMdtD+8WQb9W3PhVjzLQU+ImlyOtbqY6N478+B3wCvrjQyHbR5kKRLgR7gU2nUl4F3Szo2TfPSdJDjARVmsxfZrt0d6diyv8+PjIhfAl8HvgLcERE/rRLrJ4A/jIj1o1g/s4blR51dAXxY0pHKjJd0gqS9Rvj+28m23P9B0q7KTp55N7Akjb8H+GNJL5P0GrJjX8wqacecORN4R0Q81YS4CudCrPmuIDtA917gB8AKoB94drg3pj1N5wP/nXbtDvStv1nZtWaeAHqBlwO/FxGr0/s2ALPIiqOfk22Z/D2V//6fIjvgcwfZAf6VtkgWAdMZYm9XRPwsInzNJButRuRH3UXEXWQHSX8O2A70kXWljPT9vyIrvI4DHiU7fuy0iPhRmuQisjONt5Dl24v2PJslbZcz6ez/uxoVS9kownu3iyTpOODzEXFg0bGMlKRXAT8Cfisinig6HmtfrZgfZkVyzrQe7xFrMkl7SDpe0i6p6+8csutstYR0TMvfAktchFm9tXp+mDWbc6b1eY9Yk0l6GdnFVn+H7IySG4CPtEJRI2k8WVfJw8DM1OVpVjetnB9mRXDOtD4XYmZmZmYFcdekmZmZWUFciJmZmZkVZJfhJymnfffdN6ZOnVpx3FNPPcX48eObG9AIObbaFBnbqlWrHo2ISvflLLVWzZFqWi3mToq3VXMEWi9PHNPIlDGmqnkSES35eNOb3hTV3HLLLVXHFc2x1abI2IC7ogTf+dE+WjVHqmm1mDsp3lbNkWjBPHFMI1PGmKrlibsmzczMzAriQszMzMysIC7EzMzMzAoybCEmaaGkrZLuy7XtI2mlpLXpeWJql6RLJPVJulfS4bn3zE7Tr5U0O9f+Jkmr03sukaR6r6SZmZlZGY1kj9hVwMxBbfOAmyNiGnBzeg3ZDWynpccc4HLICjey2y4cCRwBnDNQvKVp/iL3vsHLMjMzM2tLw16+IiJulTR1UPMsoCcNLwJ6gY+l9qvT2QG3SZogaVKadmVEbAOQtBKYKakXeHlE3JbarwZOBL45lpVavWkHp8+7YdTvWz//hLEs1syqmFpDPoJz0jrLSPJk7vT+F/2+OU9aW63XEeuKiM1p+BGgKw1PBvL3H9yY2oZq31ihvSJJc8j2tNHV1UVvb2/l4PbIvqyjVW1+9bRz586mLKcWjs3MzKy5xnxB14gISU25YWVELAAWAHR3d0dPT0/F6S5dvIwLVo9+1dafWnl+9dTb20u1uIvm2MzMzJqr1rMmt6QuR9Lz1tS+CZiSm+6A1DZU+wEV2s3MzMzaXq2F2HJg4MzH2cCyXPtp6ezJo4AdqQvzRmCGpInpIP0ZwI1p3BOSjkpnS56Wm5eZmZlZWxu2/07SV8kOtt9X0kaysx/nA0slnQk8DJyUJl8BHA/0AU8DZwBExDZJ5wF3puk+PXDgPvBXZGdm7kF2kP6YDtQ3MzMzaxUjOWvylCqjjq4wbQBnVZnPQmBhhfa7gDcMF4eZmZlZu/GV9c0aSNJLJd0h6YeS1kj6VGo/SNLt6ULGX5O0W2rfPb3uS+On5ub18dT+oKRjC1ols7pyjlincyFm1ljPAO+IiDcCh5JdP+8o4LPARRHxGmA7cGaa/kxge2q/KE2HpIOBk4FDyC56/G+SxjVzRcwaxDliHc2FmFkDRWZnerlregTwDuDrqX0R2YWMIbso8qI0/HXg6HQiyyxgSUQ8ExEPkR2HeUTj18CssZwj1unGfB0xMxta2ipfBbwGuAz4CfB4RAxcdTh/IePnLn4cEf2SdgCvSO235WZb8eLHI73ocbMvkFvLBZbhhRdZbrWL+jrekWtmjqTltWyeVLpgedHfszJ+18sYUzUuxMwaLCKeBQ6VNAG4DvidBi5rRBc9bvYFcmu55Ri88CLLrXZRX8c7cs3MkbS8ls2TudP7X3TB8mZcjHwoZfyulzGmatw1adYkEfE4cAvwZmCCpIH/pvkLGT938eM0fm/gMapfFNmsbThHrBO5EDNrIEn7pa18JO0BHAM8QPZj89402eCLIg9cLPm9wHfSZWGWAyenM8YOAqYBdzRlJcwayDlinc5dk2aNNQlYlI6BeQmwNCKul3Q/sETSZ4AfAFem6a8ErpHUB2wjOwuMiFgjaSlwP9APnJW6c8xanXPEOpoLMbMGioh7gcMqtK+jwhldEfFL4H1V5nU+cH69YzQrknPEOp0LMbMOtHrTjpoOoF8//4QGRGNWTs4TawYfI2ZmZmZWEBdiZmZmZgVxIWZmZmZWEBdiZmZmZgVxIWZmZmZWEBdiZmZmZgVxIWZmZmZWEBdiZmZmZgVxIWZmZmZWkDEVYpL+l6Q1ku6T9FVJL5V0kKTbJfVJ+pqk3dK0u6fXfWn81Nx8Pp7aH5R07BjXyczMzKwl1FyISZoM/A3QHRFvAMaR3Xz1s8BFEfEaYDtwZnrLmcD21H5Rmg5JB6f3HQLMBP4t3fzVzMzMrK2NtWtyF2APSbsALwM2A+8Avp7GLwJOTMOz0mvS+KMlKbUviYhnIuIhoI8KN3o1MzMzazc13/Q7IjZJ+hfgp8AvgJuAVcDjEdGfJtsITE7Dk4EN6b39knYAr0jtt+VmnX/PC0iaA8wB6Orqore3t2JsXXvA3On9FccNpdr86mnnzp1NWU4tHFv9SZoCXA10AQEsiIiLJZ0L/AXw8zTpJyJiRXrPx8n2ID8L/E1E3JjaZwIXk+19/mJEzG/muhRhau6Gy3On94/4Bsy+6XLrcI6M3dQabkwOzpOyqLkQkzSRbG/WQcDjwL+TdS02TEQsABYAdHd3R09PT8XpLl28jAtWj37V1p9aeX711NvbS7W4i+bYGqIfmBsRd0vaC1glaWUad1FE/Et+4kFd9fsD35b02jT6MuAYso2VOyUtj4j7m7IWZo3jHLGOVnMhBrwTeCgifg4g6RvAW4AJknZJe8UOADal6TcBU4CNqStzb+CxXPuA/HvMWlpEbCbrsicinpT0AFX2+CbPddUDD0nKd9X3RcQ6AElL0rT+kbGW5hyxTjeWQuynwFGSXkbWNXk0cBdwC/BeYAkwG1iWpl+eXn8/jf9ORISk5cBXJF1ItnUzDbhjDHGZlVI6U/gw4HayjZazJZ1GljdzI2I7Q3fVbxjUfmSFZZSy+76WZQ02mpjL0I3dat3pZYi3GTmSltOyeVJrTJXU6+9dhu/OYGWMqZqxHCN2u6SvA3eT7Vr+AVm34Q3AEkmfSW1XprdcCVyTtl62ke1aJiLWSFpKttXSD5wVEc/WGpdZGUnaE7gW+GhEPCHpcuA8smNizgMuAD441uWUtft+pMd2DWXu9P4Rx9yMwwyG02rd6UXH26wcgdbOk9HkwXDqlSdFf3cqKWNM1YzprxkR5wDnDGpeR4WzHiPil8D7qsznfOD8scRiVlaSdiX7gVkcEd8AiIgtufFXANenl0N11bsL39qSc8Q6ma+sb9ZA6RItVwIPRMSFufZJucneA9yXhpcDJ6cLIB/E8131dwLT0gWTdyPbo7y8Getg1kjOEet09dm/aWbVvAX4ALBa0j2p7RPAKZIOJet2WQ98CIbuqpd0NnAj2an5CyNiTfNWw6xhnCPW0VyImTVQRHwPUIVRK4Z4T8Wu+nQNparvM2tFzhHrdO6aNDMzMyuICzEzMzOzgrgQMzMzMyuICzEzMzOzgrgQMzMzMyuICzEzMzOzgrgQMzMzMyuICzEzMzOzgrgQMzMzMyuICzEzMzOzgrgQMzMzMyuICzEzMzOzgrgQMzMzMyuICzGzBpI0RdItku6XtEbSR1L7PpJWSlqbniemdkm6RFKfpHslHZ6b1+w0/VpJs4taJ7N6co5Yp3MhZtZY/cDciDgYOAo4S9LBwDzg5oiYBtycXgMcB0xLjznA5ZD9KAHnAEcCRwDnDPwwmbU454h1NBdiZg0UEZsj4u40/CTwADAZmAUsSpMtAk5Mw7OAqyNzGzBB0iTgWGBlRGyLiO3ASmBm89bErDGcI9bpdik6ALNOIWkqcBhwO9AVEZvTqEeArjQ8GdiQe9vG1FatffAy5pDtJaCrq4ve3t6KsXTtAXOn9496HarNbzi1LGuw0cRca5z1tHPnzlLEMVJliLcZOZKW07J5UmtMldTr712G785gZYypmjEVYpImAF8E3gAE8EHgQeBrwFRgPXBSRGyXJOBi4HjgaeD0ga2g1Jf/j2m2n4mIRZi1EUl7AtcCH42IJ7J0yERESIp6LCciFgALALq7u6Onp6fidJcuXsYFq0ef/utPrTy/4Zw+74aa3pc3d3r/iGOuNc566u3tpdrnX0ZFx9usHEnza9k8GU0eDKdeeVL0d6eSMsZUzVi7Ji8GvhURvwO8kWyXsvv1zXIk7Ur2A7M4Ir6Rmrek7hTS89bUvgmYknv7AamtWrtZy3OOWCeruRCTtDfwNuBKgIj4VUQ8jvv1zZ6T9gRfCTwQERfmRi0HBs7qmg0sy7Wfls4MOwrYkbpnbgRmSJqYNlRmpDazluYcsU43lv2bBwE/B74k6Y3AKuAjdGC//miUud/asTXEW4APAKsl3ZPaPgHMB5ZKOhN4GDgpjVtB1n3fR9aFfwZARGyTdB5wZ5ru0xGxrSlrYNZYzhHraGMpxHYBDgf+OiJul3Qxz3dDAp3Trz8aZe63dmz1FxHfA1Rl9NEVpg/grCrzWggsrF90ZsVzjlinG8sxYhuBjRFxe3r9dbLCzP36ZmZmZiNQcyEWEY8AGyS9LjUdDdyP+/XNzMzMRmSs58D+NbBY0m7AOrK++pfgfn0zMzOzYY2pEIuIe4DuCqPcr29mZmY2DN/iyMzMzKwgLsTMzMzMCuJCzMzMzKwgLsTMzMzMCuJCzMzMzKwgLsTMzMzMCuJCzMzMzKwgY72gq5l1kKnzbig6BLPSc57YaHiPmJmZmVlBXIiZmZmZFcSFmFkDSVooaauk+3Jt50raJOme9Dg+N+7jkvokPSjp2Fz7zNTWJ2les9fDrFGcI9bpfIyYWWNdBXwOuHpQ+0UR8S/5BkkHAycDhwD7A9+W9No0+jLgGGAjcKek5RFxfyMDb2VjOUZn/fwT6hiJjcBVOEcKUWueOEfqy4WYWQNFxK2Spo5w8lnAkoh4BnhIUh9wRBrXFxHrACQtSdP6R8ZannPEOp0LMbNinC3pNOAuYG5EbAcmA7flptmY2gA2DGo/stJMJc0B5gB0dXXR29tbceFde8Dc6f1jib/pmhVztc9stHbu3Fm3eTVDCeNtSI5Aa+dJGWIa/HmV8LtTypiqcSFm1nyXA+cBkZ4vAD5YjxlHxAJgAUB3d3f09PRUnO7Sxcu4YHVrpf/c6f1NiXn9qT11mU9vby/VPv8yKlm8DcsRaO08aVYeDGVwjpTsuwOUM6ZqyvUNM+sAEbFlYFjSFcD16eUmYEpu0gNSG0O0m7Ud54h1Ep81adZkkiblXr4HGDhbbDlwsqTdJR0ETAPuAO4Epkk6SNJuZAcrL29mzGbN5ByxTuI9YmYNJOmrQA+wr6SNwDlAj6RDybpd1gMfAoiINZKWkh1g3A+cFRHPpvmcDdwIjAMWRsSa5q6JWWM4R6zTuRAza6CIOKVC85VDTH8+cH6F9hXAijqGZlYKzhHrdGPumpQ0TtIPJF2fXh8k6fZ0Ub2vpd3EpF3JX0vtt+dPV652gT4zMzOzdlaPY8Q+AjyQe/1ZsgvxvQbYDpyZ2s8Etqf2i9J0gy/QNxP4N0nj6hCXmZmZWamNqRCTdABwAvDF9FrAO4Cvp0kWASem4VnpNWn80Wn65y7QFxEPAfkL9JmZmZm1rbEeI/avwD8Ae6XXrwAej4iBq83lL7Y3mXTBvYjol7QjTT/UBfpeoNEX4WvGxd/KfJE5x2ZmZtZcNRdikt4FbI2IVZJ66hbREBp9Eb56XchxKGW+yJxjMzMza66x7BF7C/BHko4HXgq8HLgYmCBpl7RXLH9RvYEL8W2UtAuwN/AYQ1+gz8zMzKxt1XyMWER8PCIOiIipZAfbfyciTgVuAd6bJpsNLEvDy9Nr0vjvRERQ/QJ9ZmZmZm2tEdcR+xiwRNJngB/w/PVgrgSukdQHbCMr3oa8QJ+ZmZlZO6tLIRYRvUBvGl5HhbMeI+KXwPuqvL/iBfrMzMzM2pnvNWlmZmZWEBdiZmZmZgVxIWZmZmZWEBdiZmZmZgVxIWbWQJIWStoq6b5c2z6SVkpam54npnZJukRSn6R7JR2ee8/sNP1aSbMrLcusVTlPrJO5EDNrrKvIbmafNw+4OSKmATen1wDHkV1HbxrZrbwuh+wHCTgHOJLsjORzBn6UzNrEVThPrEO5EDNroIi4ley6eXmzgEVpeBFwYq796sjcRnaXiknAscDKiNgWEduBlbz4R8usZTlPrJM14oKuZja0rojYnIYfAbrS8GRgQ266jamtWvuLSJpDtpeArq6uqjdK79oD5k7vrzH8YjQr5nrdXL7VblRfwnidJxWUIabBn1cJvzuljKkaF2JmBYqIkBR1nN8CYAFAd3d3VLtR+qWLl3HB6tZK/7nT+5sS8/pTe+oyn1a7UX2Z43WePK9ZeTCUwTlSxu9OGWOqxl2TZs23JXWlkJ63pvZNwJTcdAektmrtZu3MeWIdwYWYWfMtBwbO6JoNLMu1n5bOCjsK2JG6Zm4EZkiamA4+npHazNqZ88Q6Qrn2uZq1GUlfBXqAfSVtJDuraz6wVNKZwMPASWnyFcDxQB/wNHAGQERsk3QecGea7tMRMfjAZrOW5TyxTuZCzKyBIuKUKqOOrjBtAGdVmc9CYGEdQzMrDeeJdTJ3TZqZmZkVxIWYmZmZWUFciJmZmZkVxIWYmZmZWUFciJmZmZkVxIWYmZmZWUF8+Qozs5yp826o6X3r559Q50jMymlwjsyd3s/pI8gb50hlNe8RkzRF0i2S7pe0RtJHUvs+klZKWpueJ6Z2SbpEUp+keyUdnpvX7DT9Wkmzqy3TzMzMrJ2MpWuyH5gbEQcDRwFnSToYmAfcHBHTgJvTa4DjgGnpMQe4HLLCjewqykcCRwDnDBRvZmZmZu2s5kIsIjZHxN1p+EngAWAyMAtYlCZbBJyYhmcBV0fmNmBCupHrscDKiNgWEduBlcDMWuMyMzMzaxV1OUZM0lTgMOB2oCvdgBXgEaArDU8GNuTetjG1VWuvtJw5ZHvT6Orqore3t2I8XXtkfdajVW1+9bRz586mLKcWjs3MzKy5xlyISdoTuBb4aEQ8Iem5cRERkmKsy8jNbwGwAKC7uzt6enoqTnfp4mVcsHr0q7b+1Mrzq6fe3l6qxV00x2ZmZtZcY7p8haRdyYqwxRHxjdS8JXU5kp63pvZNwJTc2w9IbdXazczMzNraWM6aFHAl8EBEXJgbtRwYOPNxNrAs135aOnvyKGBH6sK8EZghaWI6SH9GajNra5LWS1ot6R5Jd6W2UZ91bNbOnCfW7sayR+wtwAeAd6QEuUfS8cB84BhJa4F3ptcAK4B1QB9wBfBXABGxDTgPuDM9Pp3azDrB2yPi0IjoTq9HddaxWYdwnljbqvkYsYj4HqAqo4+uMH0AZ1WZ10JgYa2xmLWRWUBPGl4E9AIfI3fWMXCbpAmSJuVOjDHrJM4Taxu+sr5ZcQK4KZ3Q8oV0Mspozzp+wQ9Mo88sLlLZYx78Wbfamb4ljtd5ktPKMTXz+1Xi7/OLuBAzK85bI2KTpFcCKyX9KD+ylrOOG31mcZHmTu8vdcyDz7putTN9Sxyv8ySnjHkw0piacWWCASX+Pr+Ib/ptVpCI2JSetwLXkd1ZYrRnHZu1NeeJtTsXYmYFkDRe0l4Dw2RnC9/H6M86NmtbzhPrBOXav2nWObqA69IFkHcBvhIR35J0J7BU0pnAw8BJafoVwPFkZx0/DZzR/JDNms55Ym3PhZhZASJiHfDGCu2PMcqzjs3alfPEOoG7Js3MzMwK4kLMzMzMrCAuxMzMzMwK4mPEzMzqYOq8G17weu70fk4f1FbJ+vknNCoks1IZnCMj1e454j1iZmZmZgVxIWZmZmZWEBdiZmZmZgVxIWZmZmZWEBdiZmZmZgXxWZNmZgXymWRmQ6slR+ZO76en/qE0hAsxaxj/wJiZmQ3NhVgdjKbgyF9bqNkFx3BxVrvuUasURrUWftA662hmZu3FhZgNaywFjpmZmVVXmkJM0kzgYmAc8MWImN/sGJpdcLjAqazS5zLSq5S3szLkiFnZOU+s1ZSiEJM0DrgMOAbYCNwpaXlE3F9sZGbl4ByxwXwM5os5TyyvVXKkLJevOALoi4h1EfErYAkwq+CYzMrEOWI2POeJtZxS7BEDJgMbcq83AkcWFItZGTlHrC6q7SUYrvu/RfakOU9szJp94ldZCrERkTQHmJNe7pT0YJVJ9wUebU5Uo/M3jq0mjY5Nnx1y9IGNWm69tUOOVFPm72cl7RZvu+QItHaelPF75ZieV0uelKUQ2wRMyb0+ILW9QEQsABYMNzNJd0VEd/3Cqx/HVpsyx9YkHZMj1bRazI63EG2fJ45pZMoYUzVlOUbsTmCapIMk7QacDCwvOCazMnGOmA3PeWItpxR7xCKiX9LZwI1kpxwvjIg1BYdlVhrOEbPhOU+sFZWiEAOIiBXAijrNbthdzgVybLUpc2xN0UE5Uk2rxex4C9ABeeKYRqaMMVWkiCg6BjMzM7OOVJZjxMzMzMw6TlsVYpJmSnpQUp+keQUsf6GkrZLuy7XtI2mlpLXpeWJql6RLUqz3Sjq8wbFNkXSLpPslrZH0kbLEJ+mlku6Q9MMU26dS+0GSbk8xfC0dfIuk3dPrvjR+aqNia0dF58lwRpNHZTDa3CqD0eZcpykyRyStl7Ra0j2S7kptTf0/Xa/fMkmz0/RrJc1uQEznStqUPqt7JB2fG/fxFNODko7NtZfv/19EtMWD7MDMnwCvBnYDfggc3OQY3gYcDtyXa/tnYF4angd8Ng0fD3wTEHAUcHuDY5sEHJ6G9wJ+DBxchvjSMvZMw7sCt6dlLgVOTu2fB/4yDf8V8Pk0fDLwtaK/f63yKEOejCDGEedRGR6jza0yPEabc530KDpHgPXAvoPamvp/uh6/ZcA+wLr0PDENT6xzTOcCf1dh2oPT32134KD09xxX9N+22qOd9ogVfmuLiLgV2DaoeRawKA0vAk7MtV8dmduACZImNTC2zRFxdxp+EniA7CrUhceXlrEzvdw1PQJ4B/D1KrENxPx14GhJakRsbajwPBnOKPOocDXkVuFqyLlOUsYcaer/6Tr9lh0LrIyIbRGxHVgJzKxzTNXMApZExDMR8RDQR/Z3LePftq0KsUq3tphcUCx5XRGxOQ0/AnSl4cLiTV15h5FtBZciPknjJN0DbCVL2J8Aj0dEf4XlPxdbGr8DeEWjYmszZc2T4VT7npbKCHOrFEaZc52k6BwJ4CZJq5TdAQDK8X96tDE0K7azU5fowlz3f9ExjUo7FWKlF9k+00JPU5W0J3At8NGIeCI/rsj4IuLZiDiU7ErYRwC/U0QcVn5lyKNKyppb1TjnSuutEXE4cBxwlqS35UeW4btUhhiSy4HfBg4FNgMXFBpNjdqpEBvRrS0KsGVgV3F63pramx6vpF3JfigWR8Q3yhYfQEQ8DtwCvJlsF/fAte7yy38utjR+b+CxRsfWJsqaJ8Op9j0thVHmVqmMMOc6SaE5EhGb0vNW4DqyIrkM/6dHG0PDY4uILWmD4jfAFWSfVaEx1aKdCrGy3tpiOTBwtshsYFmu/bR0xslRwI7cbt+6S8dQXQk8EBEXlik+SftJmpCG9wCOITvO5hbgvVViG4j5vcB30haaDa+seTKcat/TwtWQW4WrIec6SWE5Imm8pL0GhoEZwH2U4P90DTHcCMyQNDF1Gc5IbXUz6Hi495B9VgMxnazsDPuDgGnAHZT1/1+RZwrU+0F29saPyY51+GQBy/8q2e7RX5P1PZ9JduzSzcBa4NvAPmlaAZelWFcD3Q2O7a1ku5LvBe5Jj+PLEB/wu8APUmz3Af8ntb+aLHn6gH8Hdk/tL02v+9L4Vxf93WulR9F5MoL4RpxHZXiMNrfK8BhtznXao6gcSZ//D9NjzcCym/1/ul6/ZcAH03epDzijATFdk5Z5L1lBNSk3/SdTTA8CxxX9tx3q4Svrm5mZmRWknbomzczMzFqKCzEzMzOzgrgQMzMzMyuICzEzMzOzgrgQMzMzMyuICzEzMzOzgrgQMzMzMyuICzEzMzOzgrgQMzMzMyuICzEzMzOzgrgQMzMzMyuICzEzMzOzgrgQMzMzMyuICzEzMzOzgrgQK4ikqyR9pknL+ktJWyTtlPSKJi1zqqSQtEszlmdmZtaKXIi1OEm/L+k7kp6UtEPSf0o6ODd+V+BCYEZE7An8k6TL8+MlPVWl7aimroyZmVmHcSHWwiS9GbgJWAbsDxwE/BD4b0mvTpN1AS8F1qTXtwJvy82mG/gp8AeD2gBWNSZyMzMzAxdiTSPpMEl3pz1XXyMrjpA0UdL1kn4uaXsaPiCNe5+kVYPm87eSlqWX/wxcHREXR8STEbEtIv4RuA04V9JrgQfTtI9L+g5ZIfZ6Sfum9j8AlgDjB7V9PyJ+LWl/Sdem+B6S9De5WF4iaZ6kn0h6TNJSSftUWf8/kbRe0hvG9kmamZm1DxdiTSBpN+A/gGuAfYB/B/4kjX4J8CXgQOBVwC+Az6Vxy4GDJL0+N7sPAFdLehnw+2legy0FjomIHwOHpLYJEfGOiNgAPMzze8DeBnwX+J9BbbdKegnwn2R72SYDRwMflXRsmu6vgROBPyTbI7cduKzC+p8BfBZ4Z0TcV+1zMjMz6zQuxJrjKGBX4F8j4tcR8XXgToCIeCwiro2IpyPiSeB8ssKGiHgG+BrwZwCSDgGmAteTFXQvATZXWN5mYN8K7QP+C3hbKrSOINuD9t1c21vSNL8H7BcRn46IX0XEOuAK4OQ0nw8Dn4yIjSnWc4H3DjpA/6PA3wM9EdE3kg/LzMysU7gQa479gU0REbm2hwEkvUzSFyQ9LOkJsq7DCZLGpekWAe+XJLK9YUtT0bMd+A0wqcLyJgGPDhHPwHFi04F1EfE08L1c2x7A7WR76faX9PjAA/gE2XFnpPHX5cY9ADybGw9ZEXZZRGwc8hMyMzPrQC7EmmMzMDkVUwNelZ7nAq8DjoyIl/P8gfQCiIjbgF+RdRu+n6x7k4h4Cvg+8L4KyzsJuHmIeG4F3gicQLYnDLKD+aektjsj4pfABuChiJiQe+wVEcen92wAjhs0/qURsSm3rBnAP0r6E8zMzOwFXIg1x/eBfuBv0qUh/pisSxBgL7Ljwh5PB7qfU+H9V5MdN/briPhern0eMFvS30jaKx34/xngzcCnqgWTugi3AB8hFWJpb93tqe3WNOkdwJOSPiZpD0njJL1B0u+l8Z8Hzpd0IICk/STNGrS4NcBM4DJJfzTkp2RmZtZhXIg1QUT8Cvhj4HRgG/CnwDfS6H8l6wp8lOxYrW9VmMU1wBuALw+a7/eAY9O8N5N1dx4GvDUi1g4T1q3AfsB/59q+C7wyjSMingXeBRwKPJRi/CKwd5r+YrITCm6S9GSK/8gK6//DNJ8rJB03TFxmZmYdQy88bMnKSNIewFbg8BEUWGZmZtYivEesNfwl2XFbLsLMzMzaiO8DWHKS1pMduH9isZGYmZlZvblr0szMzKwg7po0MzMzK0jLdk3uu+++MXXq1IrjnnrqKcaPH9/cgOrEsRdjqNhXrVr1aETs1+SQzMysA7RsITZ16lTuuuuuiuN6e3vp6elpbkB14tiLMVTskh5ubjRmZtYp3DVpZmZmVhAXYmZmZmYFcSFmZmZmVhAXYmZmZmYFqbkQkzRF0i2S7pe0RtJHUvs+klZKWpueJ6Z2SbpEUp+keyUdnpvX7DT9Wkmzx75aZmZmZuU3lrMm+4G5EXG3pL2AVZJWkt3Y+uaImC9pHjAP+BhwHDAtPY4ELgeOlLQPcA7QDUSaz/KI2F5rYKs37eD0eTeM+n3r559Q6yLNzMzMRq3mPWIRsTki7k7DTwIPAJOBWcCiNNkinr81zyzg6sjcBkyQNAk4FlgZEdtS8bUSmFlrXGZmZmatoi7XEZM0FTgMuB3oiojNadQjQFcangxsyL1tY2qr1l5pOXOAOQBdXV309vZWjKdrD5g7vX/U61Ftfs20c+fOUsSRt3rTjhFN17UHXLp42XOvp0/eu1Eh1V0ZP3czM2t/Yy7EJO0JXAt8NCKekPTcuIgISXW7mWVELAAWAHR3d0e1C3BeungZF6we/aqtP7Xy/JqpjBdFHWk379zp/S/43MvweY5UGT93MzNrf2M6a1LSrmRF2OKI+EZq3pK6HEnPW1P7JmBK7u0HpLZq7WZmZmZtbSxnTQq4EnggIi7MjVoODJz5OBtYlms/LZ09eRSwI3Vh3gjMkDQxnWE5I7WZmZmZtbWxdE2+BfgAsFrSPantE8B8YKmkM4GHgZPSuBXA8UAf8DRwBkBEbJN0HnBnmu7TEbFtDHG1jKkVuvzmTu8ftivQZ3eamZm1h5oLsYj4HqAqo4+uMH0AZ1WZ10JgYa2x1EulwmgkXBiZmZlZLepy1qS1hloLzWZzQWxmZp3CtzgyMzMzK4gLMTMzM7OCuBAzMzMzK4gLMTMzM7OCuBAzMzMzK4gLMTMzM7OCuBAzMzMzK4gLMTMzM7OCuBAzMzMzK4gLMTMzM7OCuBAzMzMzK4gLMTMzM7OCuBAzMzMzK4gLMTMzM7OCuBAzMzMzK4gLMTMzM7OCuBAzMzMzK4gLMTMzM7OCuBAzMzMzK4gLMTMzM7OCuBAzMzMzK4gLMTMzM7OCuBAzMzMzK4gLMTMzM7OCuBAzMzMzK4gLMTMzM7OC1FyISVooaauk+3Jt50raJOme9Dg+N+7jkvokPSjp2Fz7zNTWJ2le7atiZmZm1lrGskfsKmBmhfaLIuLQ9FgBIOlg4GTgkPSef5M0TtI44DLgOOBg4JQ0rZmZmVnb26XWN0bErZKmjnDyWcCSiHgGeEhSH3BEGtcXEesAJC1J095fa1xmZmZmraLmQmwIZ0s6DbgLmBsR24HJwG25aTamNoANg9qPrDZjSXOAOQBdXV309vZWnK5rD5g7vb/W+EetWhzDqRTjSGKv5/LqaXDszY6z1uUB7Ny5c0zvNzMzq0W9C7HLgfOASM8XAB+s18wjYgGwAKC7uzt6enoqTnfp4mVcsLoRNWZl60+tHMdwTp93w4va5k7vHzb2ei6vngbH3uw4a10eZEVcte+TmZlZo9S1WomILQPDkq4Ark8vNwFTcpMekNoYot3MzMysrdX18hWSJuVevgcYOKNyOXCypN0lHQRMA+4A7gSmSTpI0m5kB/Qvr2dMZmZmZmVV8x4xSV8FeoB9JW0EzgF6JB1K1jW5HvgQQESskbSU7CD8fuCsiHg2zeds4EZgHLAwItbUGpOZmZlZKxnLWZOnVGi+cojpzwfOr9C+AlhRaxxmZmZmrcpX1jczMzMriAsxMzMzs4K4EDMzMzMriAsxMzMzs4K4EDMzMzMriAsxMzMzs4K4EDMzMzMrSPNuyGjWYFPHcC/Nq2aOr2MkZmZmI+M9YmZmZmYFcSFmZmZmVhAXYmZmZmYFcSFmZmZmVhAXYmZmZmYFcSFmZmZmVhAXYmZmZmYFcSFmZmZmVhAXYmZmZmYFcSFmZmZmVhAXYmZmZmYFcSFmZmZmVhAXYmZmZmYFcSFmZmZmVhAXYmZmZmYFcSFmZmZmVhAXYmZmZmYFcSFmZmZmVpAxFWKSFkraKum+XNs+klZKWpueJ6Z2SbpEUp+keyUdnnvP7DT9WkmzxxKTmZmZWasY6x6xq4CZg9rmATdHxDTg5vQa4DhgWnrMAS6HrHADzgGOBI4Azhko3szMzMza2ZgKsYi4Fdg2qHkWsCgNLwJOzLVfHZnbgAmSJgHHAisjYltEbAdW8uLizszMzKzt7NKAeXZFxOY0/AjQlYYnAxty021MbdXaX0TSHLK9aXR1ddHb21s5gD1g7vT+GsMfvWpxDKdSjCOJvZ7Lq6fBsZc1zkp27txZc7xmZma1akQh9pyICElRx/ktABYAdHd3R09PT8XpLl28jAtWN3TVXmD9qZXjGM7p8254Udvc6f3Dxl7P5dXT4NjLGmclV80cT7Xvk5mZWaM04qzJLanLkfS8NbVvAqbkpjsgtVVrNzMzM2trjSjElgMDZz7OBpbl2k9LZ08eBexIXZg3AjMkTUwH6c9IbWZmZmZtbUz9d5K+CvQA+0raSHb243xgqaQzgYeBk9LkK4DjgT7gaeAMgIjYJuk84M403acjYvAJAGZmZmZtZ0yFWEScUmXU0RWmDeCsKvNZCCwcSyxmZmZmrcZX1jczMzMriAsxMzMzs4K4EDMzMzMriAsxMzMzs4K4EDMzMzMriAsxMzMzs4K4EDMzMzMriAsxMzMzs4K4EDMzMzMriAsxMzMzs4K4EDMzMzMriAsxMzMzs4K4EDMzMzMriAsxMzMzs4K4EDMzMzMriAsxMzMzs4K4EDMzMzMriAsxMzMzs4K4EDMzMzMriAsxMzMzs4K4EDMzMzMriAsxMzMzs4K4EDMzMzMriAsxMzMzs4K4EDMzMzMriAsxMzMzs4I0rBCTtF7Sakn3SLorte0jaaWktel5YmqXpEsk9Um6V9LhjYrLzMzMrCwavUfs7RFxaER0p9fzgJsjYhpwc3oNcBwwLT3mAJc3OC4zMzOzwjW7a3IWsCgNLwJOzLVfHZnbgAmSJjU5NjMzM7OmUkQ0ZsbSQ8B2IIAvRMQCSY9HxIQ0XsD2iJgg6XpgfkR8L427GfhYRNw1aJ5zyPaY0dXV9aYlS5ZUXPbWbTvY8ouGrFZF0yfvXdP7Vm/a8aK2rj0YNvZ6Lq+eBsde1jgrOWjvcey5554Vx7397W9fldura2ZmVje7NHDeb42ITZJeCayU9KP8yIgISaOqAiNiAbAAoLu7O3p6eipOd+niZVywupGr9kLrT60cx3BOn3fDi9rmTu8fNvZ6Lq+eBsde1jgruWrmeKp9n8zMzBqlYV2TEbEpPW8FrgOOALYMdDmm561p8k3AlNzbD0htZmZmZm2rIYWYpPGS9hoYBmYA9wHLgdlpstnAsjS8HDgtnT15FLAjIjY3IjYzMzOzsmhU/10XcF12GBi7AF+JiG9JuhNYKulM4GHgpDT9CuB4oA94GjijQXGZmZmZlUZDCrGIWAe8sUL7Y8DRFdoDOKsRsZiZmZmVla+sb2ZmZlYQF2JmZmZmBXEhZmZmZlYQF2JmZmZmBXEhZmZmZlYQF2JmZmZmBXEhZmZmZlYQF2JmZmZmBXEhZmZmZlYQF2JmZmZmBXEhZmZmZlYQF2JmZmZmBXEhZmZmZlYQF2JmZmZmBXEhZmZmZlYQF2JmZmZmBXEhZmZmZlYQF2JmZmZmBXEhZmZmZlYQF2JmZmZmBXEhZmZmZlYQF2JmZmZmBXEhZmZmZlYQF2JmZmZmBXEhZmZmZlYQF2JmZmZmBXEhZmZmZlaQ0hRikmZKelBSn6R5RcdjZmZm1milKMQkjQMuA44DDgZOkXRwsVGZmZmZNVYpCjHgCKAvItZFxK+AJcCsgmMyMzMzayhFRNExIOm9wMyI+PP0+gPAkRFx9qDp5gBz0svXAQ9WmeW+wKMNCrfRHHsxhor9wIjYr5nBmJlZZ9il6ABGIyIWAAuGm07SXRHR3YSQ6s6xF6OVYzczs9ZVlq7JTcCU3OsDUpuZmZlZ2ypLIXYnME3SQZJ2A04Glhcck5mZmVlDlaJrMiL6JZ0N3AiMAxZGxJoxzHLY7ssSc+zFaOXYzcysRZXiYH0zMzOzTlSWrkkzMzOzjuNCzMzMzKwgbVWIteptkiRNkXSLpPslrZH0kaJjGi1J4yT9QNL1RccyGpImSPq6pB9JekDSm4uOyczMOkfbHCOWbpP0Y+AYYCPZmZinRMT9hQY2ApImAZMi4m5JewGrgBNbIfYBkv4W6AZeHhHvKjqekZK0CPhuRHwxnbH7soh4vOCwzMysQ7TTHrGWvU1SRGyOiLvT8JPAA8DkYqMaOUkHACcAXyw6ltGQtDfwNuBKgIj4lYswMzNrpnYqxCYDG3KvN9JCxcwASVOBw4DbCw5lNP4V+AfgNwXHMVoHAT8HvpS6Vb8oaXzRQZmZWedop0Ks5UnaE7gW+GhEPFF0PCMh6V3A1ohYVXQsNdgFOBy4PCIOA54CWubYQjMza33tVIi19G2SJO1KVoQtjohvFB3PKLwF+CNJ68m6g98h6cvFhjRiG4GNETGw9/HrZIWZmZlZU7RTIdayt0mSJLLjlB6IiAuLjmc0IuLjEXFAREwl+8y/ExF/VnBYIxIRjwAbJL0uNR0NtMwJEmZm1vpKcYujemjAbZKa6S3AB4DVku5JbZ+IiBXFhdQx/hpYnIr3dcAZBcdjZmYdpG0uX2FmZmbWatqpa9LMzMyspbgQMzMzMyuICzEzMzOzgrgQMzMzMyuICzEzMzOzgrgQMzMzMyuICzEzMzOzgvx/uOvlNtdfgCUAAAAASUVORK5CYII=",
-      "text/plain": [
-       "<Figure size 720x720 with 9 Axes>"
+      "cell_type": "code",
+      "execution_count": 16,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2021-12-15T20:24:38.467067Z",
+          "iopub.status.busy": "2021-12-15T20:24:38.466671Z",
+          "iopub.status.idle": "2021-12-15T20:24:38.469107Z",
+          "shell.execute_reply": "2021-12-15T20:24:38.468710Z"
+        },
+        "pycharm": {
+          "is_executing": false
+        },
+        "id": "HSlyhmmwNRFR",
+        "outputId": "dda9b642-f2a1-4c30-f563-10e3612cacc0",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
+      },
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "(13059, 27)"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 16
+        }
+      ],
+      "source": [
+        "pd_flights.shape"
       ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "ed_flights.select_dtypes(include=np.number).hist(figsize=[10,10])\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Elasticsearch utilities"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 57,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-15T20:25:02.211768Z",
-     "iopub.status.busy": "2021-12-15T20:25:02.211404Z",
-     "iopub.status.idle": "2021-12-15T20:25:02.297769Z",
-     "shell.execute_reply": "2021-12-15T20:25:02.295526Z"
     },
-    "pycharm": {
-     "is_executing": false
-    }
-   },
-   "outputs": [],
-   "source": [
-    "ed_flights2 = ed_flights[(ed_flights.OriginAirportID == 'AMS') & (ed_flights.FlightDelayMin > 60)]\n",
-    "ed_flights2 = ed_flights2[['timestamp', 'OriginAirportID', 'DestAirportID', 'FlightDelayMin']]\n",
-    "ed_flights2 = ed_flights2.tail()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 58,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-12-15T20:25:02.319861Z",
-     "iopub.status.busy": "2021-12-15T20:25:02.305735Z",
-     "iopub.status.idle": "2021-12-15T20:25:02.325635Z",
-     "shell.execute_reply": "2021-12-15T20:25:02.326869Z"
-    },
-    "pycharm": {
-     "is_executing": false
-    }
-   },
-   "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "es_index_pattern: flights\n",
-      "Index:\n",
-      " es_index_field: _id\n",
-      " is_source_field: False\n",
-      "Mappings:\n",
-      " capabilities:\n",
-      "                   es_field_name  is_source es_dtype                  es_date_format        pd_dtype  is_searchable  is_aggregatable  is_scripted aggregatable_es_field_name\n",
-      "timestamp              timestamp       True     date  strict_date_hour_minute_second  datetime64[ns]           True             True        False                  timestamp\n",
-      "OriginAirportID  OriginAirportID       True  keyword                            None          object           True             True        False            OriginAirportID\n",
-      "DestAirportID      DestAirportID       True  keyword                            None          object           True             True        False              DestAirportID\n",
-      "FlightDelayMin    FlightDelayMin       True  integer                            None           int64           True             True        False             FlightDelayMin\n",
-      "Operations:\n",
-      " tasks: [('boolean_filter': ('boolean_filter': {'bool': {'must': [{'term': {'OriginAirportID': 'AMS'}}, {'range': {'FlightDelayMin': {'gt': 60}}}]}})), ('tail': ('sort_field': '_doc', 'count': 5))]\n",
-      " size: 5\n",
-      " sort_params: {'_doc': 'desc'}\n",
-      " _source: ['timestamp', 'OriginAirportID', 'DestAirportID', 'FlightDelayMin']\n",
-      " body: {'query': {'bool': {'must': [{'term': {'OriginAirportID': 'AMS'}}, {'range': {'FlightDelayMin': {'gt': 60}}}]}}}\n",
-      " post_processing: [('sort_index')]\n",
-      "\n"
-     ]
-    }
-   ],
-   "source": [
-    "print(ed_flights2.es_info())"
-   ]
-  }
- ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.6"
-  },
-  "pycharm": {
-   "stem_cell": {
-    "cell_type": "raw",
-    "metadata": {
-     "collapsed": false
+      "cell_type": "code",
+      "execution_count": 17,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2021-12-15T20:24:38.471904Z",
+          "iopub.status.busy": "2021-12-15T20:24:38.471491Z",
+          "iopub.status.idle": "2021-12-15T20:24:38.558583Z",
+          "shell.execute_reply": "2021-12-15T20:24:38.557300Z"
+        },
+        "pycharm": {
+          "is_executing": false
+        },
+        "id": "n7NFeQR6NRFR",
+        "outputId": "11d9ed11-442d-4465-d1f2-42507ac16c9e",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
+      },
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "(13059, 27)"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 17
+        }
+      ],
+      "source": [
+        "ed_flights.shape"
+      ]
     },
-    "source": []
-   }
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 2
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "ib-JYdwXNRFS"
+      },
+      "source": [
+        "### DataFrame.index\n",
+        "\n",
+        "Note, `eland.DataFrame.index` does not mirror `pandas.DataFrame.index`."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 18,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2021-12-15T20:24:38.569600Z",
+          "iopub.status.busy": "2021-12-15T20:24:38.568315Z",
+          "iopub.status.idle": "2021-12-15T20:24:38.575273Z",
+          "shell.execute_reply": "2021-12-15T20:24:38.574007Z"
+        },
+        "pycharm": {
+          "is_executing": false
+        },
+        "id": "mTSyzPSgNRFS",
+        "outputId": "63794e47-2f04-41a1-89ac-3a5d32e8d371",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
+      },
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "Index(['0', '1', '2', '3', '4', '5', '6', '7', '8', '9',\n",
+              "       ...\n",
+              "       '13049', '13050', '13051', '13052', '13053', '13054', '13055', '13056', '13057', '13058'],\n",
+              "      dtype='object', length=13059)"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 18
+        }
+      ],
+      "source": [
+        "pd_flights.index"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 19,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2021-12-15T20:24:38.583800Z",
+          "iopub.status.busy": "2021-12-15T20:24:38.582630Z",
+          "iopub.status.idle": "2021-12-15T20:24:38.588504Z",
+          "shell.execute_reply": "2021-12-15T20:24:38.589469Z"
+        },
+        "pycharm": {
+          "is_executing": false
+        },
+        "id": "puus-Fk7NRFS",
+        "outputId": "4ceebd2a-0009-4532-fabe-4a0d490541ec",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
+      },
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "<eland.index.Index at 0x7c7cf5552dd0>"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 19
+        }
+      ],
+      "source": [
+        "# NBVAL_IGNORE_OUTPUT\n",
+        "ed_flights.index"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 20,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2021-12-15T20:24:38.598654Z",
+          "iopub.status.busy": "2021-12-15T20:24:38.597416Z",
+          "iopub.status.idle": "2021-12-15T20:24:38.604549Z",
+          "shell.execute_reply": "2021-12-15T20:24:38.603361Z"
+        },
+        "pycharm": {
+          "is_executing": false
+        },
+        "id": "rvJ41P0BNRFT",
+        "outputId": "99d0f85c-3337-4bd7-f7d0-70b2a6702c42",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 35
+        }
+      },
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "'_id'"
+            ],
+            "application/vnd.google.colaboratory.intrinsic+json": {
+              "type": "string"
+            }
+          },
+          "metadata": {},
+          "execution_count": 20
+        }
+      ],
+      "source": [
+        "ed_flights.index.es_index_field"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "5JA3HKJgNRFT"
+      },
+      "source": [
+        "### DataFrame.values\n",
+        "\n",
+        "Note, `eland.DataFrame.values` is not supported."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 21,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2021-12-15T20:24:38.634011Z",
+          "iopub.status.busy": "2021-12-15T20:24:38.629434Z",
+          "iopub.status.idle": "2021-12-15T20:24:38.681698Z",
+          "shell.execute_reply": "2021-12-15T20:24:38.681982Z"
+        },
+        "pycharm": {
+          "is_executing": false
+        },
+        "id": "oZYSyigXNRFU",
+        "outputId": "b781594f-4772-473e-e916-7fafdb8d3e65",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
+      },
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "array([[841.2656419677076, False, 'Kibana Airlines', ..., 'Sunny', 0,\n",
+              "        Timestamp('2018-01-01 00:00:00')],\n",
+              "       [882.9826615595518, False, 'Logstash Airways', ..., 'Clear', 0,\n",
+              "        Timestamp('2018-01-01 18:27:00')],\n",
+              "       [190.6369038508356, False, 'Logstash Airways', ..., 'Rain', 0,\n",
+              "        Timestamp('2018-01-01 17:11:14')],\n",
+              "       ...,\n",
+              "       [997.7518761454494, False, 'Logstash Airways', ..., 'Sunny', 6,\n",
+              "        Timestamp('2018-02-11 04:09:27')],\n",
+              "       [1102.8144645388556, False, 'JetBeats', ..., 'Hail', 6,\n",
+              "        Timestamp('2018-02-11 08:28:21')],\n",
+              "       [858.1443369038839, False, 'JetBeats', ..., 'Rain', 6,\n",
+              "        Timestamp('2018-02-11 14:54:34')]], dtype=object)"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 21
+        }
+      ],
+      "source": [
+        "pd_flights.values"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 22,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2021-12-15T20:24:38.685031Z",
+          "iopub.status.busy": "2021-12-15T20:24:38.684450Z",
+          "iopub.status.idle": "2021-12-15T20:24:38.687106Z",
+          "shell.execute_reply": "2021-12-15T20:24:38.686771Z"
+        },
+        "pycharm": {
+          "is_executing": false
+        },
+        "id": "gQTQLsmWNRFU",
+        "outputId": "761684f1-c8ac-49e8-c220-b7c886cdebba",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "This method would scan/scroll the entire Elasticsearch index(s) into memory. If this is explicitly required, and there is sufficient memory, call `ed.eland_to_pandas(ed_df).values`\n"
+          ]
+        }
+      ],
+      "source": [
+        "try:\n",
+        "    ed_flights.values\n",
+        "except AttributeError as e:\n",
+        "    print(e)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "lKqYv_fTNRFV"
+      },
+      "source": [
+        "## Indexing, iteration"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "_RlN4vASNRFV"
+      },
+      "source": [
+        "### DataFrame.head"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 23,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2021-12-15T20:24:38.694742Z",
+          "iopub.status.busy": "2021-12-15T20:24:38.694371Z",
+          "iopub.status.idle": "2021-12-15T20:24:38.696502Z",
+          "shell.execute_reply": "2021-12-15T20:24:38.696207Z"
+        },
+        "pycharm": {
+          "is_executing": false
+        },
+        "id": "PnuvMIlMNRFV",
+        "outputId": "315ae8c2-e827-451b-b886-69eb11a58ada",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 236
+        }
+      },
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "   AvgTicketPrice  Cancelled  ... dayOfWeek           timestamp\n",
+              "0      841.265642      False  ...         0 2018-01-01 00:00:00\n",
+              "1      882.982662      False  ...         0 2018-01-01 18:27:00\n",
+              "2      190.636904      False  ...         0 2018-01-01 17:11:14\n",
+              "3      181.694216       True  ...         0 2018-01-01 10:33:28\n",
+              "4      730.041778      False  ...         0 2018-01-01 05:13:00\n",
+              "\n",
+              "[5 rows x 27 columns]"
+            ],
+            "text/html": [
+              "\n",
+              "  <div id=\"df-448a03d4-dce8-46a9-baa4-4a72b55c4933\" class=\"colab-df-container\">\n",
+              "    <div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>AvgTicketPrice</th>\n",
+              "      <th>Cancelled</th>\n",
+              "      <th>...</th>\n",
+              "      <th>dayOfWeek</th>\n",
+              "      <th>timestamp</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>841.265642</td>\n",
+              "      <td>False</td>\n",
+              "      <td>...</td>\n",
+              "      <td>0</td>\n",
+              "      <td>2018-01-01 00:00:00</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>1</th>\n",
+              "      <td>882.982662</td>\n",
+              "      <td>False</td>\n",
+              "      <td>...</td>\n",
+              "      <td>0</td>\n",
+              "      <td>2018-01-01 18:27:00</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>2</th>\n",
+              "      <td>190.636904</td>\n",
+              "      <td>False</td>\n",
+              "      <td>...</td>\n",
+              "      <td>0</td>\n",
+              "      <td>2018-01-01 17:11:14</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>3</th>\n",
+              "      <td>181.694216</td>\n",
+              "      <td>True</td>\n",
+              "      <td>...</td>\n",
+              "      <td>0</td>\n",
+              "      <td>2018-01-01 10:33:28</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>4</th>\n",
+              "      <td>730.041778</td>\n",
+              "      <td>False</td>\n",
+              "      <td>...</td>\n",
+              "      <td>0</td>\n",
+              "      <td>2018-01-01 05:13:00</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "<p>5 rows × 27 columns</p>\n",
+              "</div>\n",
+              "    <div class=\"colab-df-buttons\">\n",
+              "\n",
+              "  <div class=\"colab-df-container\">\n",
+              "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-448a03d4-dce8-46a9-baa4-4a72b55c4933')\"\n",
+              "            title=\"Convert this dataframe to an interactive table.\"\n",
+              "            style=\"display:none;\">\n",
+              "\n",
+              "  <svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\" viewBox=\"0 -960 960 960\">\n",
+              "    <path d=\"M120-120v-720h720v720H120Zm60-500h600v-160H180v160Zm220 220h160v-160H400v160Zm0 220h160v-160H400v160ZM180-400h160v-160H180v160Zm440 0h160v-160H620v160ZM180-180h160v-160H180v160Zm440 0h160v-160H620v160Z\"/>\n",
+              "  </svg>\n",
+              "    </button>\n",
+              "\n",
+              "  <style>\n",
+              "    .colab-df-container {\n",
+              "      display:flex;\n",
+              "      gap: 12px;\n",
+              "    }\n",
+              "\n",
+              "    .colab-df-convert {\n",
+              "      background-color: #E8F0FE;\n",
+              "      border: none;\n",
+              "      border-radius: 50%;\n",
+              "      cursor: pointer;\n",
+              "      display: none;\n",
+              "      fill: #1967D2;\n",
+              "      height: 32px;\n",
+              "      padding: 0 0 0 0;\n",
+              "      width: 32px;\n",
+              "    }\n",
+              "\n",
+              "    .colab-df-convert:hover {\n",
+              "      background-color: #E2EBFA;\n",
+              "      box-shadow: 0px 1px 2px rgba(60, 64, 67, 0.3), 0px 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
+              "      fill: #174EA6;\n",
+              "    }\n",
+              "\n",
+              "    .colab-df-buttons div {\n",
+              "      margin-bottom: 4px;\n",
+              "    }\n",
+              "\n",
+              "    [theme=dark] .colab-df-convert {\n",
+              "      background-color: #3B4455;\n",
+              "      fill: #D2E3FC;\n",
+              "    }\n",
+              "\n",
+              "    [theme=dark] .colab-df-convert:hover {\n",
+              "      background-color: #434B5C;\n",
+              "      box-shadow: 0px 1px 3px 1px rgba(0, 0, 0, 0.15);\n",
+              "      filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.3));\n",
+              "      fill: #FFFFFF;\n",
+              "    }\n",
+              "  </style>\n",
+              "\n",
+              "    <script>\n",
+              "      const buttonEl =\n",
+              "        document.querySelector('#df-448a03d4-dce8-46a9-baa4-4a72b55c4933 button.colab-df-convert');\n",
+              "      buttonEl.style.display =\n",
+              "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
+              "\n",
+              "      async function convertToInteractive(key) {\n",
+              "        const element = document.querySelector('#df-448a03d4-dce8-46a9-baa4-4a72b55c4933');\n",
+              "        const dataTable =\n",
+              "          await google.colab.kernel.invokeFunction('convertToInteractive',\n",
+              "                                                    [key], {});\n",
+              "        if (!dataTable) return;\n",
+              "\n",
+              "        const docLinkHtml = 'Like what you see? Visit the ' +\n",
+              "          '<a target=\"_blank\" href=https://colab.research.google.com/notebooks/data_table.ipynb>data table notebook</a>'\n",
+              "          + ' to learn more about interactive tables.';\n",
+              "        element.innerHTML = '';\n",
+              "        dataTable['output_type'] = 'display_data';\n",
+              "        await google.colab.output.renderOutput(dataTable, element);\n",
+              "        const docLink = document.createElement('div');\n",
+              "        docLink.innerHTML = docLinkHtml;\n",
+              "        element.appendChild(docLink);\n",
+              "      }\n",
+              "    </script>\n",
+              "  </div>\n",
+              "\n",
+              "\n",
+              "<div id=\"df-a82787a2-8947-4bc3-a3b6-890eb657f7ef\">\n",
+              "  <button class=\"colab-df-quickchart\" onclick=\"quickchart('df-a82787a2-8947-4bc3-a3b6-890eb657f7ef')\"\n",
+              "            title=\"Suggest charts.\"\n",
+              "            style=\"display:none;\">\n",
+              "\n",
+              "<svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\"viewBox=\"0 0 24 24\"\n",
+              "     width=\"24px\">\n",
+              "    <g>\n",
+              "        <path d=\"M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zM9 17H7v-7h2v7zm4 0h-2V7h2v10zm4 0h-2v-4h2v4z\"/>\n",
+              "    </g>\n",
+              "</svg>\n",
+              "  </button>\n",
+              "\n",
+              "<style>\n",
+              "  .colab-df-quickchart {\n",
+              "      --bg-color: #E8F0FE;\n",
+              "      --fill-color: #1967D2;\n",
+              "      --hover-bg-color: #E2EBFA;\n",
+              "      --hover-fill-color: #174EA6;\n",
+              "      --disabled-fill-color: #AAA;\n",
+              "      --disabled-bg-color: #DDD;\n",
+              "  }\n",
+              "\n",
+              "  [theme=dark] .colab-df-quickchart {\n",
+              "      --bg-color: #3B4455;\n",
+              "      --fill-color: #D2E3FC;\n",
+              "      --hover-bg-color: #434B5C;\n",
+              "      --hover-fill-color: #FFFFFF;\n",
+              "      --disabled-bg-color: #3B4455;\n",
+              "      --disabled-fill-color: #666;\n",
+              "  }\n",
+              "\n",
+              "  .colab-df-quickchart {\n",
+              "    background-color: var(--bg-color);\n",
+              "    border: none;\n",
+              "    border-radius: 50%;\n",
+              "    cursor: pointer;\n",
+              "    display: none;\n",
+              "    fill: var(--fill-color);\n",
+              "    height: 32px;\n",
+              "    padding: 0;\n",
+              "    width: 32px;\n",
+              "  }\n",
+              "\n",
+              "  .colab-df-quickchart:hover {\n",
+              "    background-color: var(--hover-bg-color);\n",
+              "    box-shadow: 0 1px 2px rgba(60, 64, 67, 0.3), 0 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
+              "    fill: var(--button-hover-fill-color);\n",
+              "  }\n",
+              "\n",
+              "  .colab-df-quickchart-complete:disabled,\n",
+              "  .colab-df-quickchart-complete:disabled:hover {\n",
+              "    background-color: var(--disabled-bg-color);\n",
+              "    fill: var(--disabled-fill-color);\n",
+              "    box-shadow: none;\n",
+              "  }\n",
+              "\n",
+              "  .colab-df-spinner {\n",
+              "    border: 2px solid var(--fill-color);\n",
+              "    border-color: transparent;\n",
+              "    border-bottom-color: var(--fill-color);\n",
+              "    animation:\n",
+              "      spin 1s steps(1) infinite;\n",
+              "  }\n",
+              "\n",
+              "  @keyframes spin {\n",
+              "    0% {\n",
+              "      border-color: transparent;\n",
+              "      border-bottom-color: var(--fill-color);\n",
+              "      border-left-color: var(--fill-color);\n",
+              "    }\n",
+              "    20% {\n",
+              "      border-color: transparent;\n",
+              "      border-left-color: var(--fill-color);\n",
+              "      border-top-color: var(--fill-color);\n",
+              "    }\n",
+              "    30% {\n",
+              "      border-color: transparent;\n",
+              "      border-left-color: var(--fill-color);\n",
+              "      border-top-color: var(--fill-color);\n",
+              "      border-right-color: var(--fill-color);\n",
+              "    }\n",
+              "    40% {\n",
+              "      border-color: transparent;\n",
+              "      border-right-color: var(--fill-color);\n",
+              "      border-top-color: var(--fill-color);\n",
+              "    }\n",
+              "    60% {\n",
+              "      border-color: transparent;\n",
+              "      border-right-color: var(--fill-color);\n",
+              "    }\n",
+              "    80% {\n",
+              "      border-color: transparent;\n",
+              "      border-right-color: var(--fill-color);\n",
+              "      border-bottom-color: var(--fill-color);\n",
+              "    }\n",
+              "    90% {\n",
+              "      border-color: transparent;\n",
+              "      border-bottom-color: var(--fill-color);\n",
+              "    }\n",
+              "  }\n",
+              "</style>\n",
+              "\n",
+              "  <script>\n",
+              "    async function quickchart(key) {\n",
+              "      const quickchartButtonEl =\n",
+              "        document.querySelector('#' + key + ' button');\n",
+              "      quickchartButtonEl.disabled = true;  // To prevent multiple clicks.\n",
+              "      quickchartButtonEl.classList.add('colab-df-spinner');\n",
+              "      try {\n",
+              "        const charts = await google.colab.kernel.invokeFunction(\n",
+              "            'suggestCharts', [key], {});\n",
+              "      } catch (error) {\n",
+              "        console.error('Error during call to suggestCharts:', error);\n",
+              "      }\n",
+              "      quickchartButtonEl.classList.remove('colab-df-spinner');\n",
+              "      quickchartButtonEl.classList.add('colab-df-quickchart-complete');\n",
+              "    }\n",
+              "    (() => {\n",
+              "      let quickchartButtonEl =\n",
+              "        document.querySelector('#df-a82787a2-8947-4bc3-a3b6-890eb657f7ef button');\n",
+              "      quickchartButtonEl.style.display =\n",
+              "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
+              "    })();\n",
+              "  </script>\n",
+              "</div>\n",
+              "    </div>\n",
+              "  </div>\n"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 23
+        }
+      ],
+      "source": [
+        "pd_flights.head()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 24,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2021-12-15T20:24:38.699691Z",
+          "iopub.status.busy": "2021-12-15T20:24:38.699271Z",
+          "iopub.status.idle": "2021-12-15T20:24:40.675206Z",
+          "shell.execute_reply": "2021-12-15T20:24:40.676183Z"
+        },
+        "pycharm": {
+          "is_executing": false
+        },
+        "id": "i1-efE1RNRFW",
+        "outputId": "15bf7cde-edf5-41fc-ef66-7af780d95a99",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 236
+        }
+      },
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "   AvgTicketPrice  Cancelled  ... dayOfWeek           timestamp\n",
+              "0      841.265642      False  ...         0 2018-01-01 00:00:00\n",
+              "1      882.982662      False  ...         0 2018-01-01 18:27:00\n",
+              "2      190.636904      False  ...         0 2018-01-01 17:11:14\n",
+              "3      181.694216       True  ...         0 2018-01-01 10:33:28\n",
+              "4      730.041778      False  ...         0 2018-01-01 05:13:00\n",
+              "\n",
+              "[5 rows x 27 columns]"
+            ],
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>AvgTicketPrice</th>\n",
+              "      <th>Cancelled</th>\n",
+              "      <th>...</th>\n",
+              "      <th>dayOfWeek</th>\n",
+              "      <th>timestamp</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>841.265642</td>\n",
+              "      <td>False</td>\n",
+              "      <td>...</td>\n",
+              "      <td>0</td>\n",
+              "      <td>2018-01-01 00:00:00</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>1</th>\n",
+              "      <td>882.982662</td>\n",
+              "      <td>False</td>\n",
+              "      <td>...</td>\n",
+              "      <td>0</td>\n",
+              "      <td>2018-01-01 18:27:00</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>2</th>\n",
+              "      <td>190.636904</td>\n",
+              "      <td>False</td>\n",
+              "      <td>...</td>\n",
+              "      <td>0</td>\n",
+              "      <td>2018-01-01 17:11:14</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>3</th>\n",
+              "      <td>181.694216</td>\n",
+              "      <td>True</td>\n",
+              "      <td>...</td>\n",
+              "      <td>0</td>\n",
+              "      <td>2018-01-01 10:33:28</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>4</th>\n",
+              "      <td>730.041778</td>\n",
+              "      <td>False</td>\n",
+              "      <td>...</td>\n",
+              "      <td>0</td>\n",
+              "      <td>2018-01-01 05:13:00</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>\n",
+              "<p>5 rows × 27 columns</p>"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 24
+        }
+      ],
+      "source": [
+        "ed_flights.head()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "55T-dd4ENRFW"
+      },
+      "source": [
+        "### DataFrame.tail"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 25,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2021-12-15T20:24:40.695639Z",
+          "iopub.status.busy": "2021-12-15T20:24:40.694910Z",
+          "iopub.status.idle": "2021-12-15T20:24:40.698148Z",
+          "shell.execute_reply": "2021-12-15T20:24:40.698704Z"
+        },
+        "pycharm": {
+          "is_executing": false
+        },
+        "id": "MUKzwkRtNRFW",
+        "outputId": "d24b73d4-a18a-4029-fe89-3b4690ca7cc4",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 236
+        }
+      },
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "       AvgTicketPrice  Cancelled  ... dayOfWeek           timestamp\n",
+              "13054     1080.446279      False  ...         6 2018-02-11 20:42:25\n",
+              "13055      646.612941      False  ...         6 2018-02-11 01:41:57\n",
+              "13056      997.751876      False  ...         6 2018-02-11 04:09:27\n",
+              "13057     1102.814465      False  ...         6 2018-02-11 08:28:21\n",
+              "13058      858.144337      False  ...         6 2018-02-11 14:54:34\n",
+              "\n",
+              "[5 rows x 27 columns]"
+            ],
+            "text/html": [
+              "\n",
+              "  <div id=\"df-fc6a9899-85fb-44ed-a12f-f530428667d6\" class=\"colab-df-container\">\n",
+              "    <div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>AvgTicketPrice</th>\n",
+              "      <th>Cancelled</th>\n",
+              "      <th>...</th>\n",
+              "      <th>dayOfWeek</th>\n",
+              "      <th>timestamp</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>13054</th>\n",
+              "      <td>1080.446279</td>\n",
+              "      <td>False</td>\n",
+              "      <td>...</td>\n",
+              "      <td>6</td>\n",
+              "      <td>2018-02-11 20:42:25</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>13055</th>\n",
+              "      <td>646.612941</td>\n",
+              "      <td>False</td>\n",
+              "      <td>...</td>\n",
+              "      <td>6</td>\n",
+              "      <td>2018-02-11 01:41:57</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>13056</th>\n",
+              "      <td>997.751876</td>\n",
+              "      <td>False</td>\n",
+              "      <td>...</td>\n",
+              "      <td>6</td>\n",
+              "      <td>2018-02-11 04:09:27</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>13057</th>\n",
+              "      <td>1102.814465</td>\n",
+              "      <td>False</td>\n",
+              "      <td>...</td>\n",
+              "      <td>6</td>\n",
+              "      <td>2018-02-11 08:28:21</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>13058</th>\n",
+              "      <td>858.144337</td>\n",
+              "      <td>False</td>\n",
+              "      <td>...</td>\n",
+              "      <td>6</td>\n",
+              "      <td>2018-02-11 14:54:34</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "<p>5 rows × 27 columns</p>\n",
+              "</div>\n",
+              "    <div class=\"colab-df-buttons\">\n",
+              "\n",
+              "  <div class=\"colab-df-container\">\n",
+              "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-fc6a9899-85fb-44ed-a12f-f530428667d6')\"\n",
+              "            title=\"Convert this dataframe to an interactive table.\"\n",
+              "            style=\"display:none;\">\n",
+              "\n",
+              "  <svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\" viewBox=\"0 -960 960 960\">\n",
+              "    <path d=\"M120-120v-720h720v720H120Zm60-500h600v-160H180v160Zm220 220h160v-160H400v160Zm0 220h160v-160H400v160ZM180-400h160v-160H180v160Zm440 0h160v-160H620v160ZM180-180h160v-160H180v160Zm440 0h160v-160H620v160Z\"/>\n",
+              "  </svg>\n",
+              "    </button>\n",
+              "\n",
+              "  <style>\n",
+              "    .colab-df-container {\n",
+              "      display:flex;\n",
+              "      gap: 12px;\n",
+              "    }\n",
+              "\n",
+              "    .colab-df-convert {\n",
+              "      background-color: #E8F0FE;\n",
+              "      border: none;\n",
+              "      border-radius: 50%;\n",
+              "      cursor: pointer;\n",
+              "      display: none;\n",
+              "      fill: #1967D2;\n",
+              "      height: 32px;\n",
+              "      padding: 0 0 0 0;\n",
+              "      width: 32px;\n",
+              "    }\n",
+              "\n",
+              "    .colab-df-convert:hover {\n",
+              "      background-color: #E2EBFA;\n",
+              "      box-shadow: 0px 1px 2px rgba(60, 64, 67, 0.3), 0px 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
+              "      fill: #174EA6;\n",
+              "    }\n",
+              "\n",
+              "    .colab-df-buttons div {\n",
+              "      margin-bottom: 4px;\n",
+              "    }\n",
+              "\n",
+              "    [theme=dark] .colab-df-convert {\n",
+              "      background-color: #3B4455;\n",
+              "      fill: #D2E3FC;\n",
+              "    }\n",
+              "\n",
+              "    [theme=dark] .colab-df-convert:hover {\n",
+              "      background-color: #434B5C;\n",
+              "      box-shadow: 0px 1px 3px 1px rgba(0, 0, 0, 0.15);\n",
+              "      filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.3));\n",
+              "      fill: #FFFFFF;\n",
+              "    }\n",
+              "  </style>\n",
+              "\n",
+              "    <script>\n",
+              "      const buttonEl =\n",
+              "        document.querySelector('#df-fc6a9899-85fb-44ed-a12f-f530428667d6 button.colab-df-convert');\n",
+              "      buttonEl.style.display =\n",
+              "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
+              "\n",
+              "      async function convertToInteractive(key) {\n",
+              "        const element = document.querySelector('#df-fc6a9899-85fb-44ed-a12f-f530428667d6');\n",
+              "        const dataTable =\n",
+              "          await google.colab.kernel.invokeFunction('convertToInteractive',\n",
+              "                                                    [key], {});\n",
+              "        if (!dataTable) return;\n",
+              "\n",
+              "        const docLinkHtml = 'Like what you see? Visit the ' +\n",
+              "          '<a target=\"_blank\" href=https://colab.research.google.com/notebooks/data_table.ipynb>data table notebook</a>'\n",
+              "          + ' to learn more about interactive tables.';\n",
+              "        element.innerHTML = '';\n",
+              "        dataTable['output_type'] = 'display_data';\n",
+              "        await google.colab.output.renderOutput(dataTable, element);\n",
+              "        const docLink = document.createElement('div');\n",
+              "        docLink.innerHTML = docLinkHtml;\n",
+              "        element.appendChild(docLink);\n",
+              "      }\n",
+              "    </script>\n",
+              "  </div>\n",
+              "\n",
+              "\n",
+              "<div id=\"df-919a1323-b973-4b60-ae1a-e0b4f41a04e2\">\n",
+              "  <button class=\"colab-df-quickchart\" onclick=\"quickchart('df-919a1323-b973-4b60-ae1a-e0b4f41a04e2')\"\n",
+              "            title=\"Suggest charts.\"\n",
+              "            style=\"display:none;\">\n",
+              "\n",
+              "<svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\"viewBox=\"0 0 24 24\"\n",
+              "     width=\"24px\">\n",
+              "    <g>\n",
+              "        <path d=\"M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zM9 17H7v-7h2v7zm4 0h-2V7h2v10zm4 0h-2v-4h2v4z\"/>\n",
+              "    </g>\n",
+              "</svg>\n",
+              "  </button>\n",
+              "\n",
+              "<style>\n",
+              "  .colab-df-quickchart {\n",
+              "      --bg-color: #E8F0FE;\n",
+              "      --fill-color: #1967D2;\n",
+              "      --hover-bg-color: #E2EBFA;\n",
+              "      --hover-fill-color: #174EA6;\n",
+              "      --disabled-fill-color: #AAA;\n",
+              "      --disabled-bg-color: #DDD;\n",
+              "  }\n",
+              "\n",
+              "  [theme=dark] .colab-df-quickchart {\n",
+              "      --bg-color: #3B4455;\n",
+              "      --fill-color: #D2E3FC;\n",
+              "      --hover-bg-color: #434B5C;\n",
+              "      --hover-fill-color: #FFFFFF;\n",
+              "      --disabled-bg-color: #3B4455;\n",
+              "      --disabled-fill-color: #666;\n",
+              "  }\n",
+              "\n",
+              "  .colab-df-quickchart {\n",
+              "    background-color: var(--bg-color);\n",
+              "    border: none;\n",
+              "    border-radius: 50%;\n",
+              "    cursor: pointer;\n",
+              "    display: none;\n",
+              "    fill: var(--fill-color);\n",
+              "    height: 32px;\n",
+              "    padding: 0;\n",
+              "    width: 32px;\n",
+              "  }\n",
+              "\n",
+              "  .colab-df-quickchart:hover {\n",
+              "    background-color: var(--hover-bg-color);\n",
+              "    box-shadow: 0 1px 2px rgba(60, 64, 67, 0.3), 0 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
+              "    fill: var(--button-hover-fill-color);\n",
+              "  }\n",
+              "\n",
+              "  .colab-df-quickchart-complete:disabled,\n",
+              "  .colab-df-quickchart-complete:disabled:hover {\n",
+              "    background-color: var(--disabled-bg-color);\n",
+              "    fill: var(--disabled-fill-color);\n",
+              "    box-shadow: none;\n",
+              "  }\n",
+              "\n",
+              "  .colab-df-spinner {\n",
+              "    border: 2px solid var(--fill-color);\n",
+              "    border-color: transparent;\n",
+              "    border-bottom-color: var(--fill-color);\n",
+              "    animation:\n",
+              "      spin 1s steps(1) infinite;\n",
+              "  }\n",
+              "\n",
+              "  @keyframes spin {\n",
+              "    0% {\n",
+              "      border-color: transparent;\n",
+              "      border-bottom-color: var(--fill-color);\n",
+              "      border-left-color: var(--fill-color);\n",
+              "    }\n",
+              "    20% {\n",
+              "      border-color: transparent;\n",
+              "      border-left-color: var(--fill-color);\n",
+              "      border-top-color: var(--fill-color);\n",
+              "    }\n",
+              "    30% {\n",
+              "      border-color: transparent;\n",
+              "      border-left-color: var(--fill-color);\n",
+              "      border-top-color: var(--fill-color);\n",
+              "      border-right-color: var(--fill-color);\n",
+              "    }\n",
+              "    40% {\n",
+              "      border-color: transparent;\n",
+              "      border-right-color: var(--fill-color);\n",
+              "      border-top-color: var(--fill-color);\n",
+              "    }\n",
+              "    60% {\n",
+              "      border-color: transparent;\n",
+              "      border-right-color: var(--fill-color);\n",
+              "    }\n",
+              "    80% {\n",
+              "      border-color: transparent;\n",
+              "      border-right-color: var(--fill-color);\n",
+              "      border-bottom-color: var(--fill-color);\n",
+              "    }\n",
+              "    90% {\n",
+              "      border-color: transparent;\n",
+              "      border-bottom-color: var(--fill-color);\n",
+              "    }\n",
+              "  }\n",
+              "</style>\n",
+              "\n",
+              "  <script>\n",
+              "    async function quickchart(key) {\n",
+              "      const quickchartButtonEl =\n",
+              "        document.querySelector('#' + key + ' button');\n",
+              "      quickchartButtonEl.disabled = true;  // To prevent multiple clicks.\n",
+              "      quickchartButtonEl.classList.add('colab-df-spinner');\n",
+              "      try {\n",
+              "        const charts = await google.colab.kernel.invokeFunction(\n",
+              "            'suggestCharts', [key], {});\n",
+              "      } catch (error) {\n",
+              "        console.error('Error during call to suggestCharts:', error);\n",
+              "      }\n",
+              "      quickchartButtonEl.classList.remove('colab-df-spinner');\n",
+              "      quickchartButtonEl.classList.add('colab-df-quickchart-complete');\n",
+              "    }\n",
+              "    (() => {\n",
+              "      let quickchartButtonEl =\n",
+              "        document.querySelector('#df-919a1323-b973-4b60-ae1a-e0b4f41a04e2 button');\n",
+              "      quickchartButtonEl.style.display =\n",
+              "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
+              "    })();\n",
+              "  </script>\n",
+              "</div>\n",
+              "    </div>\n",
+              "  </div>\n"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 25
+        }
+      ],
+      "source": [
+        "pd_flights.tail()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 26,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2021-12-15T20:24:40.703670Z",
+          "iopub.status.busy": "2021-12-15T20:24:40.702923Z",
+          "iopub.status.idle": "2021-12-15T20:24:42.789898Z",
+          "shell.execute_reply": "2021-12-15T20:24:42.789460Z"
+        },
+        "pycharm": {
+          "is_executing": false
+        },
+        "id": "wnFnjtDGNRFW",
+        "outputId": "6a2f8812-762a-4a01-ef35-e1cc552f5f2c",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 236
+        }
+      },
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "       AvgTicketPrice  Cancelled  ... dayOfWeek           timestamp\n",
+              "13054     1080.446279      False  ...         6 2018-02-11 20:42:25\n",
+              "13055      646.612941      False  ...         6 2018-02-11 01:41:57\n",
+              "13056      997.751876      False  ...         6 2018-02-11 04:09:27\n",
+              "13057     1102.814465      False  ...         6 2018-02-11 08:28:21\n",
+              "13058      858.144337      False  ...         6 2018-02-11 14:54:34\n",
+              "\n",
+              "[5 rows x 27 columns]"
+            ],
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>AvgTicketPrice</th>\n",
+              "      <th>Cancelled</th>\n",
+              "      <th>...</th>\n",
+              "      <th>dayOfWeek</th>\n",
+              "      <th>timestamp</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>13054</th>\n",
+              "      <td>1080.446279</td>\n",
+              "      <td>False</td>\n",
+              "      <td>...</td>\n",
+              "      <td>6</td>\n",
+              "      <td>2018-02-11 20:42:25</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>13055</th>\n",
+              "      <td>646.612941</td>\n",
+              "      <td>False</td>\n",
+              "      <td>...</td>\n",
+              "      <td>6</td>\n",
+              "      <td>2018-02-11 01:41:57</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>13056</th>\n",
+              "      <td>997.751876</td>\n",
+              "      <td>False</td>\n",
+              "      <td>...</td>\n",
+              "      <td>6</td>\n",
+              "      <td>2018-02-11 04:09:27</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>13057</th>\n",
+              "      <td>1102.814465</td>\n",
+              "      <td>False</td>\n",
+              "      <td>...</td>\n",
+              "      <td>6</td>\n",
+              "      <td>2018-02-11 08:28:21</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>13058</th>\n",
+              "      <td>858.144337</td>\n",
+              "      <td>False</td>\n",
+              "      <td>...</td>\n",
+              "      <td>6</td>\n",
+              "      <td>2018-02-11 14:54:34</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>\n",
+              "<p>5 rows × 27 columns</p>"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 26
+        }
+      ],
+      "source": [
+        "ed_flights.tail()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "y8nBZkIPNRFX"
+      },
+      "source": [
+        "### DataFrame.keys"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 27,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2021-12-15T20:24:42.793363Z",
+          "iopub.status.busy": "2021-12-15T20:24:42.791765Z",
+          "iopub.status.idle": "2021-12-15T20:24:42.796116Z",
+          "shell.execute_reply": "2021-12-15T20:24:42.795742Z"
+        },
+        "pycharm": {
+          "is_executing": false
+        },
+        "id": "NNt89qcvNRFX",
+        "outputId": "23ff7790-c863-48c6-f933-ed240fa4aa9c",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
+      },
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "Index(['AvgTicketPrice', 'Cancelled', 'Carrier', 'Dest', 'DestAirportID', 'DestCityName',\n",
+              "       'DestCountry', 'DestLocation', 'DestRegion', 'DestWeather', 'DistanceKilometers',\n",
+              "       'DistanceMiles', 'FlightDelay', 'FlightDelayMin', 'FlightDelayType', 'FlightNum',\n",
+              "       'FlightTimeHour', 'FlightTimeMin', 'Origin', 'OriginAirportID', 'OriginCityName',\n",
+              "       'OriginCountry', 'OriginLocation', 'OriginRegion', 'OriginWeather', 'dayOfWeek',\n",
+              "       'timestamp'],\n",
+              "      dtype='object')"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 27
+        }
+      ],
+      "source": [
+        "pd_flights.keys()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 28,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2021-12-15T20:24:42.799972Z",
+          "iopub.status.busy": "2021-12-15T20:24:42.799336Z",
+          "iopub.status.idle": "2021-12-15T20:24:42.802144Z",
+          "shell.execute_reply": "2021-12-15T20:24:42.801772Z"
+        },
+        "pycharm": {
+          "is_executing": false
+        },
+        "id": "zsEuViUSNRFX",
+        "outputId": "b9506acf-62ed-45e9-fec9-ffa1a7e0f392",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
+      },
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "Index(['AvgTicketPrice', 'Cancelled', 'Carrier', 'Dest', 'DestAirportID', 'DestCityName',\n",
+              "       'DestCountry', 'DestLocation', 'DestRegion', 'DestWeather', 'DistanceKilometers',\n",
+              "       'DistanceMiles', 'FlightDelay', 'FlightDelayMin', 'FlightDelayType', 'FlightNum',\n",
+              "       'FlightTimeHour', 'FlightTimeMin', 'Origin', 'OriginAirportID', 'OriginCityName',\n",
+              "       'OriginCountry', 'OriginLocation', 'OriginRegion', 'OriginWeather', 'dayOfWeek',\n",
+              "       'timestamp'],\n",
+              "      dtype='object')"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 28
+        }
+      ],
+      "source": [
+        "ed_flights.keys()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "KtypOwLUNRFX"
+      },
+      "source": [
+        "### DataFrame.get"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 29,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2021-12-15T20:24:42.807664Z",
+          "iopub.status.busy": "2021-12-15T20:24:42.807137Z",
+          "iopub.status.idle": "2021-12-15T20:24:42.809592Z",
+          "shell.execute_reply": "2021-12-15T20:24:42.809225Z"
+        },
+        "pycharm": {
+          "is_executing": false
+        },
+        "id": "kFa9r_yQNRFY",
+        "outputId": "2c193851-2f59-427c-cf63-d420209e086f",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
+      },
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "0         Kibana Airlines\n",
+              "1        Logstash Airways\n",
+              "2        Logstash Airways\n",
+              "3         Kibana Airlines\n",
+              "4         Kibana Airlines\n",
+              "               ...       \n",
+              "13054    Logstash Airways\n",
+              "13055    Logstash Airways\n",
+              "13056    Logstash Airways\n",
+              "13057            JetBeats\n",
+              "13058            JetBeats\n",
+              "Name: Carrier, Length: 13059, dtype: object"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 29
+        }
+      ],
+      "source": [
+        "pd_flights.get('Carrier')"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 30,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2021-12-15T20:24:42.813306Z",
+          "iopub.status.busy": "2021-12-15T20:24:42.812951Z",
+          "iopub.status.idle": "2021-12-15T20:24:44.238665Z",
+          "shell.execute_reply": "2021-12-15T20:24:44.239468Z"
+        },
+        "pycharm": {
+          "is_executing": false
+        },
+        "id": "Fp52TYwGNRFY",
+        "outputId": "f45d1ae9-77b0-4fcc-f9b7-22fa7824f060",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
+      },
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "0         Kibana Airlines\n",
+              "1        Logstash Airways\n",
+              "2        Logstash Airways\n",
+              "3         Kibana Airlines\n",
+              "4         Kibana Airlines\n",
+              "               ...       \n",
+              "13054    Logstash Airways\n",
+              "13055    Logstash Airways\n",
+              "13056    Logstash Airways\n",
+              "13057            JetBeats\n",
+              "13058            JetBeats\n",
+              "Name: Carrier, Length: 13059, dtype: object"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 30
+        }
+      ],
+      "source": [
+        "ed_flights.get('Carrier')"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 31,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2021-12-15T20:24:44.252784Z",
+          "iopub.status.busy": "2021-12-15T20:24:44.244955Z",
+          "iopub.status.idle": "2021-12-15T20:24:44.257030Z",
+          "shell.execute_reply": "2021-12-15T20:24:44.258040Z"
+        },
+        "pycharm": {
+          "is_executing": false
+        },
+        "id": "-1zPSsGHNRFY",
+        "outputId": "2f034c29-21f7-4b98-d17a-3844e20c223b",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 424
+        }
+      },
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "                Carrier                                             Origin\n",
+              "0       Kibana Airlines                          Frankfurt am Main Airport\n",
+              "1      Logstash Airways                    Cape Town International Airport\n",
+              "2      Logstash Airways                          Venice Marco Polo Airport\n",
+              "3       Kibana Airlines                       Naples International Airport\n",
+              "4       Kibana Airlines     Licenciado Benito Juarez International Airport\n",
+              "...                 ...                                                ...\n",
+              "13054  Logstash Airways                         Pisa International Airport\n",
+              "13055  Logstash Airways  Winnipeg / James Armstrong Richardson Internat...\n",
+              "13056  Logstash Airways     Licenciado Benito Juarez International Airport\n",
+              "13057          JetBeats                                      Itami Airport\n",
+              "13058          JetBeats                     Adelaide International Airport\n",
+              "\n",
+              "[13059 rows x 2 columns]"
+            ],
+            "text/html": [
+              "\n",
+              "  <div id=\"df-839ab481-cb93-432b-8e22-3ceed218a732\" class=\"colab-df-container\">\n",
+              "    <div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>Carrier</th>\n",
+              "      <th>Origin</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>Kibana Airlines</td>\n",
+              "      <td>Frankfurt am Main Airport</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>1</th>\n",
+              "      <td>Logstash Airways</td>\n",
+              "      <td>Cape Town International Airport</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>2</th>\n",
+              "      <td>Logstash Airways</td>\n",
+              "      <td>Venice Marco Polo Airport</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>3</th>\n",
+              "      <td>Kibana Airlines</td>\n",
+              "      <td>Naples International Airport</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>4</th>\n",
+              "      <td>Kibana Airlines</td>\n",
+              "      <td>Licenciado Benito Juarez International Airport</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>...</th>\n",
+              "      <td>...</td>\n",
+              "      <td>...</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>13054</th>\n",
+              "      <td>Logstash Airways</td>\n",
+              "      <td>Pisa International Airport</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>13055</th>\n",
+              "      <td>Logstash Airways</td>\n",
+              "      <td>Winnipeg / James Armstrong Richardson Internat...</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>13056</th>\n",
+              "      <td>Logstash Airways</td>\n",
+              "      <td>Licenciado Benito Juarez International Airport</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>13057</th>\n",
+              "      <td>JetBeats</td>\n",
+              "      <td>Itami Airport</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>13058</th>\n",
+              "      <td>JetBeats</td>\n",
+              "      <td>Adelaide International Airport</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "<p>13059 rows × 2 columns</p>\n",
+              "</div>\n",
+              "    <div class=\"colab-df-buttons\">\n",
+              "\n",
+              "  <div class=\"colab-df-container\">\n",
+              "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-839ab481-cb93-432b-8e22-3ceed218a732')\"\n",
+              "            title=\"Convert this dataframe to an interactive table.\"\n",
+              "            style=\"display:none;\">\n",
+              "\n",
+              "  <svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\" viewBox=\"0 -960 960 960\">\n",
+              "    <path d=\"M120-120v-720h720v720H120Zm60-500h600v-160H180v160Zm220 220h160v-160H400v160Zm0 220h160v-160H400v160ZM180-400h160v-160H180v160Zm440 0h160v-160H620v160ZM180-180h160v-160H180v160Zm440 0h160v-160H620v160Z\"/>\n",
+              "  </svg>\n",
+              "    </button>\n",
+              "\n",
+              "  <style>\n",
+              "    .colab-df-container {\n",
+              "      display:flex;\n",
+              "      gap: 12px;\n",
+              "    }\n",
+              "\n",
+              "    .colab-df-convert {\n",
+              "      background-color: #E8F0FE;\n",
+              "      border: none;\n",
+              "      border-radius: 50%;\n",
+              "      cursor: pointer;\n",
+              "      display: none;\n",
+              "      fill: #1967D2;\n",
+              "      height: 32px;\n",
+              "      padding: 0 0 0 0;\n",
+              "      width: 32px;\n",
+              "    }\n",
+              "\n",
+              "    .colab-df-convert:hover {\n",
+              "      background-color: #E2EBFA;\n",
+              "      box-shadow: 0px 1px 2px rgba(60, 64, 67, 0.3), 0px 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
+              "      fill: #174EA6;\n",
+              "    }\n",
+              "\n",
+              "    .colab-df-buttons div {\n",
+              "      margin-bottom: 4px;\n",
+              "    }\n",
+              "\n",
+              "    [theme=dark] .colab-df-convert {\n",
+              "      background-color: #3B4455;\n",
+              "      fill: #D2E3FC;\n",
+              "    }\n",
+              "\n",
+              "    [theme=dark] .colab-df-convert:hover {\n",
+              "      background-color: #434B5C;\n",
+              "      box-shadow: 0px 1px 3px 1px rgba(0, 0, 0, 0.15);\n",
+              "      filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.3));\n",
+              "      fill: #FFFFFF;\n",
+              "    }\n",
+              "  </style>\n",
+              "\n",
+              "    <script>\n",
+              "      const buttonEl =\n",
+              "        document.querySelector('#df-839ab481-cb93-432b-8e22-3ceed218a732 button.colab-df-convert');\n",
+              "      buttonEl.style.display =\n",
+              "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
+              "\n",
+              "      async function convertToInteractive(key) {\n",
+              "        const element = document.querySelector('#df-839ab481-cb93-432b-8e22-3ceed218a732');\n",
+              "        const dataTable =\n",
+              "          await google.colab.kernel.invokeFunction('convertToInteractive',\n",
+              "                                                    [key], {});\n",
+              "        if (!dataTable) return;\n",
+              "\n",
+              "        const docLinkHtml = 'Like what you see? Visit the ' +\n",
+              "          '<a target=\"_blank\" href=https://colab.research.google.com/notebooks/data_table.ipynb>data table notebook</a>'\n",
+              "          + ' to learn more about interactive tables.';\n",
+              "        element.innerHTML = '';\n",
+              "        dataTable['output_type'] = 'display_data';\n",
+              "        await google.colab.output.renderOutput(dataTable, element);\n",
+              "        const docLink = document.createElement('div');\n",
+              "        docLink.innerHTML = docLinkHtml;\n",
+              "        element.appendChild(docLink);\n",
+              "      }\n",
+              "    </script>\n",
+              "  </div>\n",
+              "\n",
+              "\n",
+              "<div id=\"df-9835d2bd-db66-41e3-9844-02f122edecc1\">\n",
+              "  <button class=\"colab-df-quickchart\" onclick=\"quickchart('df-9835d2bd-db66-41e3-9844-02f122edecc1')\"\n",
+              "            title=\"Suggest charts.\"\n",
+              "            style=\"display:none;\">\n",
+              "\n",
+              "<svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\"viewBox=\"0 0 24 24\"\n",
+              "     width=\"24px\">\n",
+              "    <g>\n",
+              "        <path d=\"M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zM9 17H7v-7h2v7zm4 0h-2V7h2v10zm4 0h-2v-4h2v4z\"/>\n",
+              "    </g>\n",
+              "</svg>\n",
+              "  </button>\n",
+              "\n",
+              "<style>\n",
+              "  .colab-df-quickchart {\n",
+              "      --bg-color: #E8F0FE;\n",
+              "      --fill-color: #1967D2;\n",
+              "      --hover-bg-color: #E2EBFA;\n",
+              "      --hover-fill-color: #174EA6;\n",
+              "      --disabled-fill-color: #AAA;\n",
+              "      --disabled-bg-color: #DDD;\n",
+              "  }\n",
+              "\n",
+              "  [theme=dark] .colab-df-quickchart {\n",
+              "      --bg-color: #3B4455;\n",
+              "      --fill-color: #D2E3FC;\n",
+              "      --hover-bg-color: #434B5C;\n",
+              "      --hover-fill-color: #FFFFFF;\n",
+              "      --disabled-bg-color: #3B4455;\n",
+              "      --disabled-fill-color: #666;\n",
+              "  }\n",
+              "\n",
+              "  .colab-df-quickchart {\n",
+              "    background-color: var(--bg-color);\n",
+              "    border: none;\n",
+              "    border-radius: 50%;\n",
+              "    cursor: pointer;\n",
+              "    display: none;\n",
+              "    fill: var(--fill-color);\n",
+              "    height: 32px;\n",
+              "    padding: 0;\n",
+              "    width: 32px;\n",
+              "  }\n",
+              "\n",
+              "  .colab-df-quickchart:hover {\n",
+              "    background-color: var(--hover-bg-color);\n",
+              "    box-shadow: 0 1px 2px rgba(60, 64, 67, 0.3), 0 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
+              "    fill: var(--button-hover-fill-color);\n",
+              "  }\n",
+              "\n",
+              "  .colab-df-quickchart-complete:disabled,\n",
+              "  .colab-df-quickchart-complete:disabled:hover {\n",
+              "    background-color: var(--disabled-bg-color);\n",
+              "    fill: var(--disabled-fill-color);\n",
+              "    box-shadow: none;\n",
+              "  }\n",
+              "\n",
+              "  .colab-df-spinner {\n",
+              "    border: 2px solid var(--fill-color);\n",
+              "    border-color: transparent;\n",
+              "    border-bottom-color: var(--fill-color);\n",
+              "    animation:\n",
+              "      spin 1s steps(1) infinite;\n",
+              "  }\n",
+              "\n",
+              "  @keyframes spin {\n",
+              "    0% {\n",
+              "      border-color: transparent;\n",
+              "      border-bottom-color: var(--fill-color);\n",
+              "      border-left-color: var(--fill-color);\n",
+              "    }\n",
+              "    20% {\n",
+              "      border-color: transparent;\n",
+              "      border-left-color: var(--fill-color);\n",
+              "      border-top-color: var(--fill-color);\n",
+              "    }\n",
+              "    30% {\n",
+              "      border-color: transparent;\n",
+              "      border-left-color: var(--fill-color);\n",
+              "      border-top-color: var(--fill-color);\n",
+              "      border-right-color: var(--fill-color);\n",
+              "    }\n",
+              "    40% {\n",
+              "      border-color: transparent;\n",
+              "      border-right-color: var(--fill-color);\n",
+              "      border-top-color: var(--fill-color);\n",
+              "    }\n",
+              "    60% {\n",
+              "      border-color: transparent;\n",
+              "      border-right-color: var(--fill-color);\n",
+              "    }\n",
+              "    80% {\n",
+              "      border-color: transparent;\n",
+              "      border-right-color: var(--fill-color);\n",
+              "      border-bottom-color: var(--fill-color);\n",
+              "    }\n",
+              "    90% {\n",
+              "      border-color: transparent;\n",
+              "      border-bottom-color: var(--fill-color);\n",
+              "    }\n",
+              "  }\n",
+              "</style>\n",
+              "\n",
+              "  <script>\n",
+              "    async function quickchart(key) {\n",
+              "      const quickchartButtonEl =\n",
+              "        document.querySelector('#' + key + ' button');\n",
+              "      quickchartButtonEl.disabled = true;  // To prevent multiple clicks.\n",
+              "      quickchartButtonEl.classList.add('colab-df-spinner');\n",
+              "      try {\n",
+              "        const charts = await google.colab.kernel.invokeFunction(\n",
+              "            'suggestCharts', [key], {});\n",
+              "      } catch (error) {\n",
+              "        console.error('Error during call to suggestCharts:', error);\n",
+              "      }\n",
+              "      quickchartButtonEl.classList.remove('colab-df-spinner');\n",
+              "      quickchartButtonEl.classList.add('colab-df-quickchart-complete');\n",
+              "    }\n",
+              "    (() => {\n",
+              "      let quickchartButtonEl =\n",
+              "        document.querySelector('#df-9835d2bd-db66-41e3-9844-02f122edecc1 button');\n",
+              "      quickchartButtonEl.style.display =\n",
+              "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
+              "    })();\n",
+              "  </script>\n",
+              "</div>\n",
+              "    </div>\n",
+              "  </div>\n"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 31
+        }
+      ],
+      "source": [
+        "pd_flights.get(['Carrier', 'Origin'])"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "Fk7pTfyGNRFZ"
+      },
+      "source": [
+        "List input not currently supported by `eland.DataFrame.get`"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 32,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2021-12-15T20:24:44.263674Z",
+          "iopub.status.busy": "2021-12-15T20:24:44.261671Z",
+          "iopub.status.idle": "2021-12-15T20:24:44.266564Z",
+          "shell.execute_reply": "2021-12-15T20:24:44.267454Z"
+        },
+        "pycharm": {
+          "is_executing": false
+        },
+        "id": "iIGNGv6NNRFZ",
+        "outputId": "dd15cda4-0952-4fc3-f66b-c237eb0e29df",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "unhashable type: 'list'\n"
+          ]
+        }
+      ],
+      "source": [
+        "try:\n",
+        "    ed_flights.get(['Carrier', 'Origin'])\n",
+        "except TypeError as e:\n",
+        "    print(e)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "jygQjxYRNRFa"
+      },
+      "source": [
+        "### DataFrame.query"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 33,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2021-12-15T20:24:44.291893Z",
+          "iopub.status.busy": "2021-12-15T20:24:44.279615Z",
+          "iopub.status.idle": "2021-12-15T20:24:44.294715Z",
+          "shell.execute_reply": "2021-12-15T20:24:44.294192Z"
+        },
+        "pycharm": {
+          "is_executing": false
+        },
+        "id": "fpKfuV-uNRFa",
+        "outputId": "5c9ce26c-e631-4d87-b9c9-0f309f3e278b",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 424
+        }
+      },
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "       AvgTicketPrice  Cancelled  ... dayOfWeek           timestamp\n",
+              "8          960.869736       True  ...         0 2018-01-01 12:09:35\n",
+              "26         975.812632       True  ...         0 2018-01-01 15:38:32\n",
+              "311        946.358410       True  ...         0 2018-01-01 11:51:12\n",
+              "651        975.383864       True  ...         2 2018-01-03 21:13:17\n",
+              "950        907.836523       True  ...         2 2018-01-03 05:14:51\n",
+              "...               ...        ...  ...       ...                 ...\n",
+              "12820      909.973606       True  ...         5 2018-02-10 05:11:35\n",
+              "12906      983.429244       True  ...         6 2018-02-11 06:19:58\n",
+              "12918     1136.678150       True  ...         6 2018-02-11 16:03:10\n",
+              "12919     1105.211803       True  ...         6 2018-02-11 05:36:05\n",
+              "13013     1055.350213       True  ...         6 2018-02-11 13:20:16\n",
+              "\n",
+              "[68 rows x 27 columns]"
+            ],
+            "text/html": [
+              "\n",
+              "  <div id=\"df-e2228412-ba39-472a-8ecb-703ccdb66ee0\" class=\"colab-df-container\">\n",
+              "    <div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>AvgTicketPrice</th>\n",
+              "      <th>Cancelled</th>\n",
+              "      <th>...</th>\n",
+              "      <th>dayOfWeek</th>\n",
+              "      <th>timestamp</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>8</th>\n",
+              "      <td>960.869736</td>\n",
+              "      <td>True</td>\n",
+              "      <td>...</td>\n",
+              "      <td>0</td>\n",
+              "      <td>2018-01-01 12:09:35</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>26</th>\n",
+              "      <td>975.812632</td>\n",
+              "      <td>True</td>\n",
+              "      <td>...</td>\n",
+              "      <td>0</td>\n",
+              "      <td>2018-01-01 15:38:32</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>311</th>\n",
+              "      <td>946.358410</td>\n",
+              "      <td>True</td>\n",
+              "      <td>...</td>\n",
+              "      <td>0</td>\n",
+              "      <td>2018-01-01 11:51:12</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>651</th>\n",
+              "      <td>975.383864</td>\n",
+              "      <td>True</td>\n",
+              "      <td>...</td>\n",
+              "      <td>2</td>\n",
+              "      <td>2018-01-03 21:13:17</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>950</th>\n",
+              "      <td>907.836523</td>\n",
+              "      <td>True</td>\n",
+              "      <td>...</td>\n",
+              "      <td>2</td>\n",
+              "      <td>2018-01-03 05:14:51</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>...</th>\n",
+              "      <td>...</td>\n",
+              "      <td>...</td>\n",
+              "      <td>...</td>\n",
+              "      <td>...</td>\n",
+              "      <td>...</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>12820</th>\n",
+              "      <td>909.973606</td>\n",
+              "      <td>True</td>\n",
+              "      <td>...</td>\n",
+              "      <td>5</td>\n",
+              "      <td>2018-02-10 05:11:35</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>12906</th>\n",
+              "      <td>983.429244</td>\n",
+              "      <td>True</td>\n",
+              "      <td>...</td>\n",
+              "      <td>6</td>\n",
+              "      <td>2018-02-11 06:19:58</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>12918</th>\n",
+              "      <td>1136.678150</td>\n",
+              "      <td>True</td>\n",
+              "      <td>...</td>\n",
+              "      <td>6</td>\n",
+              "      <td>2018-02-11 16:03:10</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>12919</th>\n",
+              "      <td>1105.211803</td>\n",
+              "      <td>True</td>\n",
+              "      <td>...</td>\n",
+              "      <td>6</td>\n",
+              "      <td>2018-02-11 05:36:05</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>13013</th>\n",
+              "      <td>1055.350213</td>\n",
+              "      <td>True</td>\n",
+              "      <td>...</td>\n",
+              "      <td>6</td>\n",
+              "      <td>2018-02-11 13:20:16</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "<p>68 rows × 27 columns</p>\n",
+              "</div>\n",
+              "    <div class=\"colab-df-buttons\">\n",
+              "\n",
+              "  <div class=\"colab-df-container\">\n",
+              "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-e2228412-ba39-472a-8ecb-703ccdb66ee0')\"\n",
+              "            title=\"Convert this dataframe to an interactive table.\"\n",
+              "            style=\"display:none;\">\n",
+              "\n",
+              "  <svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\" viewBox=\"0 -960 960 960\">\n",
+              "    <path d=\"M120-120v-720h720v720H120Zm60-500h600v-160H180v160Zm220 220h160v-160H400v160Zm0 220h160v-160H400v160ZM180-400h160v-160H180v160Zm440 0h160v-160H620v160ZM180-180h160v-160H180v160Zm440 0h160v-160H620v160Z\"/>\n",
+              "  </svg>\n",
+              "    </button>\n",
+              "\n",
+              "  <style>\n",
+              "    .colab-df-container {\n",
+              "      display:flex;\n",
+              "      gap: 12px;\n",
+              "    }\n",
+              "\n",
+              "    .colab-df-convert {\n",
+              "      background-color: #E8F0FE;\n",
+              "      border: none;\n",
+              "      border-radius: 50%;\n",
+              "      cursor: pointer;\n",
+              "      display: none;\n",
+              "      fill: #1967D2;\n",
+              "      height: 32px;\n",
+              "      padding: 0 0 0 0;\n",
+              "      width: 32px;\n",
+              "    }\n",
+              "\n",
+              "    .colab-df-convert:hover {\n",
+              "      background-color: #E2EBFA;\n",
+              "      box-shadow: 0px 1px 2px rgba(60, 64, 67, 0.3), 0px 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
+              "      fill: #174EA6;\n",
+              "    }\n",
+              "\n",
+              "    .colab-df-buttons div {\n",
+              "      margin-bottom: 4px;\n",
+              "    }\n",
+              "\n",
+              "    [theme=dark] .colab-df-convert {\n",
+              "      background-color: #3B4455;\n",
+              "      fill: #D2E3FC;\n",
+              "    }\n",
+              "\n",
+              "    [theme=dark] .colab-df-convert:hover {\n",
+              "      background-color: #434B5C;\n",
+              "      box-shadow: 0px 1px 3px 1px rgba(0, 0, 0, 0.15);\n",
+              "      filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.3));\n",
+              "      fill: #FFFFFF;\n",
+              "    }\n",
+              "  </style>\n",
+              "\n",
+              "    <script>\n",
+              "      const buttonEl =\n",
+              "        document.querySelector('#df-e2228412-ba39-472a-8ecb-703ccdb66ee0 button.colab-df-convert');\n",
+              "      buttonEl.style.display =\n",
+              "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
+              "\n",
+              "      async function convertToInteractive(key) {\n",
+              "        const element = document.querySelector('#df-e2228412-ba39-472a-8ecb-703ccdb66ee0');\n",
+              "        const dataTable =\n",
+              "          await google.colab.kernel.invokeFunction('convertToInteractive',\n",
+              "                                                    [key], {});\n",
+              "        if (!dataTable) return;\n",
+              "\n",
+              "        const docLinkHtml = 'Like what you see? Visit the ' +\n",
+              "          '<a target=\"_blank\" href=https://colab.research.google.com/notebooks/data_table.ipynb>data table notebook</a>'\n",
+              "          + ' to learn more about interactive tables.';\n",
+              "        element.innerHTML = '';\n",
+              "        dataTable['output_type'] = 'display_data';\n",
+              "        await google.colab.output.renderOutput(dataTable, element);\n",
+              "        const docLink = document.createElement('div');\n",
+              "        docLink.innerHTML = docLinkHtml;\n",
+              "        element.appendChild(docLink);\n",
+              "      }\n",
+              "    </script>\n",
+              "  </div>\n",
+              "\n",
+              "\n",
+              "<div id=\"df-af7efa3e-1879-4963-a549-be22cdde18ef\">\n",
+              "  <button class=\"colab-df-quickchart\" onclick=\"quickchart('df-af7efa3e-1879-4963-a549-be22cdde18ef')\"\n",
+              "            title=\"Suggest charts.\"\n",
+              "            style=\"display:none;\">\n",
+              "\n",
+              "<svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\"viewBox=\"0 0 24 24\"\n",
+              "     width=\"24px\">\n",
+              "    <g>\n",
+              "        <path d=\"M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zM9 17H7v-7h2v7zm4 0h-2V7h2v10zm4 0h-2v-4h2v4z\"/>\n",
+              "    </g>\n",
+              "</svg>\n",
+              "  </button>\n",
+              "\n",
+              "<style>\n",
+              "  .colab-df-quickchart {\n",
+              "      --bg-color: #E8F0FE;\n",
+              "      --fill-color: #1967D2;\n",
+              "      --hover-bg-color: #E2EBFA;\n",
+              "      --hover-fill-color: #174EA6;\n",
+              "      --disabled-fill-color: #AAA;\n",
+              "      --disabled-bg-color: #DDD;\n",
+              "  }\n",
+              "\n",
+              "  [theme=dark] .colab-df-quickchart {\n",
+              "      --bg-color: #3B4455;\n",
+              "      --fill-color: #D2E3FC;\n",
+              "      --hover-bg-color: #434B5C;\n",
+              "      --hover-fill-color: #FFFFFF;\n",
+              "      --disabled-bg-color: #3B4455;\n",
+              "      --disabled-fill-color: #666;\n",
+              "  }\n",
+              "\n",
+              "  .colab-df-quickchart {\n",
+              "    background-color: var(--bg-color);\n",
+              "    border: none;\n",
+              "    border-radius: 50%;\n",
+              "    cursor: pointer;\n",
+              "    display: none;\n",
+              "    fill: var(--fill-color);\n",
+              "    height: 32px;\n",
+              "    padding: 0;\n",
+              "    width: 32px;\n",
+              "  }\n",
+              "\n",
+              "  .colab-df-quickchart:hover {\n",
+              "    background-color: var(--hover-bg-color);\n",
+              "    box-shadow: 0 1px 2px rgba(60, 64, 67, 0.3), 0 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
+              "    fill: var(--button-hover-fill-color);\n",
+              "  }\n",
+              "\n",
+              "  .colab-df-quickchart-complete:disabled,\n",
+              "  .colab-df-quickchart-complete:disabled:hover {\n",
+              "    background-color: var(--disabled-bg-color);\n",
+              "    fill: var(--disabled-fill-color);\n",
+              "    box-shadow: none;\n",
+              "  }\n",
+              "\n",
+              "  .colab-df-spinner {\n",
+              "    border: 2px solid var(--fill-color);\n",
+              "    border-color: transparent;\n",
+              "    border-bottom-color: var(--fill-color);\n",
+              "    animation:\n",
+              "      spin 1s steps(1) infinite;\n",
+              "  }\n",
+              "\n",
+              "  @keyframes spin {\n",
+              "    0% {\n",
+              "      border-color: transparent;\n",
+              "      border-bottom-color: var(--fill-color);\n",
+              "      border-left-color: var(--fill-color);\n",
+              "    }\n",
+              "    20% {\n",
+              "      border-color: transparent;\n",
+              "      border-left-color: var(--fill-color);\n",
+              "      border-top-color: var(--fill-color);\n",
+              "    }\n",
+              "    30% {\n",
+              "      border-color: transparent;\n",
+              "      border-left-color: var(--fill-color);\n",
+              "      border-top-color: var(--fill-color);\n",
+              "      border-right-color: var(--fill-color);\n",
+              "    }\n",
+              "    40% {\n",
+              "      border-color: transparent;\n",
+              "      border-right-color: var(--fill-color);\n",
+              "      border-top-color: var(--fill-color);\n",
+              "    }\n",
+              "    60% {\n",
+              "      border-color: transparent;\n",
+              "      border-right-color: var(--fill-color);\n",
+              "    }\n",
+              "    80% {\n",
+              "      border-color: transparent;\n",
+              "      border-right-color: var(--fill-color);\n",
+              "      border-bottom-color: var(--fill-color);\n",
+              "    }\n",
+              "    90% {\n",
+              "      border-color: transparent;\n",
+              "      border-bottom-color: var(--fill-color);\n",
+              "    }\n",
+              "  }\n",
+              "</style>\n",
+              "\n",
+              "  <script>\n",
+              "    async function quickchart(key) {\n",
+              "      const quickchartButtonEl =\n",
+              "        document.querySelector('#' + key + ' button');\n",
+              "      quickchartButtonEl.disabled = true;  // To prevent multiple clicks.\n",
+              "      quickchartButtonEl.classList.add('colab-df-spinner');\n",
+              "      try {\n",
+              "        const charts = await google.colab.kernel.invokeFunction(\n",
+              "            'suggestCharts', [key], {});\n",
+              "      } catch (error) {\n",
+              "        console.error('Error during call to suggestCharts:', error);\n",
+              "      }\n",
+              "      quickchartButtonEl.classList.remove('colab-df-spinner');\n",
+              "      quickchartButtonEl.classList.add('colab-df-quickchart-complete');\n",
+              "    }\n",
+              "    (() => {\n",
+              "      let quickchartButtonEl =\n",
+              "        document.querySelector('#df-af7efa3e-1879-4963-a549-be22cdde18ef button');\n",
+              "      quickchartButtonEl.style.display =\n",
+              "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
+              "    })();\n",
+              "  </script>\n",
+              "</div>\n",
+              "    </div>\n",
+              "  </div>\n"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 33
+        }
+      ],
+      "source": [
+        "pd_flights.query('Carrier == \"Kibana Airlines\" & AvgTicketPrice > 900.0 & Cancelled == True')"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "BOtIJQ8iNRFb"
+      },
+      "source": [
+        "`eland.DataFrame.query` requires qualifier on bool i.e.\n",
+        "\n",
+        "`ed_flights.query('Carrier == \"Kibana Airlines\" & AvgTicketPrice > 900.0 & Cancelled')` fails"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 34,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2021-12-15T20:24:44.317223Z",
+          "iopub.status.busy": "2021-12-15T20:24:44.316680Z",
+          "iopub.status.idle": "2021-12-15T20:24:46.365286Z",
+          "shell.execute_reply": "2021-12-15T20:24:46.366706Z"
+        },
+        "pycharm": {
+          "is_executing": false
+        },
+        "id": "BQY-QkAENRFb",
+        "outputId": "4883043c-d971-472d-b17c-bbbb57f85d4e",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "query() failed as expected: TypeError(\"Cannot interpret '{'terms': {'Carrier': ['Kibana Airlines']}}' as a data type\").\n"
+          ]
+        }
+      ],
+      "source": [
+        "try:\n",
+        "  ed_flights.query('Carrier == \"Kibana Airlines\" & AvgTicketPrice > 900.0 & Cancelled == True')\n",
+        "except Exception as e:\n",
+        "  print(f\"query() failed as expected: {repr(e)}.\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "u669zWowNRFb"
+      },
+      "source": [
+        "#### Boolean indexing query"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 35,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2021-12-15T20:24:46.417274Z",
+          "iopub.status.busy": "2021-12-15T20:24:46.416156Z",
+          "iopub.status.idle": "2021-12-15T20:24:46.421120Z",
+          "shell.execute_reply": "2021-12-15T20:24:46.421781Z"
+        },
+        "pycharm": {
+          "is_executing": false
+        },
+        "id": "f59Szl_9NRFc",
+        "outputId": "5d4a9d8c-e384-4b1b-97a9-8be3ec1bc35f",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 424
+        }
+      },
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "       AvgTicketPrice  Cancelled  ... dayOfWeek           timestamp\n",
+              "8          960.869736       True  ...         0 2018-01-01 12:09:35\n",
+              "26         975.812632       True  ...         0 2018-01-01 15:38:32\n",
+              "311        946.358410       True  ...         0 2018-01-01 11:51:12\n",
+              "651        975.383864       True  ...         2 2018-01-03 21:13:17\n",
+              "950        907.836523       True  ...         2 2018-01-03 05:14:51\n",
+              "...               ...        ...  ...       ...                 ...\n",
+              "12820      909.973606       True  ...         5 2018-02-10 05:11:35\n",
+              "12906      983.429244       True  ...         6 2018-02-11 06:19:58\n",
+              "12918     1136.678150       True  ...         6 2018-02-11 16:03:10\n",
+              "12919     1105.211803       True  ...         6 2018-02-11 05:36:05\n",
+              "13013     1055.350213       True  ...         6 2018-02-11 13:20:16\n",
+              "\n",
+              "[68 rows x 27 columns]"
+            ],
+            "text/html": [
+              "\n",
+              "  <div id=\"df-3fe16129-dcce-4cd2-9e51-4677c46f253d\" class=\"colab-df-container\">\n",
+              "    <div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>AvgTicketPrice</th>\n",
+              "      <th>Cancelled</th>\n",
+              "      <th>...</th>\n",
+              "      <th>dayOfWeek</th>\n",
+              "      <th>timestamp</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>8</th>\n",
+              "      <td>960.869736</td>\n",
+              "      <td>True</td>\n",
+              "      <td>...</td>\n",
+              "      <td>0</td>\n",
+              "      <td>2018-01-01 12:09:35</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>26</th>\n",
+              "      <td>975.812632</td>\n",
+              "      <td>True</td>\n",
+              "      <td>...</td>\n",
+              "      <td>0</td>\n",
+              "      <td>2018-01-01 15:38:32</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>311</th>\n",
+              "      <td>946.358410</td>\n",
+              "      <td>True</td>\n",
+              "      <td>...</td>\n",
+              "      <td>0</td>\n",
+              "      <td>2018-01-01 11:51:12</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>651</th>\n",
+              "      <td>975.383864</td>\n",
+              "      <td>True</td>\n",
+              "      <td>...</td>\n",
+              "      <td>2</td>\n",
+              "      <td>2018-01-03 21:13:17</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>950</th>\n",
+              "      <td>907.836523</td>\n",
+              "      <td>True</td>\n",
+              "      <td>...</td>\n",
+              "      <td>2</td>\n",
+              "      <td>2018-01-03 05:14:51</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>...</th>\n",
+              "      <td>...</td>\n",
+              "      <td>...</td>\n",
+              "      <td>...</td>\n",
+              "      <td>...</td>\n",
+              "      <td>...</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>12820</th>\n",
+              "      <td>909.973606</td>\n",
+              "      <td>True</td>\n",
+              "      <td>...</td>\n",
+              "      <td>5</td>\n",
+              "      <td>2018-02-10 05:11:35</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>12906</th>\n",
+              "      <td>983.429244</td>\n",
+              "      <td>True</td>\n",
+              "      <td>...</td>\n",
+              "      <td>6</td>\n",
+              "      <td>2018-02-11 06:19:58</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>12918</th>\n",
+              "      <td>1136.678150</td>\n",
+              "      <td>True</td>\n",
+              "      <td>...</td>\n",
+              "      <td>6</td>\n",
+              "      <td>2018-02-11 16:03:10</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>12919</th>\n",
+              "      <td>1105.211803</td>\n",
+              "      <td>True</td>\n",
+              "      <td>...</td>\n",
+              "      <td>6</td>\n",
+              "      <td>2018-02-11 05:36:05</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>13013</th>\n",
+              "      <td>1055.350213</td>\n",
+              "      <td>True</td>\n",
+              "      <td>...</td>\n",
+              "      <td>6</td>\n",
+              "      <td>2018-02-11 13:20:16</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "<p>68 rows × 27 columns</p>\n",
+              "</div>\n",
+              "    <div class=\"colab-df-buttons\">\n",
+              "\n",
+              "  <div class=\"colab-df-container\">\n",
+              "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-3fe16129-dcce-4cd2-9e51-4677c46f253d')\"\n",
+              "            title=\"Convert this dataframe to an interactive table.\"\n",
+              "            style=\"display:none;\">\n",
+              "\n",
+              "  <svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\" viewBox=\"0 -960 960 960\">\n",
+              "    <path d=\"M120-120v-720h720v720H120Zm60-500h600v-160H180v160Zm220 220h160v-160H400v160Zm0 220h160v-160H400v160ZM180-400h160v-160H180v160Zm440 0h160v-160H620v160ZM180-180h160v-160H180v160Zm440 0h160v-160H620v160Z\"/>\n",
+              "  </svg>\n",
+              "    </button>\n",
+              "\n",
+              "  <style>\n",
+              "    .colab-df-container {\n",
+              "      display:flex;\n",
+              "      gap: 12px;\n",
+              "    }\n",
+              "\n",
+              "    .colab-df-convert {\n",
+              "      background-color: #E8F0FE;\n",
+              "      border: none;\n",
+              "      border-radius: 50%;\n",
+              "      cursor: pointer;\n",
+              "      display: none;\n",
+              "      fill: #1967D2;\n",
+              "      height: 32px;\n",
+              "      padding: 0 0 0 0;\n",
+              "      width: 32px;\n",
+              "    }\n",
+              "\n",
+              "    .colab-df-convert:hover {\n",
+              "      background-color: #E2EBFA;\n",
+              "      box-shadow: 0px 1px 2px rgba(60, 64, 67, 0.3), 0px 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
+              "      fill: #174EA6;\n",
+              "    }\n",
+              "\n",
+              "    .colab-df-buttons div {\n",
+              "      margin-bottom: 4px;\n",
+              "    }\n",
+              "\n",
+              "    [theme=dark] .colab-df-convert {\n",
+              "      background-color: #3B4455;\n",
+              "      fill: #D2E3FC;\n",
+              "    }\n",
+              "\n",
+              "    [theme=dark] .colab-df-convert:hover {\n",
+              "      background-color: #434B5C;\n",
+              "      box-shadow: 0px 1px 3px 1px rgba(0, 0, 0, 0.15);\n",
+              "      filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.3));\n",
+              "      fill: #FFFFFF;\n",
+              "    }\n",
+              "  </style>\n",
+              "\n",
+              "    <script>\n",
+              "      const buttonEl =\n",
+              "        document.querySelector('#df-3fe16129-dcce-4cd2-9e51-4677c46f253d button.colab-df-convert');\n",
+              "      buttonEl.style.display =\n",
+              "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
+              "\n",
+              "      async function convertToInteractive(key) {\n",
+              "        const element = document.querySelector('#df-3fe16129-dcce-4cd2-9e51-4677c46f253d');\n",
+              "        const dataTable =\n",
+              "          await google.colab.kernel.invokeFunction('convertToInteractive',\n",
+              "                                                    [key], {});\n",
+              "        if (!dataTable) return;\n",
+              "\n",
+              "        const docLinkHtml = 'Like what you see? Visit the ' +\n",
+              "          '<a target=\"_blank\" href=https://colab.research.google.com/notebooks/data_table.ipynb>data table notebook</a>'\n",
+              "          + ' to learn more about interactive tables.';\n",
+              "        element.innerHTML = '';\n",
+              "        dataTable['output_type'] = 'display_data';\n",
+              "        await google.colab.output.renderOutput(dataTable, element);\n",
+              "        const docLink = document.createElement('div');\n",
+              "        docLink.innerHTML = docLinkHtml;\n",
+              "        element.appendChild(docLink);\n",
+              "      }\n",
+              "    </script>\n",
+              "  </div>\n",
+              "\n",
+              "\n",
+              "<div id=\"df-8bdd4957-d9f7-4474-bad6-c2951e1ece54\">\n",
+              "  <button class=\"colab-df-quickchart\" onclick=\"quickchart('df-8bdd4957-d9f7-4474-bad6-c2951e1ece54')\"\n",
+              "            title=\"Suggest charts.\"\n",
+              "            style=\"display:none;\">\n",
+              "\n",
+              "<svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\"viewBox=\"0 0 24 24\"\n",
+              "     width=\"24px\">\n",
+              "    <g>\n",
+              "        <path d=\"M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zM9 17H7v-7h2v7zm4 0h-2V7h2v10zm4 0h-2v-4h2v4z\"/>\n",
+              "    </g>\n",
+              "</svg>\n",
+              "  </button>\n",
+              "\n",
+              "<style>\n",
+              "  .colab-df-quickchart {\n",
+              "      --bg-color: #E8F0FE;\n",
+              "      --fill-color: #1967D2;\n",
+              "      --hover-bg-color: #E2EBFA;\n",
+              "      --hover-fill-color: #174EA6;\n",
+              "      --disabled-fill-color: #AAA;\n",
+              "      --disabled-bg-color: #DDD;\n",
+              "  }\n",
+              "\n",
+              "  [theme=dark] .colab-df-quickchart {\n",
+              "      --bg-color: #3B4455;\n",
+              "      --fill-color: #D2E3FC;\n",
+              "      --hover-bg-color: #434B5C;\n",
+              "      --hover-fill-color: #FFFFFF;\n",
+              "      --disabled-bg-color: #3B4455;\n",
+              "      --disabled-fill-color: #666;\n",
+              "  }\n",
+              "\n",
+              "  .colab-df-quickchart {\n",
+              "    background-color: var(--bg-color);\n",
+              "    border: none;\n",
+              "    border-radius: 50%;\n",
+              "    cursor: pointer;\n",
+              "    display: none;\n",
+              "    fill: var(--fill-color);\n",
+              "    height: 32px;\n",
+              "    padding: 0;\n",
+              "    width: 32px;\n",
+              "  }\n",
+              "\n",
+              "  .colab-df-quickchart:hover {\n",
+              "    background-color: var(--hover-bg-color);\n",
+              "    box-shadow: 0 1px 2px rgba(60, 64, 67, 0.3), 0 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
+              "    fill: var(--button-hover-fill-color);\n",
+              "  }\n",
+              "\n",
+              "  .colab-df-quickchart-complete:disabled,\n",
+              "  .colab-df-quickchart-complete:disabled:hover {\n",
+              "    background-color: var(--disabled-bg-color);\n",
+              "    fill: var(--disabled-fill-color);\n",
+              "    box-shadow: none;\n",
+              "  }\n",
+              "\n",
+              "  .colab-df-spinner {\n",
+              "    border: 2px solid var(--fill-color);\n",
+              "    border-color: transparent;\n",
+              "    border-bottom-color: var(--fill-color);\n",
+              "    animation:\n",
+              "      spin 1s steps(1) infinite;\n",
+              "  }\n",
+              "\n",
+              "  @keyframes spin {\n",
+              "    0% {\n",
+              "      border-color: transparent;\n",
+              "      border-bottom-color: var(--fill-color);\n",
+              "      border-left-color: var(--fill-color);\n",
+              "    }\n",
+              "    20% {\n",
+              "      border-color: transparent;\n",
+              "      border-left-color: var(--fill-color);\n",
+              "      border-top-color: var(--fill-color);\n",
+              "    }\n",
+              "    30% {\n",
+              "      border-color: transparent;\n",
+              "      border-left-color: var(--fill-color);\n",
+              "      border-top-color: var(--fill-color);\n",
+              "      border-right-color: var(--fill-color);\n",
+              "    }\n",
+              "    40% {\n",
+              "      border-color: transparent;\n",
+              "      border-right-color: var(--fill-color);\n",
+              "      border-top-color: var(--fill-color);\n",
+              "    }\n",
+              "    60% {\n",
+              "      border-color: transparent;\n",
+              "      border-right-color: var(--fill-color);\n",
+              "    }\n",
+              "    80% {\n",
+              "      border-color: transparent;\n",
+              "      border-right-color: var(--fill-color);\n",
+              "      border-bottom-color: var(--fill-color);\n",
+              "    }\n",
+              "    90% {\n",
+              "      border-color: transparent;\n",
+              "      border-bottom-color: var(--fill-color);\n",
+              "    }\n",
+              "  }\n",
+              "</style>\n",
+              "\n",
+              "  <script>\n",
+              "    async function quickchart(key) {\n",
+              "      const quickchartButtonEl =\n",
+              "        document.querySelector('#' + key + ' button');\n",
+              "      quickchartButtonEl.disabled = true;  // To prevent multiple clicks.\n",
+              "      quickchartButtonEl.classList.add('colab-df-spinner');\n",
+              "      try {\n",
+              "        const charts = await google.colab.kernel.invokeFunction(\n",
+              "            'suggestCharts', [key], {});\n",
+              "      } catch (error) {\n",
+              "        console.error('Error during call to suggestCharts:', error);\n",
+              "      }\n",
+              "      quickchartButtonEl.classList.remove('colab-df-spinner');\n",
+              "      quickchartButtonEl.classList.add('colab-df-quickchart-complete');\n",
+              "    }\n",
+              "    (() => {\n",
+              "      let quickchartButtonEl =\n",
+              "        document.querySelector('#df-8bdd4957-d9f7-4474-bad6-c2951e1ece54 button');\n",
+              "      quickchartButtonEl.style.display =\n",
+              "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
+              "    })();\n",
+              "  </script>\n",
+              "</div>\n",
+              "    </div>\n",
+              "  </div>\n"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 35
+        }
+      ],
+      "source": [
+        "pd_flights[(pd_flights.Carrier==\"Kibana Airlines\") &\n",
+        "           (pd_flights.AvgTicketPrice > 900.0) &\n",
+        "           (pd_flights.Cancelled == True)]"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 36,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2021-12-15T20:24:46.431697Z",
+          "iopub.status.busy": "2021-12-15T20:24:46.431114Z",
+          "iopub.status.idle": "2021-12-15T20:24:48.414684Z",
+          "shell.execute_reply": "2021-12-15T20:24:48.415148Z"
+        },
+        "pycharm": {
+          "is_executing": false
+        },
+        "id": "ZiewRsffNRFc",
+        "outputId": "1df6d2d6-2164-4e06-abf4-4922aac5e42a",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 424
+        }
+      },
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "       AvgTicketPrice  Cancelled  ... dayOfWeek           timestamp\n",
+              "8          960.869736       True  ...         0 2018-01-01 12:09:35\n",
+              "26         975.812632       True  ...         0 2018-01-01 15:38:32\n",
+              "311        946.358410       True  ...         0 2018-01-01 11:51:12\n",
+              "651        975.383864       True  ...         2 2018-01-03 21:13:17\n",
+              "950        907.836523       True  ...         2 2018-01-03 05:14:51\n",
+              "...               ...        ...  ...       ...                 ...\n",
+              "12820      909.973606       True  ...         5 2018-02-10 05:11:35\n",
+              "12906      983.429244       True  ...         6 2018-02-11 06:19:58\n",
+              "12918     1136.678150       True  ...         6 2018-02-11 16:03:10\n",
+              "12919     1105.211803       True  ...         6 2018-02-11 05:36:05\n",
+              "13013     1055.350213       True  ...         6 2018-02-11 13:20:16\n",
+              "\n",
+              "[68 rows x 27 columns]"
+            ],
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>AvgTicketPrice</th>\n",
+              "      <th>Cancelled</th>\n",
+              "      <th>...</th>\n",
+              "      <th>dayOfWeek</th>\n",
+              "      <th>timestamp</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>8</th>\n",
+              "      <td>960.869736</td>\n",
+              "      <td>True</td>\n",
+              "      <td>...</td>\n",
+              "      <td>0</td>\n",
+              "      <td>2018-01-01 12:09:35</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>26</th>\n",
+              "      <td>975.812632</td>\n",
+              "      <td>True</td>\n",
+              "      <td>...</td>\n",
+              "      <td>0</td>\n",
+              "      <td>2018-01-01 15:38:32</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>311</th>\n",
+              "      <td>946.358410</td>\n",
+              "      <td>True</td>\n",
+              "      <td>...</td>\n",
+              "      <td>0</td>\n",
+              "      <td>2018-01-01 11:51:12</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>651</th>\n",
+              "      <td>975.383864</td>\n",
+              "      <td>True</td>\n",
+              "      <td>...</td>\n",
+              "      <td>2</td>\n",
+              "      <td>2018-01-03 21:13:17</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>950</th>\n",
+              "      <td>907.836523</td>\n",
+              "      <td>True</td>\n",
+              "      <td>...</td>\n",
+              "      <td>2</td>\n",
+              "      <td>2018-01-03 05:14:51</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>...</th>\n",
+              "      <td>...</td>\n",
+              "      <td>...</td>\n",
+              "      <td>...</td>\n",
+              "      <td>...</td>\n",
+              "      <td>...</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>12820</th>\n",
+              "      <td>909.973606</td>\n",
+              "      <td>True</td>\n",
+              "      <td>...</td>\n",
+              "      <td>5</td>\n",
+              "      <td>2018-02-10 05:11:35</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>12906</th>\n",
+              "      <td>983.429244</td>\n",
+              "      <td>True</td>\n",
+              "      <td>...</td>\n",
+              "      <td>6</td>\n",
+              "      <td>2018-02-11 06:19:58</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>12918</th>\n",
+              "      <td>1136.678150</td>\n",
+              "      <td>True</td>\n",
+              "      <td>...</td>\n",
+              "      <td>6</td>\n",
+              "      <td>2018-02-11 16:03:10</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>12919</th>\n",
+              "      <td>1105.211803</td>\n",
+              "      <td>True</td>\n",
+              "      <td>...</td>\n",
+              "      <td>6</td>\n",
+              "      <td>2018-02-11 05:36:05</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>13013</th>\n",
+              "      <td>1055.350213</td>\n",
+              "      <td>True</td>\n",
+              "      <td>...</td>\n",
+              "      <td>6</td>\n",
+              "      <td>2018-02-11 13:20:16</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>\n",
+              "<p>68 rows × 27 columns</p>"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 36
+        }
+      ],
+      "source": [
+        "ed_flights[(ed_flights.Carrier==\"Kibana Airlines\") &\n",
+        "           (ed_flights.AvgTicketPrice > 900.0) &\n",
+        "           (ed_flights.Cancelled == True)]"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "2aEJXYr3NRFc"
+      },
+      "source": [
+        "## Function application, GroupBy & window"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "PLNjRajUNRFd"
+      },
+      "source": [
+        "### DataFrame.aggs"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 37,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2021-12-15T20:24:48.421015Z",
+          "iopub.status.busy": "2021-12-15T20:24:48.420431Z",
+          "iopub.status.idle": "2021-12-15T20:24:48.428382Z",
+          "shell.execute_reply": "2021-12-15T20:24:48.428690Z"
+        },
+        "pycharm": {
+          "is_executing": false
+        },
+        "id": "-j7Hwl9FNRFd",
+        "outputId": "3aa241a3-f1b9-4853-f177-4d83eec89f47",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 143
+        }
+      },
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "     DistanceKilometers  AvgTicketPrice\n",
+              "sum        9.261629e+07    8.204365e+06\n",
+              "min        0.000000e+00    1.000205e+02\n",
+              "std        4.578438e+03    2.663969e+02"
+            ],
+            "text/html": [
+              "\n",
+              "  <div id=\"df-ffe34f9c-28c2-4b5d-ab31-094808fa43ac\" class=\"colab-df-container\">\n",
+              "    <div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>DistanceKilometers</th>\n",
+              "      <th>AvgTicketPrice</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>sum</th>\n",
+              "      <td>9.261629e+07</td>\n",
+              "      <td>8.204365e+06</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>min</th>\n",
+              "      <td>0.000000e+00</td>\n",
+              "      <td>1.000205e+02</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>std</th>\n",
+              "      <td>4.578438e+03</td>\n",
+              "      <td>2.663969e+02</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>\n",
+              "    <div class=\"colab-df-buttons\">\n",
+              "\n",
+              "  <div class=\"colab-df-container\">\n",
+              "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-ffe34f9c-28c2-4b5d-ab31-094808fa43ac')\"\n",
+              "            title=\"Convert this dataframe to an interactive table.\"\n",
+              "            style=\"display:none;\">\n",
+              "\n",
+              "  <svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\" viewBox=\"0 -960 960 960\">\n",
+              "    <path d=\"M120-120v-720h720v720H120Zm60-500h600v-160H180v160Zm220 220h160v-160H400v160Zm0 220h160v-160H400v160ZM180-400h160v-160H180v160Zm440 0h160v-160H620v160ZM180-180h160v-160H180v160Zm440 0h160v-160H620v160Z\"/>\n",
+              "  </svg>\n",
+              "    </button>\n",
+              "\n",
+              "  <style>\n",
+              "    .colab-df-container {\n",
+              "      display:flex;\n",
+              "      gap: 12px;\n",
+              "    }\n",
+              "\n",
+              "    .colab-df-convert {\n",
+              "      background-color: #E8F0FE;\n",
+              "      border: none;\n",
+              "      border-radius: 50%;\n",
+              "      cursor: pointer;\n",
+              "      display: none;\n",
+              "      fill: #1967D2;\n",
+              "      height: 32px;\n",
+              "      padding: 0 0 0 0;\n",
+              "      width: 32px;\n",
+              "    }\n",
+              "\n",
+              "    .colab-df-convert:hover {\n",
+              "      background-color: #E2EBFA;\n",
+              "      box-shadow: 0px 1px 2px rgba(60, 64, 67, 0.3), 0px 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
+              "      fill: #174EA6;\n",
+              "    }\n",
+              "\n",
+              "    .colab-df-buttons div {\n",
+              "      margin-bottom: 4px;\n",
+              "    }\n",
+              "\n",
+              "    [theme=dark] .colab-df-convert {\n",
+              "      background-color: #3B4455;\n",
+              "      fill: #D2E3FC;\n",
+              "    }\n",
+              "\n",
+              "    [theme=dark] .colab-df-convert:hover {\n",
+              "      background-color: #434B5C;\n",
+              "      box-shadow: 0px 1px 3px 1px rgba(0, 0, 0, 0.15);\n",
+              "      filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.3));\n",
+              "      fill: #FFFFFF;\n",
+              "    }\n",
+              "  </style>\n",
+              "\n",
+              "    <script>\n",
+              "      const buttonEl =\n",
+              "        document.querySelector('#df-ffe34f9c-28c2-4b5d-ab31-094808fa43ac button.colab-df-convert');\n",
+              "      buttonEl.style.display =\n",
+              "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
+              "\n",
+              "      async function convertToInteractive(key) {\n",
+              "        const element = document.querySelector('#df-ffe34f9c-28c2-4b5d-ab31-094808fa43ac');\n",
+              "        const dataTable =\n",
+              "          await google.colab.kernel.invokeFunction('convertToInteractive',\n",
+              "                                                    [key], {});\n",
+              "        if (!dataTable) return;\n",
+              "\n",
+              "        const docLinkHtml = 'Like what you see? Visit the ' +\n",
+              "          '<a target=\"_blank\" href=https://colab.research.google.com/notebooks/data_table.ipynb>data table notebook</a>'\n",
+              "          + ' to learn more about interactive tables.';\n",
+              "        element.innerHTML = '';\n",
+              "        dataTable['output_type'] = 'display_data';\n",
+              "        await google.colab.output.renderOutput(dataTable, element);\n",
+              "        const docLink = document.createElement('div');\n",
+              "        docLink.innerHTML = docLinkHtml;\n",
+              "        element.appendChild(docLink);\n",
+              "      }\n",
+              "    </script>\n",
+              "  </div>\n",
+              "\n",
+              "\n",
+              "<div id=\"df-9052a490-cc56-456d-ba05-e4dcc27b91ac\">\n",
+              "  <button class=\"colab-df-quickchart\" onclick=\"quickchart('df-9052a490-cc56-456d-ba05-e4dcc27b91ac')\"\n",
+              "            title=\"Suggest charts.\"\n",
+              "            style=\"display:none;\">\n",
+              "\n",
+              "<svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\"viewBox=\"0 0 24 24\"\n",
+              "     width=\"24px\">\n",
+              "    <g>\n",
+              "        <path d=\"M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zM9 17H7v-7h2v7zm4 0h-2V7h2v10zm4 0h-2v-4h2v4z\"/>\n",
+              "    </g>\n",
+              "</svg>\n",
+              "  </button>\n",
+              "\n",
+              "<style>\n",
+              "  .colab-df-quickchart {\n",
+              "      --bg-color: #E8F0FE;\n",
+              "      --fill-color: #1967D2;\n",
+              "      --hover-bg-color: #E2EBFA;\n",
+              "      --hover-fill-color: #174EA6;\n",
+              "      --disabled-fill-color: #AAA;\n",
+              "      --disabled-bg-color: #DDD;\n",
+              "  }\n",
+              "\n",
+              "  [theme=dark] .colab-df-quickchart {\n",
+              "      --bg-color: #3B4455;\n",
+              "      --fill-color: #D2E3FC;\n",
+              "      --hover-bg-color: #434B5C;\n",
+              "      --hover-fill-color: #FFFFFF;\n",
+              "      --disabled-bg-color: #3B4455;\n",
+              "      --disabled-fill-color: #666;\n",
+              "  }\n",
+              "\n",
+              "  .colab-df-quickchart {\n",
+              "    background-color: var(--bg-color);\n",
+              "    border: none;\n",
+              "    border-radius: 50%;\n",
+              "    cursor: pointer;\n",
+              "    display: none;\n",
+              "    fill: var(--fill-color);\n",
+              "    height: 32px;\n",
+              "    padding: 0;\n",
+              "    width: 32px;\n",
+              "  }\n",
+              "\n",
+              "  .colab-df-quickchart:hover {\n",
+              "    background-color: var(--hover-bg-color);\n",
+              "    box-shadow: 0 1px 2px rgba(60, 64, 67, 0.3), 0 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
+              "    fill: var(--button-hover-fill-color);\n",
+              "  }\n",
+              "\n",
+              "  .colab-df-quickchart-complete:disabled,\n",
+              "  .colab-df-quickchart-complete:disabled:hover {\n",
+              "    background-color: var(--disabled-bg-color);\n",
+              "    fill: var(--disabled-fill-color);\n",
+              "    box-shadow: none;\n",
+              "  }\n",
+              "\n",
+              "  .colab-df-spinner {\n",
+              "    border: 2px solid var(--fill-color);\n",
+              "    border-color: transparent;\n",
+              "    border-bottom-color: var(--fill-color);\n",
+              "    animation:\n",
+              "      spin 1s steps(1) infinite;\n",
+              "  }\n",
+              "\n",
+              "  @keyframes spin {\n",
+              "    0% {\n",
+              "      border-color: transparent;\n",
+              "      border-bottom-color: var(--fill-color);\n",
+              "      border-left-color: var(--fill-color);\n",
+              "    }\n",
+              "    20% {\n",
+              "      border-color: transparent;\n",
+              "      border-left-color: var(--fill-color);\n",
+              "      border-top-color: var(--fill-color);\n",
+              "    }\n",
+              "    30% {\n",
+              "      border-color: transparent;\n",
+              "      border-left-color: var(--fill-color);\n",
+              "      border-top-color: var(--fill-color);\n",
+              "      border-right-color: var(--fill-color);\n",
+              "    }\n",
+              "    40% {\n",
+              "      border-color: transparent;\n",
+              "      border-right-color: var(--fill-color);\n",
+              "      border-top-color: var(--fill-color);\n",
+              "    }\n",
+              "    60% {\n",
+              "      border-color: transparent;\n",
+              "      border-right-color: var(--fill-color);\n",
+              "    }\n",
+              "    80% {\n",
+              "      border-color: transparent;\n",
+              "      border-right-color: var(--fill-color);\n",
+              "      border-bottom-color: var(--fill-color);\n",
+              "    }\n",
+              "    90% {\n",
+              "      border-color: transparent;\n",
+              "      border-bottom-color: var(--fill-color);\n",
+              "    }\n",
+              "  }\n",
+              "</style>\n",
+              "\n",
+              "  <script>\n",
+              "    async function quickchart(key) {\n",
+              "      const quickchartButtonEl =\n",
+              "        document.querySelector('#' + key + ' button');\n",
+              "      quickchartButtonEl.disabled = true;  // To prevent multiple clicks.\n",
+              "      quickchartButtonEl.classList.add('colab-df-spinner');\n",
+              "      try {\n",
+              "        const charts = await google.colab.kernel.invokeFunction(\n",
+              "            'suggestCharts', [key], {});\n",
+              "      } catch (error) {\n",
+              "        console.error('Error during call to suggestCharts:', error);\n",
+              "      }\n",
+              "      quickchartButtonEl.classList.remove('colab-df-spinner');\n",
+              "      quickchartButtonEl.classList.add('colab-df-quickchart-complete');\n",
+              "    }\n",
+              "    (() => {\n",
+              "      let quickchartButtonEl =\n",
+              "        document.querySelector('#df-9052a490-cc56-456d-ba05-e4dcc27b91ac button');\n",
+              "      quickchartButtonEl.style.display =\n",
+              "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
+              "    })();\n",
+              "  </script>\n",
+              "</div>\n",
+              "    </div>\n",
+              "  </div>\n"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 37
+        }
+      ],
+      "source": [
+        "pd_flights[['DistanceKilometers', 'AvgTicketPrice']].aggregate(['sum', 'min', 'std'])"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "BL2p1GPLNRFd"
+      },
+      "source": [
+        "`eland.DataFrame.aggregate` currently only supported numeric columns"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 38,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2021-12-15T20:24:48.433082Z",
+          "iopub.status.busy": "2021-12-15T20:24:48.432716Z",
+          "iopub.status.idle": "2021-12-15T20:24:48.541272Z",
+          "shell.execute_reply": "2021-12-15T20:24:48.542346Z"
+        },
+        "pycharm": {
+          "is_executing": false
+        },
+        "id": "ok4Ui8BhNRFe",
+        "outputId": "6d9ee598-2f23-4a7f-f42e-e181fbdc9426",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 143
+        }
+      },
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "     DistanceKilometers  AvgTicketPrice\n",
+              "sum        9.261629e+07    8.204365e+06\n",
+              "min        0.000000e+00    1.000205e+02\n",
+              "std        4.578614e+03    2.664071e+02"
+            ],
+            "text/html": [
+              "\n",
+              "  <div id=\"df-8bdad06d-4658-48ac-b77f-f54456dea62a\" class=\"colab-df-container\">\n",
+              "    <div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>DistanceKilometers</th>\n",
+              "      <th>AvgTicketPrice</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>sum</th>\n",
+              "      <td>9.261629e+07</td>\n",
+              "      <td>8.204365e+06</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>min</th>\n",
+              "      <td>0.000000e+00</td>\n",
+              "      <td>1.000205e+02</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>std</th>\n",
+              "      <td>4.578614e+03</td>\n",
+              "      <td>2.664071e+02</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>\n",
+              "    <div class=\"colab-df-buttons\">\n",
+              "\n",
+              "  <div class=\"colab-df-container\">\n",
+              "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-8bdad06d-4658-48ac-b77f-f54456dea62a')\"\n",
+              "            title=\"Convert this dataframe to an interactive table.\"\n",
+              "            style=\"display:none;\">\n",
+              "\n",
+              "  <svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\" viewBox=\"0 -960 960 960\">\n",
+              "    <path d=\"M120-120v-720h720v720H120Zm60-500h600v-160H180v160Zm220 220h160v-160H400v160Zm0 220h160v-160H400v160ZM180-400h160v-160H180v160Zm440 0h160v-160H620v160ZM180-180h160v-160H180v160Zm440 0h160v-160H620v160Z\"/>\n",
+              "  </svg>\n",
+              "    </button>\n",
+              "\n",
+              "  <style>\n",
+              "    .colab-df-container {\n",
+              "      display:flex;\n",
+              "      gap: 12px;\n",
+              "    }\n",
+              "\n",
+              "    .colab-df-convert {\n",
+              "      background-color: #E8F0FE;\n",
+              "      border: none;\n",
+              "      border-radius: 50%;\n",
+              "      cursor: pointer;\n",
+              "      display: none;\n",
+              "      fill: #1967D2;\n",
+              "      height: 32px;\n",
+              "      padding: 0 0 0 0;\n",
+              "      width: 32px;\n",
+              "    }\n",
+              "\n",
+              "    .colab-df-convert:hover {\n",
+              "      background-color: #E2EBFA;\n",
+              "      box-shadow: 0px 1px 2px rgba(60, 64, 67, 0.3), 0px 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
+              "      fill: #174EA6;\n",
+              "    }\n",
+              "\n",
+              "    .colab-df-buttons div {\n",
+              "      margin-bottom: 4px;\n",
+              "    }\n",
+              "\n",
+              "    [theme=dark] .colab-df-convert {\n",
+              "      background-color: #3B4455;\n",
+              "      fill: #D2E3FC;\n",
+              "    }\n",
+              "\n",
+              "    [theme=dark] .colab-df-convert:hover {\n",
+              "      background-color: #434B5C;\n",
+              "      box-shadow: 0px 1px 3px 1px rgba(0, 0, 0, 0.15);\n",
+              "      filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.3));\n",
+              "      fill: #FFFFFF;\n",
+              "    }\n",
+              "  </style>\n",
+              "\n",
+              "    <script>\n",
+              "      const buttonEl =\n",
+              "        document.querySelector('#df-8bdad06d-4658-48ac-b77f-f54456dea62a button.colab-df-convert');\n",
+              "      buttonEl.style.display =\n",
+              "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
+              "\n",
+              "      async function convertToInteractive(key) {\n",
+              "        const element = document.querySelector('#df-8bdad06d-4658-48ac-b77f-f54456dea62a');\n",
+              "        const dataTable =\n",
+              "          await google.colab.kernel.invokeFunction('convertToInteractive',\n",
+              "                                                    [key], {});\n",
+              "        if (!dataTable) return;\n",
+              "\n",
+              "        const docLinkHtml = 'Like what you see? Visit the ' +\n",
+              "          '<a target=\"_blank\" href=https://colab.research.google.com/notebooks/data_table.ipynb>data table notebook</a>'\n",
+              "          + ' to learn more about interactive tables.';\n",
+              "        element.innerHTML = '';\n",
+              "        dataTable['output_type'] = 'display_data';\n",
+              "        await google.colab.output.renderOutput(dataTable, element);\n",
+              "        const docLink = document.createElement('div');\n",
+              "        docLink.innerHTML = docLinkHtml;\n",
+              "        element.appendChild(docLink);\n",
+              "      }\n",
+              "    </script>\n",
+              "  </div>\n",
+              "\n",
+              "\n",
+              "<div id=\"df-82508f35-0ec3-402f-98df-b0ab6d857639\">\n",
+              "  <button class=\"colab-df-quickchart\" onclick=\"quickchart('df-82508f35-0ec3-402f-98df-b0ab6d857639')\"\n",
+              "            title=\"Suggest charts.\"\n",
+              "            style=\"display:none;\">\n",
+              "\n",
+              "<svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\"viewBox=\"0 0 24 24\"\n",
+              "     width=\"24px\">\n",
+              "    <g>\n",
+              "        <path d=\"M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zM9 17H7v-7h2v7zm4 0h-2V7h2v10zm4 0h-2v-4h2v4z\"/>\n",
+              "    </g>\n",
+              "</svg>\n",
+              "  </button>\n",
+              "\n",
+              "<style>\n",
+              "  .colab-df-quickchart {\n",
+              "      --bg-color: #E8F0FE;\n",
+              "      --fill-color: #1967D2;\n",
+              "      --hover-bg-color: #E2EBFA;\n",
+              "      --hover-fill-color: #174EA6;\n",
+              "      --disabled-fill-color: #AAA;\n",
+              "      --disabled-bg-color: #DDD;\n",
+              "  }\n",
+              "\n",
+              "  [theme=dark] .colab-df-quickchart {\n",
+              "      --bg-color: #3B4455;\n",
+              "      --fill-color: #D2E3FC;\n",
+              "      --hover-bg-color: #434B5C;\n",
+              "      --hover-fill-color: #FFFFFF;\n",
+              "      --disabled-bg-color: #3B4455;\n",
+              "      --disabled-fill-color: #666;\n",
+              "  }\n",
+              "\n",
+              "  .colab-df-quickchart {\n",
+              "    background-color: var(--bg-color);\n",
+              "    border: none;\n",
+              "    border-radius: 50%;\n",
+              "    cursor: pointer;\n",
+              "    display: none;\n",
+              "    fill: var(--fill-color);\n",
+              "    height: 32px;\n",
+              "    padding: 0;\n",
+              "    width: 32px;\n",
+              "  }\n",
+              "\n",
+              "  .colab-df-quickchart:hover {\n",
+              "    background-color: var(--hover-bg-color);\n",
+              "    box-shadow: 0 1px 2px rgba(60, 64, 67, 0.3), 0 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
+              "    fill: var(--button-hover-fill-color);\n",
+              "  }\n",
+              "\n",
+              "  .colab-df-quickchart-complete:disabled,\n",
+              "  .colab-df-quickchart-complete:disabled:hover {\n",
+              "    background-color: var(--disabled-bg-color);\n",
+              "    fill: var(--disabled-fill-color);\n",
+              "    box-shadow: none;\n",
+              "  }\n",
+              "\n",
+              "  .colab-df-spinner {\n",
+              "    border: 2px solid var(--fill-color);\n",
+              "    border-color: transparent;\n",
+              "    border-bottom-color: var(--fill-color);\n",
+              "    animation:\n",
+              "      spin 1s steps(1) infinite;\n",
+              "  }\n",
+              "\n",
+              "  @keyframes spin {\n",
+              "    0% {\n",
+              "      border-color: transparent;\n",
+              "      border-bottom-color: var(--fill-color);\n",
+              "      border-left-color: var(--fill-color);\n",
+              "    }\n",
+              "    20% {\n",
+              "      border-color: transparent;\n",
+              "      border-left-color: var(--fill-color);\n",
+              "      border-top-color: var(--fill-color);\n",
+              "    }\n",
+              "    30% {\n",
+              "      border-color: transparent;\n",
+              "      border-left-color: var(--fill-color);\n",
+              "      border-top-color: var(--fill-color);\n",
+              "      border-right-color: var(--fill-color);\n",
+              "    }\n",
+              "    40% {\n",
+              "      border-color: transparent;\n",
+              "      border-right-color: var(--fill-color);\n",
+              "      border-top-color: var(--fill-color);\n",
+              "    }\n",
+              "    60% {\n",
+              "      border-color: transparent;\n",
+              "      border-right-color: var(--fill-color);\n",
+              "    }\n",
+              "    80% {\n",
+              "      border-color: transparent;\n",
+              "      border-right-color: var(--fill-color);\n",
+              "      border-bottom-color: var(--fill-color);\n",
+              "    }\n",
+              "    90% {\n",
+              "      border-color: transparent;\n",
+              "      border-bottom-color: var(--fill-color);\n",
+              "    }\n",
+              "  }\n",
+              "</style>\n",
+              "\n",
+              "  <script>\n",
+              "    async function quickchart(key) {\n",
+              "      const quickchartButtonEl =\n",
+              "        document.querySelector('#' + key + ' button');\n",
+              "      quickchartButtonEl.disabled = true;  // To prevent multiple clicks.\n",
+              "      quickchartButtonEl.classList.add('colab-df-spinner');\n",
+              "      try {\n",
+              "        const charts = await google.colab.kernel.invokeFunction(\n",
+              "            'suggestCharts', [key], {});\n",
+              "      } catch (error) {\n",
+              "        console.error('Error during call to suggestCharts:', error);\n",
+              "      }\n",
+              "      quickchartButtonEl.classList.remove('colab-df-spinner');\n",
+              "      quickchartButtonEl.classList.add('colab-df-quickchart-complete');\n",
+              "    }\n",
+              "    (() => {\n",
+              "      let quickchartButtonEl =\n",
+              "        document.querySelector('#df-82508f35-0ec3-402f-98df-b0ab6d857639 button');\n",
+              "      quickchartButtonEl.style.display =\n",
+              "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
+              "    })();\n",
+              "  </script>\n",
+              "</div>\n",
+              "    </div>\n",
+              "  </div>\n"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 38
+        }
+      ],
+      "source": [
+        "ed_flights[['DistanceKilometers', 'AvgTicketPrice']].aggregate(['sum', 'min', 'std'])"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "v-49A_fDNRFe"
+      },
+      "source": [
+        "## Computations / descriptive stats"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "00OupOBTNRFe"
+      },
+      "source": [
+        "### DataFrame.count"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 39,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2021-12-15T20:24:48.574692Z",
+          "iopub.status.busy": "2021-12-15T20:24:48.574008Z",
+          "iopub.status.idle": "2021-12-15T20:24:48.580240Z",
+          "shell.execute_reply": "2021-12-15T20:24:48.579845Z"
+        },
+        "pycharm": {
+          "is_executing": false
+        },
+        "id": "-1b9NDszNRFe",
+        "outputId": "d788498d-a027-4fcf-b963-e1863cd3ad86",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
+      },
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "AvgTicketPrice    13059\n",
+              "Cancelled         13059\n",
+              "Carrier           13059\n",
+              "Dest              13059\n",
+              "DestAirportID     13059\n",
+              "                  ...  \n",
+              "OriginLocation    13059\n",
+              "OriginRegion      13059\n",
+              "OriginWeather     13059\n",
+              "dayOfWeek         13059\n",
+              "timestamp         13059\n",
+              "Length: 27, dtype: int64"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 39
+        }
+      ],
+      "source": [
+        "pd_flights.count()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 40,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2021-12-15T20:24:48.583948Z",
+          "iopub.status.busy": "2021-12-15T20:24:48.583565Z",
+          "iopub.status.idle": "2021-12-15T20:24:50.642201Z",
+          "shell.execute_reply": "2021-12-15T20:24:50.643158Z"
+        },
+        "pycharm": {
+          "is_executing": false
+        },
+        "id": "GjHLdmvPNRFf",
+        "outputId": "3cbfb5f9-b75d-4b1e-dcd1-8c735887ca51",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
+      },
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "AvgTicketPrice    13059\n",
+              "Cancelled         13059\n",
+              "Carrier           13059\n",
+              "Dest              13059\n",
+              "DestAirportID     13059\n",
+              "                  ...  \n",
+              "OriginLocation    13059\n",
+              "OriginRegion      13059\n",
+              "OriginWeather     13059\n",
+              "dayOfWeek         13059\n",
+              "timestamp         13059\n",
+              "Length: 27, dtype: int64"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 40
+        }
+      ],
+      "source": [
+        "ed_flights.count()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "tF40dPiPNRFf"
+      },
+      "source": [
+        "### DataFrame.describe"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 41,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2021-12-15T20:24:50.655939Z",
+          "iopub.status.busy": "2021-12-15T20:24:50.654654Z",
+          "iopub.status.idle": "2021-12-15T20:24:50.702251Z",
+          "shell.execute_reply": "2021-12-15T20:24:50.701757Z"
+        },
+        "pycharm": {
+          "is_executing": false
+        },
+        "id": "IKjmnuuBNRFf",
+        "outputId": "8a1418a2-f2e4-408c-8837-ff3626b307b8",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 330
+        }
+      },
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "       AvgTicketPrice  DistanceKilometers  ...  FlightTimeMin     dayOfWeek\n",
+              "count    13059.000000        13059.000000  ...   13059.000000  13059.000000\n",
+              "mean       628.253689         7092.142455  ...     511.127842      2.835975\n",
+              "std        266.396861         4578.438497  ...     334.753952      1.939439\n",
+              "min        100.020528            0.000000  ...       0.000000      0.000000\n",
+              "25%        409.893816         2459.705673  ...     252.333192      1.000000\n",
+              "50%        640.556668         7610.330866  ...     503.045170      3.000000\n",
+              "75%        842.185470         9736.637600  ...     720.416036      4.000000\n",
+              "max       1199.729053        19881.482315  ...    1902.902032      6.000000\n",
+              "\n",
+              "[8 rows x 7 columns]"
+            ],
+            "text/html": [
+              "\n",
+              "  <div id=\"df-ad1dcf82-a33c-4cc9-af15-8f33e0f886ac\" class=\"colab-df-container\">\n",
+              "    <div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>AvgTicketPrice</th>\n",
+              "      <th>DistanceKilometers</th>\n",
+              "      <th>...</th>\n",
+              "      <th>FlightTimeMin</th>\n",
+              "      <th>dayOfWeek</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>count</th>\n",
+              "      <td>13059.000000</td>\n",
+              "      <td>13059.000000</td>\n",
+              "      <td>...</td>\n",
+              "      <td>13059.000000</td>\n",
+              "      <td>13059.000000</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>mean</th>\n",
+              "      <td>628.253689</td>\n",
+              "      <td>7092.142455</td>\n",
+              "      <td>...</td>\n",
+              "      <td>511.127842</td>\n",
+              "      <td>2.835975</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>std</th>\n",
+              "      <td>266.396861</td>\n",
+              "      <td>4578.438497</td>\n",
+              "      <td>...</td>\n",
+              "      <td>334.753952</td>\n",
+              "      <td>1.939439</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>min</th>\n",
+              "      <td>100.020528</td>\n",
+              "      <td>0.000000</td>\n",
+              "      <td>...</td>\n",
+              "      <td>0.000000</td>\n",
+              "      <td>0.000000</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>25%</th>\n",
+              "      <td>409.893816</td>\n",
+              "      <td>2459.705673</td>\n",
+              "      <td>...</td>\n",
+              "      <td>252.333192</td>\n",
+              "      <td>1.000000</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>50%</th>\n",
+              "      <td>640.556668</td>\n",
+              "      <td>7610.330866</td>\n",
+              "      <td>...</td>\n",
+              "      <td>503.045170</td>\n",
+              "      <td>3.000000</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>75%</th>\n",
+              "      <td>842.185470</td>\n",
+              "      <td>9736.637600</td>\n",
+              "      <td>...</td>\n",
+              "      <td>720.416036</td>\n",
+              "      <td>4.000000</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>max</th>\n",
+              "      <td>1199.729053</td>\n",
+              "      <td>19881.482315</td>\n",
+              "      <td>...</td>\n",
+              "      <td>1902.902032</td>\n",
+              "      <td>6.000000</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "<p>8 rows × 7 columns</p>\n",
+              "</div>\n",
+              "    <div class=\"colab-df-buttons\">\n",
+              "\n",
+              "  <div class=\"colab-df-container\">\n",
+              "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-ad1dcf82-a33c-4cc9-af15-8f33e0f886ac')\"\n",
+              "            title=\"Convert this dataframe to an interactive table.\"\n",
+              "            style=\"display:none;\">\n",
+              "\n",
+              "  <svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\" viewBox=\"0 -960 960 960\">\n",
+              "    <path d=\"M120-120v-720h720v720H120Zm60-500h600v-160H180v160Zm220 220h160v-160H400v160Zm0 220h160v-160H400v160ZM180-400h160v-160H180v160Zm440 0h160v-160H620v160ZM180-180h160v-160H180v160Zm440 0h160v-160H620v160Z\"/>\n",
+              "  </svg>\n",
+              "    </button>\n",
+              "\n",
+              "  <style>\n",
+              "    .colab-df-container {\n",
+              "      display:flex;\n",
+              "      gap: 12px;\n",
+              "    }\n",
+              "\n",
+              "    .colab-df-convert {\n",
+              "      background-color: #E8F0FE;\n",
+              "      border: none;\n",
+              "      border-radius: 50%;\n",
+              "      cursor: pointer;\n",
+              "      display: none;\n",
+              "      fill: #1967D2;\n",
+              "      height: 32px;\n",
+              "      padding: 0 0 0 0;\n",
+              "      width: 32px;\n",
+              "    }\n",
+              "\n",
+              "    .colab-df-convert:hover {\n",
+              "      background-color: #E2EBFA;\n",
+              "      box-shadow: 0px 1px 2px rgba(60, 64, 67, 0.3), 0px 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
+              "      fill: #174EA6;\n",
+              "    }\n",
+              "\n",
+              "    .colab-df-buttons div {\n",
+              "      margin-bottom: 4px;\n",
+              "    }\n",
+              "\n",
+              "    [theme=dark] .colab-df-convert {\n",
+              "      background-color: #3B4455;\n",
+              "      fill: #D2E3FC;\n",
+              "    }\n",
+              "\n",
+              "    [theme=dark] .colab-df-convert:hover {\n",
+              "      background-color: #434B5C;\n",
+              "      box-shadow: 0px 1px 3px 1px rgba(0, 0, 0, 0.15);\n",
+              "      filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.3));\n",
+              "      fill: #FFFFFF;\n",
+              "    }\n",
+              "  </style>\n",
+              "\n",
+              "    <script>\n",
+              "      const buttonEl =\n",
+              "        document.querySelector('#df-ad1dcf82-a33c-4cc9-af15-8f33e0f886ac button.colab-df-convert');\n",
+              "      buttonEl.style.display =\n",
+              "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
+              "\n",
+              "      async function convertToInteractive(key) {\n",
+              "        const element = document.querySelector('#df-ad1dcf82-a33c-4cc9-af15-8f33e0f886ac');\n",
+              "        const dataTable =\n",
+              "          await google.colab.kernel.invokeFunction('convertToInteractive',\n",
+              "                                                    [key], {});\n",
+              "        if (!dataTable) return;\n",
+              "\n",
+              "        const docLinkHtml = 'Like what you see? Visit the ' +\n",
+              "          '<a target=\"_blank\" href=https://colab.research.google.com/notebooks/data_table.ipynb>data table notebook</a>'\n",
+              "          + ' to learn more about interactive tables.';\n",
+              "        element.innerHTML = '';\n",
+              "        dataTable['output_type'] = 'display_data';\n",
+              "        await google.colab.output.renderOutput(dataTable, element);\n",
+              "        const docLink = document.createElement('div');\n",
+              "        docLink.innerHTML = docLinkHtml;\n",
+              "        element.appendChild(docLink);\n",
+              "      }\n",
+              "    </script>\n",
+              "  </div>\n",
+              "\n",
+              "\n",
+              "<div id=\"df-ca137ff9-91bd-4b18-a9a6-6d960bc0f917\">\n",
+              "  <button class=\"colab-df-quickchart\" onclick=\"quickchart('df-ca137ff9-91bd-4b18-a9a6-6d960bc0f917')\"\n",
+              "            title=\"Suggest charts.\"\n",
+              "            style=\"display:none;\">\n",
+              "\n",
+              "<svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\"viewBox=\"0 0 24 24\"\n",
+              "     width=\"24px\">\n",
+              "    <g>\n",
+              "        <path d=\"M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zM9 17H7v-7h2v7zm4 0h-2V7h2v10zm4 0h-2v-4h2v4z\"/>\n",
+              "    </g>\n",
+              "</svg>\n",
+              "  </button>\n",
+              "\n",
+              "<style>\n",
+              "  .colab-df-quickchart {\n",
+              "      --bg-color: #E8F0FE;\n",
+              "      --fill-color: #1967D2;\n",
+              "      --hover-bg-color: #E2EBFA;\n",
+              "      --hover-fill-color: #174EA6;\n",
+              "      --disabled-fill-color: #AAA;\n",
+              "      --disabled-bg-color: #DDD;\n",
+              "  }\n",
+              "\n",
+              "  [theme=dark] .colab-df-quickchart {\n",
+              "      --bg-color: #3B4455;\n",
+              "      --fill-color: #D2E3FC;\n",
+              "      --hover-bg-color: #434B5C;\n",
+              "      --hover-fill-color: #FFFFFF;\n",
+              "      --disabled-bg-color: #3B4455;\n",
+              "      --disabled-fill-color: #666;\n",
+              "  }\n",
+              "\n",
+              "  .colab-df-quickchart {\n",
+              "    background-color: var(--bg-color);\n",
+              "    border: none;\n",
+              "    border-radius: 50%;\n",
+              "    cursor: pointer;\n",
+              "    display: none;\n",
+              "    fill: var(--fill-color);\n",
+              "    height: 32px;\n",
+              "    padding: 0;\n",
+              "    width: 32px;\n",
+              "  }\n",
+              "\n",
+              "  .colab-df-quickchart:hover {\n",
+              "    background-color: var(--hover-bg-color);\n",
+              "    box-shadow: 0 1px 2px rgba(60, 64, 67, 0.3), 0 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
+              "    fill: var(--button-hover-fill-color);\n",
+              "  }\n",
+              "\n",
+              "  .colab-df-quickchart-complete:disabled,\n",
+              "  .colab-df-quickchart-complete:disabled:hover {\n",
+              "    background-color: var(--disabled-bg-color);\n",
+              "    fill: var(--disabled-fill-color);\n",
+              "    box-shadow: none;\n",
+              "  }\n",
+              "\n",
+              "  .colab-df-spinner {\n",
+              "    border: 2px solid var(--fill-color);\n",
+              "    border-color: transparent;\n",
+              "    border-bottom-color: var(--fill-color);\n",
+              "    animation:\n",
+              "      spin 1s steps(1) infinite;\n",
+              "  }\n",
+              "\n",
+              "  @keyframes spin {\n",
+              "    0% {\n",
+              "      border-color: transparent;\n",
+              "      border-bottom-color: var(--fill-color);\n",
+              "      border-left-color: var(--fill-color);\n",
+              "    }\n",
+              "    20% {\n",
+              "      border-color: transparent;\n",
+              "      border-left-color: var(--fill-color);\n",
+              "      border-top-color: var(--fill-color);\n",
+              "    }\n",
+              "    30% {\n",
+              "      border-color: transparent;\n",
+              "      border-left-color: var(--fill-color);\n",
+              "      border-top-color: var(--fill-color);\n",
+              "      border-right-color: var(--fill-color);\n",
+              "    }\n",
+              "    40% {\n",
+              "      border-color: transparent;\n",
+              "      border-right-color: var(--fill-color);\n",
+              "      border-top-color: var(--fill-color);\n",
+              "    }\n",
+              "    60% {\n",
+              "      border-color: transparent;\n",
+              "      border-right-color: var(--fill-color);\n",
+              "    }\n",
+              "    80% {\n",
+              "      border-color: transparent;\n",
+              "      border-right-color: var(--fill-color);\n",
+              "      border-bottom-color: var(--fill-color);\n",
+              "    }\n",
+              "    90% {\n",
+              "      border-color: transparent;\n",
+              "      border-bottom-color: var(--fill-color);\n",
+              "    }\n",
+              "  }\n",
+              "</style>\n",
+              "\n",
+              "  <script>\n",
+              "    async function quickchart(key) {\n",
+              "      const quickchartButtonEl =\n",
+              "        document.querySelector('#' + key + ' button');\n",
+              "      quickchartButtonEl.disabled = true;  // To prevent multiple clicks.\n",
+              "      quickchartButtonEl.classList.add('colab-df-spinner');\n",
+              "      try {\n",
+              "        const charts = await google.colab.kernel.invokeFunction(\n",
+              "            'suggestCharts', [key], {});\n",
+              "      } catch (error) {\n",
+              "        console.error('Error during call to suggestCharts:', error);\n",
+              "      }\n",
+              "      quickchartButtonEl.classList.remove('colab-df-spinner');\n",
+              "      quickchartButtonEl.classList.add('colab-df-quickchart-complete');\n",
+              "    }\n",
+              "    (() => {\n",
+              "      let quickchartButtonEl =\n",
+              "        document.querySelector('#df-ca137ff9-91bd-4b18-a9a6-6d960bc0f917 button');\n",
+              "      quickchartButtonEl.style.display =\n",
+              "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
+              "    })();\n",
+              "  </script>\n",
+              "</div>\n",
+              "    </div>\n",
+              "  </div>\n"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 41
+        }
+      ],
+      "source": [
+        "pd_flights.describe()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "O4FVtGT9NRFg"
+      },
+      "source": [
+        "Values returned from `eland.DataFrame.describe` may vary due to results of Elasticsearch aggregations."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 42,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2021-12-15T20:24:50.710321Z",
+          "iopub.status.busy": "2021-12-15T20:24:50.709905Z",
+          "iopub.status.idle": "2021-12-15T20:24:50.912876Z",
+          "shell.execute_reply": "2021-12-15T20:24:50.913469Z"
+        },
+        "pycharm": {
+          "is_executing": false
+        },
+        "id": "L7eKy3AINRFg",
+        "outputId": "4e191714-77a5-43a2-d364-bfbed1559b98",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 330
+        }
+      },
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "       AvgTicketPrice     Cancelled  ...  FlightTimeMin     dayOfWeek\n",
+              "count    13059.000000  13059.000000  ...   13059.000000  13059.000000\n",
+              "mean       628.253689      0.128494  ...     511.127842      2.835975\n",
+              "std        266.407061      0.334664  ...     334.766770      1.939513\n",
+              "min        100.020531      0.000000  ...       0.000000      0.000000\n",
+              "25%        411.154491      0.000000  ...     250.428538      1.058527\n",
+              "50%        639.433214      0.000000  ...     502.777975      2.935777\n",
+              "75%        842.336195      0.000000  ...     721.351220      4.427843\n",
+              "max       1199.729004      1.000000  ...    1902.901978      6.000000\n",
+              "\n",
+              "[8 rows x 9 columns]"
+            ],
+            "text/html": [
+              "\n",
+              "  <div id=\"df-c245623d-6905-46ff-a248-ff68036187bc\" class=\"colab-df-container\">\n",
+              "    <div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>AvgTicketPrice</th>\n",
+              "      <th>Cancelled</th>\n",
+              "      <th>...</th>\n",
+              "      <th>FlightTimeMin</th>\n",
+              "      <th>dayOfWeek</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>count</th>\n",
+              "      <td>13059.000000</td>\n",
+              "      <td>13059.000000</td>\n",
+              "      <td>...</td>\n",
+              "      <td>13059.000000</td>\n",
+              "      <td>13059.000000</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>mean</th>\n",
+              "      <td>628.253689</td>\n",
+              "      <td>0.128494</td>\n",
+              "      <td>...</td>\n",
+              "      <td>511.127842</td>\n",
+              "      <td>2.835975</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>std</th>\n",
+              "      <td>266.407061</td>\n",
+              "      <td>0.334664</td>\n",
+              "      <td>...</td>\n",
+              "      <td>334.766770</td>\n",
+              "      <td>1.939513</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>min</th>\n",
+              "      <td>100.020531</td>\n",
+              "      <td>0.000000</td>\n",
+              "      <td>...</td>\n",
+              "      <td>0.000000</td>\n",
+              "      <td>0.000000</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>25%</th>\n",
+              "      <td>411.154491</td>\n",
+              "      <td>0.000000</td>\n",
+              "      <td>...</td>\n",
+              "      <td>250.428538</td>\n",
+              "      <td>1.058527</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>50%</th>\n",
+              "      <td>639.433214</td>\n",
+              "      <td>0.000000</td>\n",
+              "      <td>...</td>\n",
+              "      <td>502.777975</td>\n",
+              "      <td>2.935777</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>75%</th>\n",
+              "      <td>842.336195</td>\n",
+              "      <td>0.000000</td>\n",
+              "      <td>...</td>\n",
+              "      <td>721.351220</td>\n",
+              "      <td>4.427843</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>max</th>\n",
+              "      <td>1199.729004</td>\n",
+              "      <td>1.000000</td>\n",
+              "      <td>...</td>\n",
+              "      <td>1902.901978</td>\n",
+              "      <td>6.000000</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "<p>8 rows × 9 columns</p>\n",
+              "</div>\n",
+              "    <div class=\"colab-df-buttons\">\n",
+              "\n",
+              "  <div class=\"colab-df-container\">\n",
+              "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-c245623d-6905-46ff-a248-ff68036187bc')\"\n",
+              "            title=\"Convert this dataframe to an interactive table.\"\n",
+              "            style=\"display:none;\">\n",
+              "\n",
+              "  <svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\" viewBox=\"0 -960 960 960\">\n",
+              "    <path d=\"M120-120v-720h720v720H120Zm60-500h600v-160H180v160Zm220 220h160v-160H400v160Zm0 220h160v-160H400v160ZM180-400h160v-160H180v160Zm440 0h160v-160H620v160ZM180-180h160v-160H180v160Zm440 0h160v-160H620v160Z\"/>\n",
+              "  </svg>\n",
+              "    </button>\n",
+              "\n",
+              "  <style>\n",
+              "    .colab-df-container {\n",
+              "      display:flex;\n",
+              "      gap: 12px;\n",
+              "    }\n",
+              "\n",
+              "    .colab-df-convert {\n",
+              "      background-color: #E8F0FE;\n",
+              "      border: none;\n",
+              "      border-radius: 50%;\n",
+              "      cursor: pointer;\n",
+              "      display: none;\n",
+              "      fill: #1967D2;\n",
+              "      height: 32px;\n",
+              "      padding: 0 0 0 0;\n",
+              "      width: 32px;\n",
+              "    }\n",
+              "\n",
+              "    .colab-df-convert:hover {\n",
+              "      background-color: #E2EBFA;\n",
+              "      box-shadow: 0px 1px 2px rgba(60, 64, 67, 0.3), 0px 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
+              "      fill: #174EA6;\n",
+              "    }\n",
+              "\n",
+              "    .colab-df-buttons div {\n",
+              "      margin-bottom: 4px;\n",
+              "    }\n",
+              "\n",
+              "    [theme=dark] .colab-df-convert {\n",
+              "      background-color: #3B4455;\n",
+              "      fill: #D2E3FC;\n",
+              "    }\n",
+              "\n",
+              "    [theme=dark] .colab-df-convert:hover {\n",
+              "      background-color: #434B5C;\n",
+              "      box-shadow: 0px 1px 3px 1px rgba(0, 0, 0, 0.15);\n",
+              "      filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.3));\n",
+              "      fill: #FFFFFF;\n",
+              "    }\n",
+              "  </style>\n",
+              "\n",
+              "    <script>\n",
+              "      const buttonEl =\n",
+              "        document.querySelector('#df-c245623d-6905-46ff-a248-ff68036187bc button.colab-df-convert');\n",
+              "      buttonEl.style.display =\n",
+              "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
+              "\n",
+              "      async function convertToInteractive(key) {\n",
+              "        const element = document.querySelector('#df-c245623d-6905-46ff-a248-ff68036187bc');\n",
+              "        const dataTable =\n",
+              "          await google.colab.kernel.invokeFunction('convertToInteractive',\n",
+              "                                                    [key], {});\n",
+              "        if (!dataTable) return;\n",
+              "\n",
+              "        const docLinkHtml = 'Like what you see? Visit the ' +\n",
+              "          '<a target=\"_blank\" href=https://colab.research.google.com/notebooks/data_table.ipynb>data table notebook</a>'\n",
+              "          + ' to learn more about interactive tables.';\n",
+              "        element.innerHTML = '';\n",
+              "        dataTable['output_type'] = 'display_data';\n",
+              "        await google.colab.output.renderOutput(dataTable, element);\n",
+              "        const docLink = document.createElement('div');\n",
+              "        docLink.innerHTML = docLinkHtml;\n",
+              "        element.appendChild(docLink);\n",
+              "      }\n",
+              "    </script>\n",
+              "  </div>\n",
+              "\n",
+              "\n",
+              "<div id=\"df-0c99c5fd-4def-4a58-bdfc-0f05b33edd88\">\n",
+              "  <button class=\"colab-df-quickchart\" onclick=\"quickchart('df-0c99c5fd-4def-4a58-bdfc-0f05b33edd88')\"\n",
+              "            title=\"Suggest charts.\"\n",
+              "            style=\"display:none;\">\n",
+              "\n",
+              "<svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\"viewBox=\"0 0 24 24\"\n",
+              "     width=\"24px\">\n",
+              "    <g>\n",
+              "        <path d=\"M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zM9 17H7v-7h2v7zm4 0h-2V7h2v10zm4 0h-2v-4h2v4z\"/>\n",
+              "    </g>\n",
+              "</svg>\n",
+              "  </button>\n",
+              "\n",
+              "<style>\n",
+              "  .colab-df-quickchart {\n",
+              "      --bg-color: #E8F0FE;\n",
+              "      --fill-color: #1967D2;\n",
+              "      --hover-bg-color: #E2EBFA;\n",
+              "      --hover-fill-color: #174EA6;\n",
+              "      --disabled-fill-color: #AAA;\n",
+              "      --disabled-bg-color: #DDD;\n",
+              "  }\n",
+              "\n",
+              "  [theme=dark] .colab-df-quickchart {\n",
+              "      --bg-color: #3B4455;\n",
+              "      --fill-color: #D2E3FC;\n",
+              "      --hover-bg-color: #434B5C;\n",
+              "      --hover-fill-color: #FFFFFF;\n",
+              "      --disabled-bg-color: #3B4455;\n",
+              "      --disabled-fill-color: #666;\n",
+              "  }\n",
+              "\n",
+              "  .colab-df-quickchart {\n",
+              "    background-color: var(--bg-color);\n",
+              "    border: none;\n",
+              "    border-radius: 50%;\n",
+              "    cursor: pointer;\n",
+              "    display: none;\n",
+              "    fill: var(--fill-color);\n",
+              "    height: 32px;\n",
+              "    padding: 0;\n",
+              "    width: 32px;\n",
+              "  }\n",
+              "\n",
+              "  .colab-df-quickchart:hover {\n",
+              "    background-color: var(--hover-bg-color);\n",
+              "    box-shadow: 0 1px 2px rgba(60, 64, 67, 0.3), 0 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
+              "    fill: var(--button-hover-fill-color);\n",
+              "  }\n",
+              "\n",
+              "  .colab-df-quickchart-complete:disabled,\n",
+              "  .colab-df-quickchart-complete:disabled:hover {\n",
+              "    background-color: var(--disabled-bg-color);\n",
+              "    fill: var(--disabled-fill-color);\n",
+              "    box-shadow: none;\n",
+              "  }\n",
+              "\n",
+              "  .colab-df-spinner {\n",
+              "    border: 2px solid var(--fill-color);\n",
+              "    border-color: transparent;\n",
+              "    border-bottom-color: var(--fill-color);\n",
+              "    animation:\n",
+              "      spin 1s steps(1) infinite;\n",
+              "  }\n",
+              "\n",
+              "  @keyframes spin {\n",
+              "    0% {\n",
+              "      border-color: transparent;\n",
+              "      border-bottom-color: var(--fill-color);\n",
+              "      border-left-color: var(--fill-color);\n",
+              "    }\n",
+              "    20% {\n",
+              "      border-color: transparent;\n",
+              "      border-left-color: var(--fill-color);\n",
+              "      border-top-color: var(--fill-color);\n",
+              "    }\n",
+              "    30% {\n",
+              "      border-color: transparent;\n",
+              "      border-left-color: var(--fill-color);\n",
+              "      border-top-color: var(--fill-color);\n",
+              "      border-right-color: var(--fill-color);\n",
+              "    }\n",
+              "    40% {\n",
+              "      border-color: transparent;\n",
+              "      border-right-color: var(--fill-color);\n",
+              "      border-top-color: var(--fill-color);\n",
+              "    }\n",
+              "    60% {\n",
+              "      border-color: transparent;\n",
+              "      border-right-color: var(--fill-color);\n",
+              "    }\n",
+              "    80% {\n",
+              "      border-color: transparent;\n",
+              "      border-right-color: var(--fill-color);\n",
+              "      border-bottom-color: var(--fill-color);\n",
+              "    }\n",
+              "    90% {\n",
+              "      border-color: transparent;\n",
+              "      border-bottom-color: var(--fill-color);\n",
+              "    }\n",
+              "  }\n",
+              "</style>\n",
+              "\n",
+              "  <script>\n",
+              "    async function quickchart(key) {\n",
+              "      const quickchartButtonEl =\n",
+              "        document.querySelector('#' + key + ' button');\n",
+              "      quickchartButtonEl.disabled = true;  // To prevent multiple clicks.\n",
+              "      quickchartButtonEl.classList.add('colab-df-spinner');\n",
+              "      try {\n",
+              "        const charts = await google.colab.kernel.invokeFunction(\n",
+              "            'suggestCharts', [key], {});\n",
+              "      } catch (error) {\n",
+              "        console.error('Error during call to suggestCharts:', error);\n",
+              "      }\n",
+              "      quickchartButtonEl.classList.remove('colab-df-spinner');\n",
+              "      quickchartButtonEl.classList.add('colab-df-quickchart-complete');\n",
+              "    }\n",
+              "    (() => {\n",
+              "      let quickchartButtonEl =\n",
+              "        document.querySelector('#df-0c99c5fd-4def-4a58-bdfc-0f05b33edd88 button');\n",
+              "      quickchartButtonEl.style.display =\n",
+              "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
+              "    })();\n",
+              "  </script>\n",
+              "</div>\n",
+              "    </div>\n",
+              "  </div>\n"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 42
+        }
+      ],
+      "source": [
+        "# NBVAL_IGNORE_OUTPUT\n",
+        "ed_flights.describe()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "qDo76JgKNRFh"
+      },
+      "source": [
+        "### DataFrame.info"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 43,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2021-12-15T20:24:50.944997Z",
+          "iopub.status.busy": "2021-12-15T20:24:50.918277Z",
+          "iopub.status.idle": "2021-12-15T20:24:50.958394Z",
+          "shell.execute_reply": "2021-12-15T20:24:50.958030Z"
+        },
+        "pycharm": {
+          "is_executing": false
+        },
+        "id": "GvvfPrPdNRFh",
+        "outputId": "f7f62b65-8741-4f93-e037-7743b1e9f6f5",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "<class 'pandas.core.frame.DataFrame'>\n",
+            "Index: 13059 entries, 0 to 13058\n",
+            "Data columns (total 27 columns):\n",
+            " #   Column              Non-Null Count  Dtype         \n",
+            "---  ------              --------------  -----         \n",
+            " 0   AvgTicketPrice      13059 non-null  float64       \n",
+            " 1   Cancelled           13059 non-null  bool          \n",
+            " 2   Carrier             13059 non-null  object        \n",
+            " 3   Dest                13059 non-null  object        \n",
+            " 4   DestAirportID       13059 non-null  object        \n",
+            " 5   DestCityName        13059 non-null  object        \n",
+            " 6   DestCountry         13059 non-null  object        \n",
+            " 7   DestLocation        13059 non-null  object        \n",
+            " 8   DestRegion          13059 non-null  object        \n",
+            " 9   DestWeather         13059 non-null  object        \n",
+            " 10  DistanceKilometers  13059 non-null  float64       \n",
+            " 11  DistanceMiles       13059 non-null  float64       \n",
+            " 12  FlightDelay         13059 non-null  bool          \n",
+            " 13  FlightDelayMin      13059 non-null  int64         \n",
+            " 14  FlightDelayType     13059 non-null  object        \n",
+            " 15  FlightNum           13059 non-null  object        \n",
+            " 16  FlightTimeHour      13059 non-null  float64       \n",
+            " 17  FlightTimeMin       13059 non-null  float64       \n",
+            " 18  Origin              13059 non-null  object        \n",
+            " 19  OriginAirportID     13059 non-null  object        \n",
+            " 20  OriginCityName      13059 non-null  object        \n",
+            " 21  OriginCountry       13059 non-null  object        \n",
+            " 22  OriginLocation      13059 non-null  object        \n",
+            " 23  OriginRegion        13059 non-null  object        \n",
+            " 24  OriginWeather       13059 non-null  object        \n",
+            " 25  dayOfWeek           13059 non-null  int64         \n",
+            " 26  timestamp           13059 non-null  datetime64[ns]\n",
+            "dtypes: bool(2), datetime64[ns](1), float64(5), int64(2), object(17)\n",
+            "memory usage: 3.1+ MB\n"
+          ]
+        }
+      ],
+      "source": [
+        "pd_flights.info()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 44,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2021-12-15T20:24:50.961762Z",
+          "iopub.status.busy": "2021-12-15T20:24:50.961398Z",
+          "iopub.status.idle": "2021-12-15T20:24:55.507758Z",
+          "shell.execute_reply": "2021-12-15T20:24:55.507382Z"
+        },
+        "pycharm": {
+          "is_executing": false
+        },
+        "id": "ByVDPJXkNRFh",
+        "outputId": "98bff4c2-44f3-42d1-b124-8bf8683fc663",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "<class 'eland.dataframe.DataFrame'>\n",
+            "Index: 13059 entries, 0 to 13058\n",
+            "Data columns (total 27 columns):\n",
+            " #   Column              Non-Null Count  Dtype         \n",
+            "---  ------              --------------  -----         \n",
+            " 0   AvgTicketPrice      13059 non-null  float64       \n",
+            " 1   Cancelled           13059 non-null  bool          \n",
+            " 2   Carrier             13059 non-null  object        \n",
+            " 3   Dest                13059 non-null  object        \n",
+            " 4   DestAirportID       13059 non-null  object        \n",
+            " 5   DestCityName        13059 non-null  object        \n",
+            " 6   DestCountry         13059 non-null  object        \n",
+            " 7   DestLocation        13059 non-null  object        \n",
+            " 8   DestRegion          13059 non-null  object        \n",
+            " 9   DestWeather         13059 non-null  object        \n",
+            " 10  DistanceKilometers  13059 non-null  float64       \n",
+            " 11  DistanceMiles       13059 non-null  float64       \n",
+            " 12  FlightDelay         13059 non-null  bool          \n",
+            " 13  FlightDelayMin      13059 non-null  int64         \n",
+            " 14  FlightDelayType     13059 non-null  object        \n",
+            " 15  FlightNum           13059 non-null  object        \n",
+            " 16  FlightTimeHour      13059 non-null  float64       \n",
+            " 17  FlightTimeMin       13059 non-null  float64       \n",
+            " 18  Origin              13059 non-null  object        \n",
+            " 19  OriginAirportID     13059 non-null  object        \n",
+            " 20  OriginCityName      13059 non-null  object        \n",
+            " 21  OriginCountry       13059 non-null  object        \n",
+            " 22  OriginLocation      13059 non-null  object        \n",
+            " 23  OriginRegion        13059 non-null  object        \n",
+            " 24  OriginWeather       13059 non-null  object        \n",
+            " 25  dayOfWeek           13059 non-null  int64         \n",
+            " 26  timestamp           13059 non-null  datetime64[ns]\n",
+            "dtypes: bool(2), datetime64[ns](1), float64(5), int64(2), object(17)\n",
+            "memory usage: 64.000 bytes\n",
+            "Elasticsearch storage usage: 11.066 MB\n"
+          ]
+        }
+      ],
+      "source": [
+        "ed_flights.info()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "nW0sRoI3NRFi"
+      },
+      "source": [
+        "### DataFrame.max, DataFrame.min, DataFrame.mean, DataFrame.sum"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "iMSuS3Q9NRFi"
+      },
+      "source": [
+        "#### max"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 45,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2021-12-15T20:24:55.511067Z",
+          "iopub.status.busy": "2021-12-15T20:24:55.510706Z",
+          "iopub.status.idle": "2021-12-15T20:24:55.515166Z",
+          "shell.execute_reply": "2021-12-15T20:24:55.514795Z"
+        },
+        "pycharm": {
+          "is_executing": false
+        },
+        "id": "a06G_BihNRFj",
+        "outputId": "cd85c3d7-985c-4eb3-bf0d-7cb5dfb5f1ac",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
+      },
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "AvgTicketPrice         1199.729053\n",
+              "Cancelled                     True\n",
+              "DistanceKilometers    19881.482315\n",
+              "DistanceMiles         12353.780369\n",
+              "FlightDelay                   True\n",
+              "FlightDelayMin                 360\n",
+              "FlightTimeHour           31.715034\n",
+              "FlightTimeMin          1902.902032\n",
+              "dayOfWeek                        6\n",
+              "dtype: object"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 45
+        }
+      ],
+      "source": [
+        "pd_flights.max(numeric_only=True)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "a6F0YCOCNRFj"
+      },
+      "source": [
+        "`eland.DataFrame.max,min,mean,sum` only aggregate numeric columns"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 46,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2021-12-15T20:24:55.521502Z",
+          "iopub.status.busy": "2021-12-15T20:24:55.521124Z",
+          "iopub.status.idle": "2021-12-15T20:24:55.615898Z",
+          "shell.execute_reply": "2021-12-15T20:24:55.614418Z"
+        },
+        "pycharm": {
+          "is_executing": false
+        },
+        "id": "JG56E5IoNRFj",
+        "outputId": "736b6d37-4021-41f6-92cf-6e6bf0762a44",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
+      },
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "AvgTicketPrice         1199.729004\n",
+              "Cancelled                 1.000000\n",
+              "DistanceKilometers    19881.482422\n",
+              "DistanceMiles         12353.780273\n",
+              "FlightDelay               1.000000\n",
+              "FlightDelayMin          360.000000\n",
+              "FlightTimeHour           31.715034\n",
+              "FlightTimeMin          1902.901978\n",
+              "dayOfWeek                 6.000000\n",
+              "dtype: float64"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 46
+        }
+      ],
+      "source": [
+        "ed_flights.max(numeric_only=True)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "cigqPPNZNRFk"
+      },
+      "source": [
+        "#### min"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 47,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2021-12-15T20:24:55.629444Z",
+          "iopub.status.busy": "2021-12-15T20:24:55.627340Z",
+          "iopub.status.idle": "2021-12-15T20:24:55.638818Z",
+          "shell.execute_reply": "2021-12-15T20:24:55.637856Z"
+        },
+        "pycharm": {
+          "is_executing": false
+        },
+        "id": "jy4YPXvmNRFk",
+        "outputId": "7e546b63-2510-4c5b-dd3d-af2cf8cd13e3",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
+      },
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "AvgTicketPrice        100.020528\n",
+              "Cancelled                  False\n",
+              "DistanceKilometers           0.0\n",
+              "DistanceMiles                0.0\n",
+              "FlightDelay                False\n",
+              "FlightDelayMin                 0\n",
+              "FlightTimeHour               0.0\n",
+              "FlightTimeMin                0.0\n",
+              "dayOfWeek                      0\n",
+              "dtype: object"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 47
+        }
+      ],
+      "source": [
+        "pd_flights.min(numeric_only=True)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 48,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2021-12-15T20:24:55.649953Z",
+          "iopub.status.busy": "2021-12-15T20:24:55.644304Z",
+          "iopub.status.idle": "2021-12-15T20:24:55.731911Z",
+          "shell.execute_reply": "2021-12-15T20:24:55.731393Z"
+        },
+        "pycharm": {
+          "is_executing": false
+        },
+        "id": "1n3xlYOuNRFk",
+        "outputId": "6983566f-92d6-4a34-d645-05c2da0c68cc",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
+      },
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "AvgTicketPrice        100.020531\n",
+              "Cancelled               0.000000\n",
+              "DistanceKilometers      0.000000\n",
+              "DistanceMiles           0.000000\n",
+              "FlightDelay             0.000000\n",
+              "FlightDelayMin          0.000000\n",
+              "FlightTimeHour          0.000000\n",
+              "FlightTimeMin           0.000000\n",
+              "dayOfWeek               0.000000\n",
+              "dtype: float64"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 48
+        }
+      ],
+      "source": [
+        "ed_flights.min(numeric_only=True)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "PJuymQk-NRFl"
+      },
+      "source": [
+        "#### mean"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 49,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2021-12-15T20:24:55.735976Z",
+          "iopub.status.busy": "2021-12-15T20:24:55.735398Z",
+          "iopub.status.idle": "2021-12-15T20:24:55.740446Z",
+          "shell.execute_reply": "2021-12-15T20:24:55.740037Z"
+        },
+        "pycharm": {
+          "is_executing": false
+        },
+        "id": "Rcj9OfiaNRFl",
+        "outputId": "10ce5668-39bc-43db-c959-21c93baf5eef",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
+      },
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "AvgTicketPrice         628.253689\n",
+              "Cancelled                0.128494\n",
+              "DistanceKilometers    7092.142455\n",
+              "DistanceMiles         4406.853013\n",
+              "FlightDelay              0.251168\n",
+              "FlightDelayMin          47.335171\n",
+              "FlightTimeHour           8.518797\n",
+              "FlightTimeMin          511.127842\n",
+              "dayOfWeek                2.835975\n",
+              "dtype: float64"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 49
+        }
+      ],
+      "source": [
+        "pd_flights.mean(numeric_only=True)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 50,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2021-12-15T20:24:55.746976Z",
+          "iopub.status.busy": "2021-12-15T20:24:55.746605Z",
+          "iopub.status.idle": "2021-12-15T20:24:55.852359Z",
+          "shell.execute_reply": "2021-12-15T20:24:55.850558Z"
+        },
+        "pycharm": {
+          "is_executing": false
+        },
+        "id": "mNz42pJQNRFl",
+        "outputId": "b0e528c6-cceb-43d4-f98a-e017f2e0fa4f",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
+      },
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "AvgTicketPrice         628.253689\n",
+              "Cancelled                0.128494\n",
+              "DistanceKilometers    7092.142457\n",
+              "DistanceMiles         4406.853010\n",
+              "FlightDelay              0.251168\n",
+              "FlightDelayMin          47.335171\n",
+              "FlightTimeHour           8.518797\n",
+              "FlightTimeMin          511.127842\n",
+              "dayOfWeek                2.835975\n",
+              "dtype: float64"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 50
+        }
+      ],
+      "source": [
+        "ed_flights.mean(numeric_only=True)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "deosSfnLNRFm"
+      },
+      "source": [
+        "#### sum"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 51,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2021-12-15T20:24:55.867747Z",
+          "iopub.status.busy": "2021-12-15T20:24:55.865996Z",
+          "iopub.status.idle": "2021-12-15T20:24:55.882127Z",
+          "shell.execute_reply": "2021-12-15T20:24:55.883534Z"
+        },
+        "pycharm": {
+          "is_executing": false
+        },
+        "id": "uKXh2waNNRFm",
+        "outputId": "47309bb4-b1e8-4824-e6a4-c5b9b5bf7ce1",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
+      },
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "AvgTicketPrice        8.204365e+06\n",
+              "Cancelled             1.678000e+03\n",
+              "DistanceKilometers    9.261629e+07\n",
+              "DistanceMiles         5.754909e+07\n",
+              "FlightDelay           3.280000e+03\n",
+              "FlightDelayMin        6.181500e+05\n",
+              "FlightTimeHour        1.112470e+05\n",
+              "FlightTimeMin         6.674818e+06\n",
+              "dayOfWeek             3.703500e+04\n",
+              "dtype: float64"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 51
+        }
+      ],
+      "source": [
+        "pd_flights.sum(numeric_only=True)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 52,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2021-12-15T20:24:55.906057Z",
+          "iopub.status.busy": "2021-12-15T20:24:55.904964Z",
+          "iopub.status.idle": "2021-12-15T20:24:55.997011Z",
+          "shell.execute_reply": "2021-12-15T20:24:55.997419Z"
+        },
+        "pycharm": {
+          "is_executing": false
+        },
+        "id": "ecX1LL0KNRFn",
+        "outputId": "c62cf351-aac2-430f-add7-d230063e349b",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
+      },
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "AvgTicketPrice        8.204365e+06\n",
+              "Cancelled             1.678000e+03\n",
+              "DistanceKilometers    9.261629e+07\n",
+              "DistanceMiles         5.754909e+07\n",
+              "FlightDelay           3.280000e+03\n",
+              "FlightDelayMin        6.181500e+05\n",
+              "FlightTimeHour        1.112470e+05\n",
+              "FlightTimeMin         6.674818e+06\n",
+              "dayOfWeek             3.703500e+04\n",
+              "dtype: float64"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 52
+        }
+      ],
+      "source": [
+        "ed_flights.sum(numeric_only=True)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "BPd8ae8SNRFn"
+      },
+      "source": [
+        "### DataFrame.nunique"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 53,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2021-12-15T20:24:56.003863Z",
+          "iopub.status.busy": "2021-12-15T20:24:56.003311Z",
+          "iopub.status.idle": "2021-12-15T20:24:56.012352Z",
+          "shell.execute_reply": "2021-12-15T20:24:56.012798Z"
+        },
+        "pycharm": {
+          "is_executing": false
+        },
+        "id": "H0_EAT-jNRFn",
+        "outputId": "96a51dc9-1fbf-4c42-9370-de2e8c479759",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
+      },
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "Carrier      4\n",
+              "Origin     156\n",
+              "Dest       156\n",
+              "dtype: int64"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 53
+        }
+      ],
+      "source": [
+        "pd_flights[['Carrier', 'Origin', 'Dest']].nunique()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 54,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2021-12-15T20:24:56.018633Z",
+          "iopub.status.busy": "2021-12-15T20:24:56.018038Z",
+          "iopub.status.idle": "2021-12-15T20:24:56.109194Z",
+          "shell.execute_reply": "2021-12-15T20:24:56.108015Z"
+        },
+        "pycharm": {
+          "is_executing": false
+        },
+        "id": "J7Y3r7BRNRFn",
+        "outputId": "14ebfc9d-d8ff-4eb4-b7af-f860498d112d",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
+      },
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "Carrier      4\n",
+              "Origin     156\n",
+              "Dest       156\n",
+              "dtype: int64"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 54
+        }
+      ],
+      "source": [
+        "ed_flights[['Carrier', 'Origin', 'Dest']].nunique()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "OpLeL6gpNRFo"
+      },
+      "source": [
+        "### DataFrame.drop"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 55,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2021-12-15T20:24:56.124377Z",
+          "iopub.status.busy": "2021-12-15T20:24:56.123206Z",
+          "iopub.status.idle": "2021-12-15T20:24:56.145226Z",
+          "shell.execute_reply": "2021-12-15T20:24:56.145628Z"
+        },
+        "pycharm": {
+          "is_executing": false
+        },
+        "id": "xkGjF6p8NRFo",
+        "outputId": "497cebfc-ee66-47a4-8d68-718f930be023",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 424
+        }
+      },
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "                Carrier DestRegion  ... dayOfWeek           timestamp\n",
+              "0       Kibana Airlines      SE-BD  ...         0 2018-01-01 00:00:00\n",
+              "1      Logstash Airways      IT-34  ...         0 2018-01-01 18:27:00\n",
+              "2      Logstash Airways      IT-34  ...         0 2018-01-01 17:11:14\n",
+              "3       Kibana Airlines      IT-34  ...         0 2018-01-01 10:33:28\n",
+              "4       Kibana Airlines      SE-BD  ...         0 2018-01-01 05:13:00\n",
+              "...                 ...        ...  ...       ...                 ...\n",
+              "13054  Logstash Airways      SE-BD  ...         6 2018-02-11 20:42:25\n",
+              "13055  Logstash Airways      CH-ZH  ...         6 2018-02-11 01:41:57\n",
+              "13056  Logstash Airways     RU-AMU  ...         6 2018-02-11 04:09:27\n",
+              "13057          JetBeats      SE-BD  ...         6 2018-02-11 08:28:21\n",
+              "13058          JetBeats      US-DC  ...         6 2018-02-11 14:54:34\n",
+              "\n",
+              "[13059 rows x 20 columns]"
+            ],
+            "text/html": [
+              "\n",
+              "  <div id=\"df-0a24b0af-65db-4f81-bffa-efebaf3eef89\" class=\"colab-df-container\">\n",
+              "    <div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>Carrier</th>\n",
+              "      <th>DestRegion</th>\n",
+              "      <th>...</th>\n",
+              "      <th>dayOfWeek</th>\n",
+              "      <th>timestamp</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>Kibana Airlines</td>\n",
+              "      <td>SE-BD</td>\n",
+              "      <td>...</td>\n",
+              "      <td>0</td>\n",
+              "      <td>2018-01-01 00:00:00</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>1</th>\n",
+              "      <td>Logstash Airways</td>\n",
+              "      <td>IT-34</td>\n",
+              "      <td>...</td>\n",
+              "      <td>0</td>\n",
+              "      <td>2018-01-01 18:27:00</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>2</th>\n",
+              "      <td>Logstash Airways</td>\n",
+              "      <td>IT-34</td>\n",
+              "      <td>...</td>\n",
+              "      <td>0</td>\n",
+              "      <td>2018-01-01 17:11:14</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>3</th>\n",
+              "      <td>Kibana Airlines</td>\n",
+              "      <td>IT-34</td>\n",
+              "      <td>...</td>\n",
+              "      <td>0</td>\n",
+              "      <td>2018-01-01 10:33:28</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>4</th>\n",
+              "      <td>Kibana Airlines</td>\n",
+              "      <td>SE-BD</td>\n",
+              "      <td>...</td>\n",
+              "      <td>0</td>\n",
+              "      <td>2018-01-01 05:13:00</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>...</th>\n",
+              "      <td>...</td>\n",
+              "      <td>...</td>\n",
+              "      <td>...</td>\n",
+              "      <td>...</td>\n",
+              "      <td>...</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>13054</th>\n",
+              "      <td>Logstash Airways</td>\n",
+              "      <td>SE-BD</td>\n",
+              "      <td>...</td>\n",
+              "      <td>6</td>\n",
+              "      <td>2018-02-11 20:42:25</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>13055</th>\n",
+              "      <td>Logstash Airways</td>\n",
+              "      <td>CH-ZH</td>\n",
+              "      <td>...</td>\n",
+              "      <td>6</td>\n",
+              "      <td>2018-02-11 01:41:57</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>13056</th>\n",
+              "      <td>Logstash Airways</td>\n",
+              "      <td>RU-AMU</td>\n",
+              "      <td>...</td>\n",
+              "      <td>6</td>\n",
+              "      <td>2018-02-11 04:09:27</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>13057</th>\n",
+              "      <td>JetBeats</td>\n",
+              "      <td>SE-BD</td>\n",
+              "      <td>...</td>\n",
+              "      <td>6</td>\n",
+              "      <td>2018-02-11 08:28:21</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>13058</th>\n",
+              "      <td>JetBeats</td>\n",
+              "      <td>US-DC</td>\n",
+              "      <td>...</td>\n",
+              "      <td>6</td>\n",
+              "      <td>2018-02-11 14:54:34</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "<p>13059 rows × 20 columns</p>\n",
+              "</div>\n",
+              "    <div class=\"colab-df-buttons\">\n",
+              "\n",
+              "  <div class=\"colab-df-container\">\n",
+              "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-0a24b0af-65db-4f81-bffa-efebaf3eef89')\"\n",
+              "            title=\"Convert this dataframe to an interactive table.\"\n",
+              "            style=\"display:none;\">\n",
+              "\n",
+              "  <svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\" viewBox=\"0 -960 960 960\">\n",
+              "    <path d=\"M120-120v-720h720v720H120Zm60-500h600v-160H180v160Zm220 220h160v-160H400v160Zm0 220h160v-160H400v160ZM180-400h160v-160H180v160Zm440 0h160v-160H620v160ZM180-180h160v-160H180v160Zm440 0h160v-160H620v160Z\"/>\n",
+              "  </svg>\n",
+              "    </button>\n",
+              "\n",
+              "  <style>\n",
+              "    .colab-df-container {\n",
+              "      display:flex;\n",
+              "      gap: 12px;\n",
+              "    }\n",
+              "\n",
+              "    .colab-df-convert {\n",
+              "      background-color: #E8F0FE;\n",
+              "      border: none;\n",
+              "      border-radius: 50%;\n",
+              "      cursor: pointer;\n",
+              "      display: none;\n",
+              "      fill: #1967D2;\n",
+              "      height: 32px;\n",
+              "      padding: 0 0 0 0;\n",
+              "      width: 32px;\n",
+              "    }\n",
+              "\n",
+              "    .colab-df-convert:hover {\n",
+              "      background-color: #E2EBFA;\n",
+              "      box-shadow: 0px 1px 2px rgba(60, 64, 67, 0.3), 0px 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
+              "      fill: #174EA6;\n",
+              "    }\n",
+              "\n",
+              "    .colab-df-buttons div {\n",
+              "      margin-bottom: 4px;\n",
+              "    }\n",
+              "\n",
+              "    [theme=dark] .colab-df-convert {\n",
+              "      background-color: #3B4455;\n",
+              "      fill: #D2E3FC;\n",
+              "    }\n",
+              "\n",
+              "    [theme=dark] .colab-df-convert:hover {\n",
+              "      background-color: #434B5C;\n",
+              "      box-shadow: 0px 1px 3px 1px rgba(0, 0, 0, 0.15);\n",
+              "      filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.3));\n",
+              "      fill: #FFFFFF;\n",
+              "    }\n",
+              "  </style>\n",
+              "\n",
+              "    <script>\n",
+              "      const buttonEl =\n",
+              "        document.querySelector('#df-0a24b0af-65db-4f81-bffa-efebaf3eef89 button.colab-df-convert');\n",
+              "      buttonEl.style.display =\n",
+              "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
+              "\n",
+              "      async function convertToInteractive(key) {\n",
+              "        const element = document.querySelector('#df-0a24b0af-65db-4f81-bffa-efebaf3eef89');\n",
+              "        const dataTable =\n",
+              "          await google.colab.kernel.invokeFunction('convertToInteractive',\n",
+              "                                                    [key], {});\n",
+              "        if (!dataTable) return;\n",
+              "\n",
+              "        const docLinkHtml = 'Like what you see? Visit the ' +\n",
+              "          '<a target=\"_blank\" href=https://colab.research.google.com/notebooks/data_table.ipynb>data table notebook</a>'\n",
+              "          + ' to learn more about interactive tables.';\n",
+              "        element.innerHTML = '';\n",
+              "        dataTable['output_type'] = 'display_data';\n",
+              "        await google.colab.output.renderOutput(dataTable, element);\n",
+              "        const docLink = document.createElement('div');\n",
+              "        docLink.innerHTML = docLinkHtml;\n",
+              "        element.appendChild(docLink);\n",
+              "      }\n",
+              "    </script>\n",
+              "  </div>\n",
+              "\n",
+              "\n",
+              "<div id=\"df-d8914f66-8357-4e5d-a145-b37879cd1b07\">\n",
+              "  <button class=\"colab-df-quickchart\" onclick=\"quickchart('df-d8914f66-8357-4e5d-a145-b37879cd1b07')\"\n",
+              "            title=\"Suggest charts.\"\n",
+              "            style=\"display:none;\">\n",
+              "\n",
+              "<svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\"viewBox=\"0 0 24 24\"\n",
+              "     width=\"24px\">\n",
+              "    <g>\n",
+              "        <path d=\"M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zM9 17H7v-7h2v7zm4 0h-2V7h2v10zm4 0h-2v-4h2v4z\"/>\n",
+              "    </g>\n",
+              "</svg>\n",
+              "  </button>\n",
+              "\n",
+              "<style>\n",
+              "  .colab-df-quickchart {\n",
+              "      --bg-color: #E8F0FE;\n",
+              "      --fill-color: #1967D2;\n",
+              "      --hover-bg-color: #E2EBFA;\n",
+              "      --hover-fill-color: #174EA6;\n",
+              "      --disabled-fill-color: #AAA;\n",
+              "      --disabled-bg-color: #DDD;\n",
+              "  }\n",
+              "\n",
+              "  [theme=dark] .colab-df-quickchart {\n",
+              "      --bg-color: #3B4455;\n",
+              "      --fill-color: #D2E3FC;\n",
+              "      --hover-bg-color: #434B5C;\n",
+              "      --hover-fill-color: #FFFFFF;\n",
+              "      --disabled-bg-color: #3B4455;\n",
+              "      --disabled-fill-color: #666;\n",
+              "  }\n",
+              "\n",
+              "  .colab-df-quickchart {\n",
+              "    background-color: var(--bg-color);\n",
+              "    border: none;\n",
+              "    border-radius: 50%;\n",
+              "    cursor: pointer;\n",
+              "    display: none;\n",
+              "    fill: var(--fill-color);\n",
+              "    height: 32px;\n",
+              "    padding: 0;\n",
+              "    width: 32px;\n",
+              "  }\n",
+              "\n",
+              "  .colab-df-quickchart:hover {\n",
+              "    background-color: var(--hover-bg-color);\n",
+              "    box-shadow: 0 1px 2px rgba(60, 64, 67, 0.3), 0 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
+              "    fill: var(--button-hover-fill-color);\n",
+              "  }\n",
+              "\n",
+              "  .colab-df-quickchart-complete:disabled,\n",
+              "  .colab-df-quickchart-complete:disabled:hover {\n",
+              "    background-color: var(--disabled-bg-color);\n",
+              "    fill: var(--disabled-fill-color);\n",
+              "    box-shadow: none;\n",
+              "  }\n",
+              "\n",
+              "  .colab-df-spinner {\n",
+              "    border: 2px solid var(--fill-color);\n",
+              "    border-color: transparent;\n",
+              "    border-bottom-color: var(--fill-color);\n",
+              "    animation:\n",
+              "      spin 1s steps(1) infinite;\n",
+              "  }\n",
+              "\n",
+              "  @keyframes spin {\n",
+              "    0% {\n",
+              "      border-color: transparent;\n",
+              "      border-bottom-color: var(--fill-color);\n",
+              "      border-left-color: var(--fill-color);\n",
+              "    }\n",
+              "    20% {\n",
+              "      border-color: transparent;\n",
+              "      border-left-color: var(--fill-color);\n",
+              "      border-top-color: var(--fill-color);\n",
+              "    }\n",
+              "    30% {\n",
+              "      border-color: transparent;\n",
+              "      border-left-color: var(--fill-color);\n",
+              "      border-top-color: var(--fill-color);\n",
+              "      border-right-color: var(--fill-color);\n",
+              "    }\n",
+              "    40% {\n",
+              "      border-color: transparent;\n",
+              "      border-right-color: var(--fill-color);\n",
+              "      border-top-color: var(--fill-color);\n",
+              "    }\n",
+              "    60% {\n",
+              "      border-color: transparent;\n",
+              "      border-right-color: var(--fill-color);\n",
+              "    }\n",
+              "    80% {\n",
+              "      border-color: transparent;\n",
+              "      border-right-color: var(--fill-color);\n",
+              "      border-bottom-color: var(--fill-color);\n",
+              "    }\n",
+              "    90% {\n",
+              "      border-color: transparent;\n",
+              "      border-bottom-color: var(--fill-color);\n",
+              "    }\n",
+              "  }\n",
+              "</style>\n",
+              "\n",
+              "  <script>\n",
+              "    async function quickchart(key) {\n",
+              "      const quickchartButtonEl =\n",
+              "        document.querySelector('#' + key + ' button');\n",
+              "      quickchartButtonEl.disabled = true;  // To prevent multiple clicks.\n",
+              "      quickchartButtonEl.classList.add('colab-df-spinner');\n",
+              "      try {\n",
+              "        const charts = await google.colab.kernel.invokeFunction(\n",
+              "            'suggestCharts', [key], {});\n",
+              "      } catch (error) {\n",
+              "        console.error('Error during call to suggestCharts:', error);\n",
+              "      }\n",
+              "      quickchartButtonEl.classList.remove('colab-df-spinner');\n",
+              "      quickchartButtonEl.classList.add('colab-df-quickchart-complete');\n",
+              "    }\n",
+              "    (() => {\n",
+              "      let quickchartButtonEl =\n",
+              "        document.querySelector('#df-d8914f66-8357-4e5d-a145-b37879cd1b07 button');\n",
+              "      quickchartButtonEl.style.display =\n",
+              "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
+              "    })();\n",
+              "  </script>\n",
+              "</div>\n",
+              "    </div>\n",
+              "  </div>\n"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 55
+        }
+      ],
+      "source": [
+        "pd_flights.drop(columns=['AvgTicketPrice',\n",
+        "                         'Cancelled',\n",
+        "                         'DestLocation',\n",
+        "                         'Dest',\n",
+        "                         'DestAirportID',\n",
+        "                         'DestCityName',\n",
+        "                         'DestCountry'])"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 56,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2021-12-15T20:24:56.151182Z",
+          "iopub.status.busy": "2021-12-15T20:24:56.150754Z",
+          "iopub.status.idle": "2021-12-15T20:25:00.584497Z",
+          "shell.execute_reply": "2021-12-15T20:25:00.583176Z"
+        },
+        "pycharm": {
+          "is_executing": false
+        },
+        "id": "dXLW2KyXNRFo",
+        "outputId": "ce268419-2c97-47bd-ed02-c1e10f110927",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 424
+        }
+      },
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "                Carrier DestRegion  ... dayOfWeek           timestamp\n",
+              "0       Kibana Airlines      SE-BD  ...         0 2018-01-01 00:00:00\n",
+              "1      Logstash Airways      IT-34  ...         0 2018-01-01 18:27:00\n",
+              "2      Logstash Airways      IT-34  ...         0 2018-01-01 17:11:14\n",
+              "3       Kibana Airlines      IT-34  ...         0 2018-01-01 10:33:28\n",
+              "4       Kibana Airlines      SE-BD  ...         0 2018-01-01 05:13:00\n",
+              "...                 ...        ...  ...       ...                 ...\n",
+              "13054  Logstash Airways      SE-BD  ...         6 2018-02-11 20:42:25\n",
+              "13055  Logstash Airways      CH-ZH  ...         6 2018-02-11 01:41:57\n",
+              "13056  Logstash Airways     RU-AMU  ...         6 2018-02-11 04:09:27\n",
+              "13057          JetBeats      SE-BD  ...         6 2018-02-11 08:28:21\n",
+              "13058          JetBeats      US-DC  ...         6 2018-02-11 14:54:34\n",
+              "\n",
+              "[13059 rows x 20 columns]"
+            ],
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>Carrier</th>\n",
+              "      <th>DestRegion</th>\n",
+              "      <th>...</th>\n",
+              "      <th>dayOfWeek</th>\n",
+              "      <th>timestamp</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>Kibana Airlines</td>\n",
+              "      <td>SE-BD</td>\n",
+              "      <td>...</td>\n",
+              "      <td>0</td>\n",
+              "      <td>2018-01-01 00:00:00</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>1</th>\n",
+              "      <td>Logstash Airways</td>\n",
+              "      <td>IT-34</td>\n",
+              "      <td>...</td>\n",
+              "      <td>0</td>\n",
+              "      <td>2018-01-01 18:27:00</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>2</th>\n",
+              "      <td>Logstash Airways</td>\n",
+              "      <td>IT-34</td>\n",
+              "      <td>...</td>\n",
+              "      <td>0</td>\n",
+              "      <td>2018-01-01 17:11:14</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>3</th>\n",
+              "      <td>Kibana Airlines</td>\n",
+              "      <td>IT-34</td>\n",
+              "      <td>...</td>\n",
+              "      <td>0</td>\n",
+              "      <td>2018-01-01 10:33:28</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>4</th>\n",
+              "      <td>Kibana Airlines</td>\n",
+              "      <td>SE-BD</td>\n",
+              "      <td>...</td>\n",
+              "      <td>0</td>\n",
+              "      <td>2018-01-01 05:13:00</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>...</th>\n",
+              "      <td>...</td>\n",
+              "      <td>...</td>\n",
+              "      <td>...</td>\n",
+              "      <td>...</td>\n",
+              "      <td>...</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>13054</th>\n",
+              "      <td>Logstash Airways</td>\n",
+              "      <td>SE-BD</td>\n",
+              "      <td>...</td>\n",
+              "      <td>6</td>\n",
+              "      <td>2018-02-11 20:42:25</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>13055</th>\n",
+              "      <td>Logstash Airways</td>\n",
+              "      <td>CH-ZH</td>\n",
+              "      <td>...</td>\n",
+              "      <td>6</td>\n",
+              "      <td>2018-02-11 01:41:57</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>13056</th>\n",
+              "      <td>Logstash Airways</td>\n",
+              "      <td>RU-AMU</td>\n",
+              "      <td>...</td>\n",
+              "      <td>6</td>\n",
+              "      <td>2018-02-11 04:09:27</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>13057</th>\n",
+              "      <td>JetBeats</td>\n",
+              "      <td>SE-BD</td>\n",
+              "      <td>...</td>\n",
+              "      <td>6</td>\n",
+              "      <td>2018-02-11 08:28:21</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>13058</th>\n",
+              "      <td>JetBeats</td>\n",
+              "      <td>US-DC</td>\n",
+              "      <td>...</td>\n",
+              "      <td>6</td>\n",
+              "      <td>2018-02-11 14:54:34</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>\n",
+              "<p>13059 rows × 20 columns</p>"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 56
+        }
+      ],
+      "source": [
+        "ed_flights.drop(columns=['AvgTicketPrice',\n",
+        "                         'Cancelled',\n",
+        "                         'DestLocation',\n",
+        "                         'Dest',\n",
+        "                         'DestAirportID',\n",
+        "                         'DestCityName',\n",
+        "                         'DestCountry'])"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "g79LTpPBNRFp"
+      },
+      "source": [
+        "### Plotting"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 57,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2021-12-15T20:25:00.608502Z",
+          "iopub.status.busy": "2021-12-15T20:25:00.607311Z",
+          "iopub.status.idle": "2021-12-15T20:25:01.255494Z",
+          "shell.execute_reply": "2021-12-15T20:25:01.255790Z"
+        },
+        "pycharm": {
+          "is_executing": false
+        },
+        "id": "0NVvSP02NRFp",
+        "outputId": "947711b0-4ed4-41ab-ca40-ca9d92ae703d",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 853
+        }
+      },
+      "outputs": [
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<Figure size 1000x1000 with 9 Axes>"
+            ],
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAA1AAAANECAYAAAC+XM68AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjcuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/bCgiHAAAACXBIWXMAAA9hAAAPYQGoP6dpAADRcElEQVR4nOzdeVhUdfs/8PeAzLDogKiAJCJiqSguoSK5ZIogkmlahppibmlQj/qkZrkAVqjlnsvTU0kL5FJmpqaMC664kaSimZrLUwnmAriOI/P5/eFvzteRxQPOCu/XdXnVnPOZc+77zMzN3HM2hRBCgIiIiIiIiB7JwdoBEBERERER2Qs2UERERERERDKxgSIiIiIiIpKJDRQREREREZFMbKCIiIiIiIhkYgNFREREREQkExsoIiIiIiIimdhAERERERERycQGioiIiIiISCY2UGRWDRo0wNChQ8v1nIyMDCgUCnz33XfmCcqEEhISoFAorB0GUYXw/Vu6Ll26oEuXLtLjc+fOQaFQICUlxWoxEdF9rF3yGL5PZWRkSNOGDh2KBg0aWC2myoINVCWyZMkSKBQKhIaGmm0dhg+jnH+2YsmSJSV+6Xk4FycnJzRs2BBDhgzBH3/8YflAiR5TSkqK0Xva2dkZvr6+iIyMxMKFC3H9+vXHXsfff/+NhIQEZGdnP37AFjZ06FBUr1692PQjR46gdu3aaNCgAc6dO2f5wEzoww8/xNq1a60dBlG5sHaVbejQoVAoFFCr1bh9+3ax+adOnZK23ccff2yFCKueatYOgEwnNTUVDRo0wIEDB3D69Gk0atTI5Oto2rQpvv76a6NpkydPRvXq1fHee+8VG3/y5Ek4OFi3T1+yZAlq165d6p6wt956C23btoVOp8Mvv/yCTz/9FBs2bMDRo0fh6+tb5rKnTJmCd955xwxRE1VcUlISAgICoNPpkJubi4yMDIwdOxZz587FunXr0KJFCwAVe//+/fffSExMRIMGDdCqVSszRG9Zx44dQ7du3eDm5obt27dLv8ymp6dbN7AK+vDDD/HSSy+hT58+1g6FqNxYu0pXrVo13Lp1Cz/99BP69+9vNC81NRXOzs64c+eO0fTOnTvj9u3bUCqVlgy1SmADVUmcPXsWe/fuxZo1a/D6668jNTUV06dPN/l6vL298eqrrxpNmzlzJmrXrl1sOgCoVCqTx2BqnTp1wksvvQQAeO211/DUU0/hrbfewpdffonJkyeX+JybN2/Czc0N1apVQ7Vq/BiRbYmKikKbNm2kx5MnT8a2bdvw/PPP44UXXsCJEyfg4uJS5d+/OTk56Nq1K1xcXLB9+3YEBARI8/iF4//cuXMHSqXS6j+GUeXH2lU6lUqFDh064Ntvvy3WQKWlpSE6Ohrff/+90XQHBwc4OztbMswqg9WwkkhNTUXNmjURHR2Nl156CampqQAAnU4HT09PvPbaa8WeU1hYCGdnZ7z99tvStPPnz+OFF16Am5sbvLy8MG7cOGzevLnYMbRylXQOVH5+PsaNG4cGDRpApVKhXr16GDJkCC5fvlzqcrRaLZ5//nm4u7tj7969AAC9Xo/58+ejWbNmcHZ2hre3N15//XVcu3bNaP05OTnYsWOHtHv7wfMaStK1a1cA95tS4P+OtT5+/DgGDhyImjVromPHjkbzHvbNN9+gXbt2cHV1Rc2aNdG5c+div2j//PPP6NSpE9zc3FCjRg1ER0cjJyenzNiIKqpr166YOnUqzp8/j2+++QZAye9fjUaDjh07wsPDA9WrV0fjxo3x7rvvArh/2Gvbtm0B3P+xwfCZMhwiu2vXLrz88suoX78+VCoV/Pz8MG7cuGKHnBgOpfvrr7/Qp08fVK9eHXXq1MHbb7+NoqIio7F6vR4LFixAcHAwnJ2dUadOHfTo0QOHDh0yGvfNN98gJCQELi4u8PT0RExMDP73v/+Vuj1OnDiBbt26QaVSYfv27WjYsKHR/IfPgSrNtm3bpM+xh4cHevfujRMnThiNMWzn33//Ha+++irc3d1Rp04dTJ06FUII/O9//0Pv3r2hVqvh4+ODOXPmFFuPVqvF9OnT0ahRI2nbTpw4EVqtVhqjUChw8+ZNfPnll9Jr82D9/euvvzBs2DB4e3tDpVKhWbNm+OKLL4zWYzi0ecWKFZgyZQqeeOIJuLq6orCwEDqdDomJiXjyySfh7OyMWrVqoWPHjtBoNI/cTkQVxdr1fwYOHIiff/4Z+fn50rSDBw/i1KlTGDhwYLHxJZ0DVRI536cA4NChQ4iMjETt2rXh4uKCgIAADBs2rMxlV1ZVq32vxFJTU9G3b18olUoMGDAAS5cuxcGDB9G2bVu8+OKLWLNmDf7zn/8Y/aq6du1aaLVaxMTEALi/V6Vr1664ePEi/vWvf8HHxwdpaWnYvn27yeK8ceMGOnXqhBMnTmDYsGF4+umncfnyZaxbtw5//vknateuXew5t2/fRu/evXHo0CFs2bJFKoKvv/46UlJS8Nprr+Gtt97C2bNn8cknn+Dw4cPYs2cPnJycMH/+fLz55ptGhxh6e3uXGeOZM2cAALVq1TKa/vLLL+PJJ5/Ehx9+CCFEqc9PTExEQkICnnnmGSQlJUGpVGL//v3Ytm0bIiIiAABff/01YmNjERkZiVmzZuHWrVtYunQpOnbsiMOHD/METzKLwYMH491330V6ejpGjhxZbH5OTg6ef/55tGjRAklJSVCpVDh9+jT27NkD4P4hvElJSZg2bRpGjRqFTp06AQCeeeYZAMDq1atx69YtjBkzBrVq1cKBAwewaNEi/Pnnn1i9erXRuoqKihAZGYnQ0FB8/PHH2LJlC+bMmYPAwECMGTNGGjd8+HCkpKQgKioKI0aMwL1797Br1y7s27dP+qX6gw8+wNSpU9G/f3+MGDEC//zzDxYtWoTOnTvj8OHD8PDwMFr3yZMn0bVrV1SrVg3bt29HYGBghbbnli1bEBUVhYYNGyIhIQG3b9/GokWL0KFDB/zyyy/FPsevvPIKmjZtipkzZ2LDhg14//334enpif/85z/o2rUrZs2ahdTUVLz99tto27YtOnfuDOD+l5sXXngBu3fvxqhRo9C0aVMcPXoU8+bNw++//y6d8/T1119jxIgRaNeuHUaNGgUAUm55eXlo3749FAoF4uPjUadOHfz8888YPnw4CgsLMXbsWKNYZ8yYAaVSibfffhtarRZKpRIJCQlITk6W1lFYWIhDhw7hl19+Qffu3Su0DYnkYO26r2/fvhg9ejTWrFkjNS5paWlo0qQJnn766QpvXznfpy5duoSIiAjUqVMH77zzDjw8PHDu3DmsWbOmwuu1a4Ls3qFDhwQAodFohBBC6PV6Ua9ePfGvf/1LCCHE5s2bBQDx008/GT2vZ8+eomHDhtLjOXPmCABi7dq10rTbt2+LJk2aCABi+/btJa6/WbNm4tlnny1xnr+/v4iNjZUeT5s2TQAQa9asKTZWr9cLIYTYvn27ACBWr14trl+/Lp599llRu3ZtcfjwYWnsrl27BACRmppqtIxNmzYVm15afIb1fPHFF+Kff/4Rf//9t9iwYYNo0KCBUCgU4uDBg0IIIaZPny4AiAEDBhRbhmGewalTp4SDg4N48cUXRVFRUYn5Xb9+XXh4eIiRI0cazc/NzRXu7u7FphPJtXz5cgFAeu+WxN3dXbRu3VoIUfz9O2/ePAFA/PPPP6U+/+DBgwKAWL58ebF5t27dKjYtOTlZKBQKcf78eWlabGysACCSkpKMxrZu3VqEhIRIj7dt2yYAiLfeeqvYcg2fp3PnzglHR0fxwQcfGM0/evSoqFatmtH02NhY4eTkJOrWrSt8fX3F77//Xmqezz77rFHdOHv2bLG8W7VqJby8vMSVK1ekab/++qtwcHAQQ4YMkaYZtvOoUaOkaffu3RP16tUTCoVCzJw5U5p+7do14eLiYlQ3v/76a+Hg4CB27dplFOOyZcsEALFnzx5pmpubm9FzDYYPHy7q1q0rLl++bDQ9JiZGuLu7S6+doS42bNiw2OvZsmVLER0dXcLWIno8rF3/p7Ta5ebmJoQQ4qWXXhLdunUTQghRVFQkfHx8RGJiolSjPvroI+l5hs/zg9/fYmNjhb+/v/RY7vepH3744ZGvUVXCQ/gqgdTUVHh7e+O5554DcP8wjldeeQUrVqxAUVERunbtitq1a2PlypXSc65duwaNRoNXXnlFmrZp0yY88cQTeOGFF6Rpzs7OJf7aU1Hff/89WrZsiRdffLHYvId3xxcUFCAiIgK//fYbMjIyjE76XL16Ndzd3dG9e3dcvnxZ+hcSEoLq1auXa6/ZsGHDUKdOHfj6+iI6Olo6BObB47ABYPTo0Y9c1tq1a6HX6zFt2rRi5wsY8tNoNMjPz8eAAQOMYnd0dERoaKhJ9/gRPax69eqlXtHK8Gvnjz/+CL1eX+5lu7i4SP9/8+ZNXL58Gc888wyEEDh8+HCx8Q9/pjp16mR0Bczvv/8eCoWixPM5DZ+nNWvWQK/Xo3///kafJx8fHzz55JPFPk9FRUW4fPkyPD09S9zjLdfFixeRnZ2NoUOHwtPTU5reokULdO/eHRs3biz2nBEjRkj/7+joiDZt2kAIgeHDh0vTPTw80LhxY6PtsHr1ajRt2hRNmjQxytFwuPGjaoYQAt9//z169eoFIYTRMiIjI1FQUIBffvnF6DmxsbFGr6chtpycHJw6dUrGFiIyrapeuwwGDhyIjIwM5ObmYtu2bcjNzS3x8D255H6fMmzj9evXQ6fTVXh9lQUP4bNzRUVFWLFiBZ577jnpnB0ACA0NxZw5c7B161ZERESgX79+SEtLg1arhUqlwpo1a6DT6YwaqPPnzyMwMLBYI2PKq/mdOXMG/fr1kzV27NixuHPnDg4fPoxmzZoZzTt16hQKCgrg5eVV4nMvXbokO6Zp06ahU6dOcHR0RO3atdG0adMST0598ATz0pw5cwYODg4ICgoqdYzhy4fhy8/D1Gq1zMiJyu/GjRulfm5eeeUVfPbZZxgxYgTeeecddOvWDX379sVLL70k6wICFy5cwLRp07Bu3bpix84XFBQYPTacE/CgmjVrGj3vzJkz8PX1NWpQHnbq1CkIIfDkk0+WON/JycnosYuLCz777DMMGjQI0dHR0Gg0cHNze2RuDzt//jwAoHHjxsXmNW3aFJs3b5YuNmNQv359o3Hu7u5wdnYu1si5u7vjypUr0uNTp07hxIkTxbaXwaPq3T///IP8/Hx8+umn+PTTT2Uto6R6l5SUhN69e+Opp55C8+bN0aNHDwwePFi6MhqROVX12mXQs2dP1KhRAytXrkR2djbatm2LRo0aVfgWDHK/Tz377LPo168fEhMTMW/ePHTp0gV9+vTBwIED7eKCYabGBsrObdu2DRcvXsSKFSuwYsWKYvNTU1MRERGBmJgY/Oc//8HPP/+MPn36YNWqVWjSpAlatmxphajl6d27N1asWIGZM2fiq6++MiqCer0eXl5e0sUyHlbaF42SBAcHIzw8/JHjHv41tqIMv459/fXX8PHxKTa/ql1ZiCznzz//REFBQak/iri4uGDnzp3Yvn07NmzYgE2bNmHlypXo2rUr0tPT4ejoWOqyi4qK0L17d1y9ehWTJk1CkyZN4Obmhr/++gtDhw4t9qtwWcsqD71eD4VCgZ9//rnEZZZ036eYmBhcu3YNb7zxBvr27YuffvrJIlfdKym+0raDeOA8S71ej+DgYMydO7fEsX5+fmWu17DtX331VcTGxpY45uEmqKR617lzZ5w5cwY//vgj0tPT8dlnn2HevHlYtmyZ0d41IlNj7fo/KpUKffv2xZdffok//vgDCQkJjx2HnO9TCoUC3333Hfbt24effvoJmzdvxrBhwzBnzhzs27ev1HgrK35Ts3Opqanw8vLC4sWLi81bs2YNfvjhByxbtgydO3dG3bp1sXLlSnTs2BHbtm0rdt8mf39/HD9+HEIIo71Qp0+fNlm8gYGBOHbsmKyxffr0QUREBIYOHYoaNWpg6dKlRsvZsmULOnTo8MjGxpI39Q0MDIRer8fx48dLvc+E4aRuLy8vWY0bkakY7uEWGRlZ6hgHBwd069YN3bp1w9y5c/Hhhx/ivffew/bt2xEeHl7q5+no0aP4/fff8eWXX2LIkCHS9Me5QltgYCA2b96Mq1evlvpLbmBgIIQQCAgIwFNPPSV72WPGjMHVq1cxZcoUvPrqq1ixYkW5LtPt7+8P4P4FKR7222+/oXbt2hXas1WSwMBA/Prrr+jWrdsj61lJ8+vUqYMaNWqgqKjosWuO4aqur732Gm7cuIHOnTsjISGBDRSZFWuXsYEDB+KLL76Ag4ODdCGwx4lV7vcpAGjfvj3at2+PDz74AGlpaRg0aBBWrFhR5WoAz4GyY7dv38aaNWvw/PPP46WXXir2Lz4+HtevX8e6devg4OCAl156CT/99BO+/vpr3Lt3z+jwPeB+Yfrrr7+wbt06adqdO3fw3//+12Qx9+vXD7/++it++OGHYvNECVe2GzJkCBYuXIhly5Zh0qRJ0vT+/fujqKgIM2bMKPace/fuGV3i083NzeixOfXp0wcODg5ISkoq9quVIb/IyEio1Wp8+OGHJR5H/M8//1gkVqpatm3bhhkzZiAgIACDBg0qcczVq1eLTTP8EGC4XLahKXj4M2X4BfXBz7EQAgsWLKhwzP369YMQAomJicXmGdbTt29fODo6IjExsVgNEUIYHQr3sPfeew/jxo3D6tWr8frrr5crtrp166JVq1b48ssvjbbFsWPHkJ6ejp49e5ZreWXp378//vrrrxJr8e3bt3Hz5k3pcUn1ztHREf369cP3339f4g9YcmvOw9uyevXqaNSokdGl1IlMjbWruOeeew4zZszAJ598UuKRLOUh9/vUtWvXisX58DauSrgHyo6tW7cO169fN7row4Pat2+POnXqIDU1Fa+88gpeeeUVLFq0CNOnT0dwcDCaNm1qNP7111/HJ598ggEDBuBf//oX6tatK93dGjDNnpwJEybgu+++w8svv4xhw4YhJCQEV69exbp167Bs2bISDymMj49HYWEh3nvvPbi7u+Pdd9/Fs88+i9dffx3JycnIzs5GREQEnJyccOrUKaxevRoLFiyQbo4bEhKCpUuX4v3330ejRo3g5eVV6vlHj6tRo0Z47733MGPGDHTq1Al9+/aFSqXCwYMH4evri+TkZKjVaixduhSDBw/G008/jZiYGNSpUwcXLlzAhg0b0KFDB3zyySdmiY+qhp9//hm//fYb7t27h7y8PGzbtg0ajQb+/v5Yt25dqTdWTEpKws6dOxEdHQ1/f39cunQJS5YsQb169aR7nwUGBsLDwwPLli1DjRo14ObmhtDQUDRp0gSBgYF4++238ddff0GtVuP7778vdj5BeTz33HMYPHgwFi5ciFOnTqFHjx7Q6/XYtWsXnnvuOcTHxyMwMBDvv/8+Jk+ejHPnzqFPnz6oUaMGzp49ix9++AGjRo0yutfdw+bMmYNr167hs88+g6enJ2bNmiU7vo8++ghRUVEICwvD8OHDpcuYu7u7P/ZhNQ8aPHgwVq1ahdGjR2P79u3o0KEDioqK8Ntvv2HVqlXYvHmzdNGbkJAQbNmyBXPnzoWvry8CAgIQGhqKmTNnYvv27QgNDcXIkSMRFBSEq1ev4pdffsGWLVtK/AL6sKCgIHTp0gUhISHw9PTEoUOH8N133yE+Pt5kuVLVxtolr3Y5ODhgypQpFY7vQXK/T3355ZdYsmQJXnzxRQQGBuL69ev473//C7VabdIfjOyGpS73R6bXq1cv4ezsLG7evFnqmKFDhwonJydx+fJlodfrhZ+fnwAg3n///RLH//HHHyI6Olq4uLiIOnXqiH//+9/i+++/FwDEvn37SnxOeS5jLoQQV65cEfHx8eKJJ54QSqVS1KtXT8TGxkqX133wMuYPmjhxogAgPvnkE2nap59+KkJCQoSLi4uoUaOGCA4OFhMnThR///23NCY3N1dER0eLGjVqCABSrKWt52GGy6WWdHnUhy+lavDFF1+I1q1bC5VKJWrWrCmeffZZ6TLzBtu3bxeRkZHC3d1dODs7i8DAQDF06FBx6NChMuMhKo3hUsCGf0qlUvj4+Iju3buLBQsWiMLCQqPxD79/t27dKnr37i18fX2FUqkUvr6+YsCAAcUu9/3jjz+KoKAgUa1aNaPLAh8/flyEh4eL6tWri9q1a4uRI0eKX3/9tdilgx+8JG9Z8Qhx/3LfH330kWjSpIlQKpWiTp06IioqSmRlZRmN+/7770XHjh2Fm5ubcHNzE02aNBFxcXHi5MmTj1zvvXv3RJ8+fQQAkZycLISQdxlzIYTYsmWL6NChg3BxcRFqtVr06tVLHD9+vMS8Hq4hpcXz7LPPimbNmhlNu3v3rpg1a5Zo1qyZVFdCQkJEYmKiKCgokMb99ttvonPnzsLFxUUAMKq/eXl5Ii4uTvj5+QknJyfh4+MjunXrJj799FNpTFl18f333xft2rUTHh4ewsXFRTRp0kR88MEH4u7du8XGEpUHa1fFateDKnoZc4NHfZ/65ZdfxIABA0T9+vWFSqUSXl5e4vnnn6+y31kUQpRxR1AiAPPnz8e4cePw559/4oknnrB2OEREREREVsMGiozcvn3b6CTCO3fuoHXr1igqKsLvv/9uxciIiIiIiKyP50CRkb59+6J+/fpo1aoVCgoK8M033+C3334r9fKWRERERERVCRsoMhIZGYnPPvsMqampKCoqQlBQEFasWFHsin1ERERERFURD+EjIiIiIiKSifeBIiIiIiIikokNFBERERERkUxV+hwovV6Pv//+GzVq1DDJTWKJ6D4hBK5fvw5fX184OFS932lYW4jMh/WF9YXIXOTWlyrdQP3999/w8/OzdhhEldb//vc/1KtXz9phWBxrC5H5sb4Qkbk8qr5U6QaqRo0aAO5vJLVabeVoAJ1Oh/T0dERERMDJycna4chibzHbW7yA/cWs0+mwdu1ajBgxQvqMVTVya4u9vbYlqQw5AJUjj6qSQ2FhIfz8/FhfqkB9sRZuu8djz9tPbn2p0g2UYde3Wq22mQbK1dUVarXabt5w9hazvcUL2F/MhngBVNnDS+TWFnt7bUtSGXIAKkceVS0H1pfKX1+shdvu8VSG7feo+lL1Dh4mIru1dOlStGjRQvriEBYWhp9//lmaf+fOHcTFxaFWrVqoXr06+vXrh7y8PKNlXLhwAdHR0XB1dYWXlxcmTJiAe/fuGY3JyMjA008/DZVKhUaNGiElJcUS6RGRFbG+EJFcbKCIyG7Uq1cPM2fORFZWFg4dOoSuXbuid+/eyMnJAQCMGzcOP/30E1avXo0dO3bg77//Rt++faXnFxUVITo6Gnfv3sXevXvx5ZdfIiUlBdOmTZPGnD17FtHR0XjuueeQnZ2NsWPHYsSIEdi8ebPF8yUiy2F9ISK5qvQhfERkX3r16mX0+IMPPsDSpUuxb98+1KtXD59//jnS0tLQtWtXAMDy5cvRtGlT7Nu3D+3bt0d6ejqOHz+OLVu2wNvbG61atcKMGTMwadIkJCQkQKlUYtmyZQgICMCcOXMAAE2bNsXu3bsxb948REZGWjxnIrIM1hcikosNFBHZpaKiIqxevRo3b95EWFgYsrKyoNPpEB4eLo1p0qQJ6tevj8zMTLRv3x6ZmZkIDg6Gt7e3NCYyMhJjxoxBTk4OWrdujczMTKNlGMaMHTu21Fi0Wi20Wq30uLCwEMD948B1Ol2pzzPMK2uMrasMOQCVI4+qkoMl8mN9qdq47R6PPW8/uTGzgSIiu3L06FGEhYXhzp07qF69On744QcEBQUhOzsbSqUSHh4eRuO9vb2Rm5sLAMjNzTX6cmOYb5hX1pjCwkLcvn0bLi4uxWJKTk5GYmJisenp6enSBTXKotFoHjnG1lWGHIDKkUdlz+HWrVtmWy/rCz2I2+7x2OP2k1tf2EARkV1p3LgxsrOzUVBQgO+++w6xsbHYsWOHVWOaPHkyxo8fLz02XAY1IiLikVfJ0mg06N69u91eqagy5ABUjjyqSg6GPTDmwPpCALfd47Ln7Se3vrCBIiK7olQq0ahRIwBASEgIDh48iAULFuCVV17B3bt3kZ+fb/QrcV5eHnx8fAAAPj4+OHDggNHyDFfRenDMw1fWysvLg1qtLvHXYQBQqVRQqVTFpjs5Ocn64yF3nC2rDDkAlSOPyp6DOXNjfaEHcds9HnvcfnLjZQNFVVaDdzaYbFnnZkabbFlUPnq9HlqtFiEhIXBycsLWrVvRr18/AMDJkydx4cIFhIWFAQDCwsLwwQcf4NKlS/Dy8gJw/xADtVqNoKAgaczGjRuN1qHRaKRlmEPzhM3QFpnmnjZ8LxKZDuuLMdYXovvYQBGR3Zg8eTKioqJQv359XL9+HWlpacjIyMDmzZvh7u6O4cOHY/z48fD09IRarcabb76JsLAwtG/fHgAQERGBoKAgDB48GLNnz0Zubi6mTJmCuLg46Rfe0aNH45NPPsHEiRMxbNgwbNu2DatWrcKGDaZruInI9rC+EJFcbKCIyG5cunQJQ4YMwcWLF+Hu7o4WLVpg8+bN6N69OwBg3rx5cHBwQL9+/aDVahEZGYklS5ZIz3d0dMT69esxZswYhIWFwc3NDbGxsUhKSpLGBAQEYMOGDRg3bhwWLFiAevXq4bPPPuMlhm2QKfcin5oRYbJlkX1ifSGD5gmbMbud6fbecc9d5cMGiojsxueff17mfGdnZyxevBiLFy8udYy/v3+xQ2ge1qVLFxw+fLhCMRKRfWJ9ISK5HKwdABERERERkb3gHiiyG6Y4XEflKKTd8oBpTqolIiIioqqDe6CIiIiIiIhkYgNFREREREQkExsoIiIiIiIimdhAERERERERycQGioiIiIiISCY2UERERERERDKxgSIiIiIiIpKJDRQREREREZFMbKCIiIiIiIhkqmbtAIgqgwbvbDDp8s7NjDbp8oiIiIjINLgHioiIiIiISCY2UERERERERDLxED4yK1Mf2kZEREREZE3cA0VERERERCQTGygiIiIiIiKZeAgfERFZBA/pJSJzMWV9UTmabFFUSXEPFBERERERkUxsoIiIiIiIiGRiA0VERERERCQTGygiIiIiIiKZ2EARERERERHJxAaKiOxGcnIy2rZtixo1asDLywt9+vTByZMnjcZ06dIFCoXC6N/o0aONxly4cAHR0dFwdXWFl5cXJkyYgHv37hmNycjIwNNPPw2VSoVGjRohJSXF3OkRkRWxvhCRXGygiMhu7NixA3Fxcdi3bx80Gg10Oh0iIiJw8+ZNo3EjR47ExYsXpX+zZ8+W5hUVFSE6Ohp3797F3r178eWXXyIlJQXTpk2Txpw9exbR0dF47rnnkJ2djbFjx2LEiBHYvHmzxXIlIstifSEiuXgfKCKyG5s2bTJ6nJKSAi8vL2RlZaFz587SdFdXV/j4+JS4jPT0dBw/fhxbtmyBt7c3WrVqhRkzZmDSpElISEiAUqnEsmXLEBAQgDlz5gAAmjZtit27d2PevHmIjIw0X4JEZDWsL0Qkl8n3QO3cuRO9evWCr68vFAoF1q5dazR/6NChxXZ/9+jRw2jM1atXMWjQIKjVanh4eGD48OG4ceOG0ZgjR46gU6dOcHZ2hp+fn9EvQERUNRQUFAAAPD09jaanpqaidu3aaN68OSZPnoxbt25J8zIzMxEcHAxvb29pWmRkJAoLC5GTkyONCQ8PN1pmZGQkMjMzzZUKEdkY1hciKo3J90DdvHkTLVu2xLBhw9C3b98Sx/To0QPLly+XHqtUKqP5gwYNwsWLF6Vd6K+99hpGjRqFtLQ0AEBhYSEiIiIQHh6OZcuW4ejRoxg2bBg8PDwwatQoU6dUpZT3Tt4qR4HZ7YDmCZuhLVKYKSqi4vR6PcaOHYsOHTqgefPm0vSBAwfC398fvr6+OHLkCCZNmoSTJ09izZo1AIDc3FyjLzcApMe5ublljiksLMTt27fh4uJiNE+r1UKr1UqPCwsLAQA6nQ46na7UHAzzVA6iXLmXpaz1mYNhfXLWq3I0XZ6mVp48bFVVycES+bG+lL1MW2TK+mLYZqbadra83czBnmuR3JhN3kBFRUUhKiqqzDEqlarU3d8nTpzApk2bcPDgQbRp0wYAsGjRIvTs2RMff/wxfH19kZqairt37+KLL76AUqlEs2bNkJ2djblz57KBIqoi4uLicOzYMezevdto+oM1IDg4GHXr1kW3bt1w5swZBAYGmiWW5ORkJCYmFpuenp4OV1fXRz5/Rhu9yWLZuHGjyZZVHhqN5pFjZrezQCAVZIhfTh62rrLn8OAeH3NhfSmZteqLHOaoL6badra83czJHmuR3PpilXOgMjIy4OXlhZo1a6Jr1654//33UatWLQD3d217eHhIzRMAhIeHw8HBAfv378eLL76IzMxMdO7cGUqlUhoTGRmJWbNm4dq1a6hZs6bFcyIiy4mPj8f69euxc+dO1KtXr8yxoaGhAIDTp08jMDAQPj4+OHDggNGYvLw8AJB+2PHx8ZGmPThGrVYX+3UYACZPnozx48dLjwsLC+Hn54eIiAio1epSY9PpdNBoNJh6yAFavWn24B5LsOw5FIYcunfvDicnpzLHNk+w3ZPkD7/XVXYetqo8r4WtkpODYQ+MubC+lM7S9aU8TFlfVA4CM9roTbbtbHm7mYM91yK59cXiDVSPHj3Qt29fBAQE4MyZM3j33XcRFRWFzMxMODo6Ijc3F15eXsZBVqsGT09Po93fAQEBRmMe3EVeWgNV0d3glmILuzzLuwvc1Lu5zc1e4n3wPWAL74vyMGecQgi8+eab+OGHH5CRkVGsDpQkOzsbAFC3bl0AQFhYGD744ANcunRJqjUajQZqtRpBQUHSmId/MdRoNAgLCytxHSqVqtihyADg5OQk64+HVq8w2SGw1vpjJSdXWz7M1xC73NfMllX2HMyVG+vLo9ny+8oc9cVU286Wt5s52WMtkhuvxRuomJgY6f+Dg4PRokULBAYGIiMjA926dTPruh93N7ilWHOXZ0V3gZvyEAFLsPV4S9rdb4+7wk0tLi4OaWlp+PHHH1GjRg3pRxV3d3e4uLjgzJkzSEtLQ8+ePVGrVi0cOXIE48aNQ+fOndGiRQsAQEREBIKCgjB48GDMnj0bubm5mDJlCuLi4qQvKaNHj8Ynn3yCiRMnYtiwYdi2bRtWrVqFDRvKd44gEdkP1hciksvqlzFv2LAhateujdOnT6Nbt27w8fHBpUuXjMbcu3cPV69efeTub8O80lR0N7il2MIuz/LuAjf1bm5zs5d4H9zdbwvvi/LQ6XT48ccfzbLspUuXArh/M8sHLV++HEOHDoVSqcSWLVswf/583Lx5E35+fujXrx+mTJkijXV0dMT69esxZswYhIWFwc3NDbGxsUhKSpLGBAQEYMOGDRg3bhwWLFiAevXq4bPPPuMlhokqMdYXIpLL6g3Un3/+iStXrhjt/s7Pz0dWVhZCQkIAANu2bYNer5eONQ4LC8N7770HnU4nfaHUaDRo3Lhxmec/Pe5ucEuxZjwV3VVtykMELMHW4y3p9be196k1CFH2oZd+fn7YsWPHI5fj7+//yJN6u3TpgsOHD5crPiKyX6wvRCSXye8DdePGDWRnZ0vHBZ89exbZ2dm4cOECbty4gQkTJmDfvn04d+4ctm7dit69e6NRo0bSLy9NmzZFjx49MHLkSBw4cAB79uxBfHw8YmJi4OvrC+D+ZUSVSiWGDx+OnJwcrFy5EgsWLDDau0RERERERGRqJm+gDh06hNatW6N169YAgPHjx6N169aYNm0aHB0dceTIEbzwwgt46qmnMHz4cISEhGDXrl1Ge4ZSU1PRpEkTdOvWDT179kTHjh3x6aefSvPd3d2Rnp6Os2fPIiQkBP/+978xbdo0XsKciIiIiIjMyuSH8HXp0qXM3eCbNz/6HBtPT0/pprmladGiBXbt2lXu+IiIiIiIiCrK5HugiIiIiIiIKis2UERERERERDJZ/Sp89PgavMN7RxARERERWQL3QBEREREREcnEBoqIiIiIiEgmNlBEREREREQysYEiIiIiIiKSiQ0UERERERGRTGygiIiIiIiIZGIDRUREREREJBMbKCIiIiIiIpnYQBEREREREcnEBoqIiIiIiEgmNlBEREREREQysYEiIiIiIiKSiQ0UERERERGRTGygiIiIiIiIZGIDRUREREREJBMbKCIiIiIiIpnYQBEREREREcnEBoqIiIiIiEgmNlBEZDeSk5PRtm1b1KhRA15eXujTpw9OnjxpNObOnTuIi4tDrVq1UL16dfTr1w95eXlGYy5cuIDo6Gi4urrCy8sLEyZMwL1794zGZGRk4Omnn4ZKpUKjRo2QkpJi7vSIyIpYX4hIrmrWDqAqavDOhhKnqxwFZrcDmidshrZIYeGoiGzfjh07EBcXh7Zt2+LevXt49913ERERgePHj8PNzQ0AMG7cOGzYsAGrV6+Gu7s74uPj0bdvX+zZswcAUFRUhOjoaPj4+GDv3r24ePEihgwZAicnJ3z44YcAgLNnzyI6OhqjR49Gamoqtm7dihEjRqBu3bqIjIy0Wv5EZD6sL0QkFxsoIrIbmzZtMnqckpICLy8vZGVloXPnzigoKMDnn3+OtLQ0dO3aFQCwfPlyNG3aFPv27UP79u2Rnp6O48ePY8uWLfD29karVq0wY8YMTJo0CQkJCVAqlVi2bBkCAgIwZ84cAEDTpk2xe/duzJs3j19wiCop1hcikosNFBHZrYKCAgCAp6cnACArKws6nQ7h4eHSmCZNmqB+/frIzMxE+/btkZmZieDgYHh7e0tjIiMjMWbMGOTk5KB169bIzMw0WoZhzNixY0uMQ6vVQqvVSo8LCwsBADqdDjqdrtT4DfNUDqIcWZetrPWZg2F9ctarcjRdnqZWnjxsVVXJwVL5sb6UvkxbZMr6Ythmptp2trzdzMGea5HcmNlAEZFd0uv1GDt2LDp06IDmzZsDAHJzc6FUKuHh4WE01tvbG7m5udKYB7/cGOYb5pU1prCwELdv34aLi4vRvOTkZCQmJhaLMT09Ha6uro/MZUYb/SPHyLVx40aTLas8NBrNI8fMbmeBQCrIEL+cPGxdZc/h1q1bZl8/60vJrFVf5DBHfTHVtrPl7WZO9liL5NYXNlBEZJfi4uJw7Ngx7N6929qhYPLkyRg/frz0uLCwEH5+foiIiIBarS71eTqdDhqNBlMPOUCrN815j8cSLHsIkCGH7t27w8nJqcyxzRM2Wyiq8jv8XlfZediq8rwWtkpODoY9MObE+lIyS9eX8jBlfVE5CMxoozfZtrPl7WYO9lyL5NYXNlBEZHfi4+Oxfv167Ny5E/Xq1ZOm+/j44O7du8jPzzf6lTgvLw8+Pj7SmAMHDhgtz3AVrQfHPHxlrby8PKjV6mK/DgOASqWCSqUqNt3JyUnWHw+tXmGyC8dY64+VnFxt+eI4htjlvma2rLLnYO7cWF9KZ8vvK3PUF1NtO1vebuZkj7VIbry8jDkR2Q0hBOLj4/HDDz9g27ZtCAgIMJofEhICJycnbN26VZp28uRJXLhwAWFhYQCAsLAwHD16FJcuXZLGaDQaqNVqBAUFSWMeXIZhjGEZRFT5sL4QkVzcA0VEdiMuLg5paWn48ccfUaNGDemcAnd3d7i4uMDd3R3Dhw/H+PHj4enpCbVajTfffBNhYWFo3749ACAiIgJBQUEYPHgwZs+ejdzcXEyZMgVxcXHSr7yjR4/GJ598gokTJ2LYsGHYtm0bVq1ahQ0bSr4FARHZP9YXIpKLe6CIyG4sXboUBQUF6NKlC+rWrSv9W7lypTRm3rx5eP7559GvXz907twZPj4+WLNmjTTf0dER69evh6OjI8LCwvDqq69iyJAhSEpKksYEBARgw4YN0Gg0aNmyJebMmYPPPvuMlxgmqsRYX4hILu6BIiK7IcSjLynr7OyMxYsXY/HixaWO8ff3f+RVkbp06YLDhw+XO0Yisk+sL0QkF/dAERERERERycQGioiIiIiISCY2UERERERERDKxgSIiIiIiIpKJDRQREREREZFMbKCIiIiIiIhkYgNFREREREQkExsoIiIiIiIimdhAERERERERycQGioiIiIiISCY2UERERERERDKxgSIiIiIiIpKJDRQREREREZFMbKCIiIiIiIhkMnkDtXPnTvTq1Qu+vr5QKBRYu3at0XwhBKZNm4a6devCxcUF4eHhOHXqlNGYq1evYtCgQVCr1fDw8MDw4cNx48YNozFHjhxBp06d4OzsDD8/P8yePdvUqRARERERERkxeQN18+ZNtGzZEosXLy5x/uzZs7Fw4UIsW7YM+/fvh5ubGyIjI3Hnzh1pzKBBg5CTkwONRoP169dj586dGDVqlDS/sLAQERER8Pf3R1ZWFj766CMkJCTg008/NXU6REREREREkmqmXmBUVBSioqJKnCeEwPz58zFlyhT07t0bAPDVV1/B29sba9euRUxMDE6cOIFNmzbh4MGDaNOmDQBg0aJF6NmzJz7++GP4+voiNTUVd+/exRdffAGlUolmzZohOzsbc+fONWq0iIiIiIiITMnkDVRZzp49i9zcXISHh0vT3N3dERoaiszMTMTExCAzMxMeHh5S8wQA4eHhcHBwwP79+/Hiiy8iMzMTnTt3hlKplMZERkZi1qxZuHbtGmrWrFni+rVaLbRarfS4sLAQAKDT6aDT6UydbqlUjqLk6Q7C6L/2wN5itpd4H3w/Gv7fku/Rx2EvcRIRERFVhEUbqNzcXACAt7e30XRvb29pXm5uLry8vIzmV6tWDZ6enkZjAgICii3DMK+0Bio5ORmJiYnFpqenp8PV1bUCGVXM7HZlz5/RRm+ZQEzI3mK29Xg3btxYbJpGo7FCJERERET0IIs2UNY2efJkjB8/XnpcWFgIPz8/REREQK1WWyyO5gmbS5yuchCY0UaPqYccoNUrLBbP47C3mO0l3mMJkdL/63Q6aDQadO/eHU5OTlaMSh6dTocff/zR2mEQERERmYVFGygfHx8AQF5eHurWrStNz8vLQ6tWraQxly5dMnrevXv3cPXqVen5Pj4+yMvLMxpjeGwYUxKVSgWVSlVsupOTk0W/mGqLyv7irtUrHjnG1thbzLYeb0nvR0u/T4mIiIioOIveByogIAA+Pj7YunWrNK2wsBD79+9HWFgYACAsLAz5+fnIysqSxmzbtg16vR6hoaHSmJ07dxqda6HRaNC4ceNSD98jIiIiIiJ6XCZvoG7cuIHs7GxkZ2cDuH/hiOzsbFy4cAEKhQJjx47F+++/j3Xr1uHo0aMYMmQIfH190adPHwBA06ZN0aNHD4wcORIHDhzAnj17EB8fj5iYGPj6+gIABg4cCKVSieHDhyMnJwcrV67EggULjA7PIyIiIiIiMjWTN1CHDh1C69at0bp1awDA+PHj0bp1a0ybNg0AMHHiRLz55psYNWoU2rZtixs3bmDTpk1wdnaWlpGamoomTZqgW7du6NmzJzp27Gh0jyd3d3ekp6fj7NmzCAkJwb///W9MmzaNlzAnquQedaPuoUOHQqFQGP3r0aOH0RjeqJuISsL6QkRymfwcqC5dukCI0i8RrVAokJSUhKSkpFLHeHp6Ii0trcz1tGjRArt27apwnERkfww36h42bBj69u1b4pgePXpg+fLl0uOHz3scNGgQLl68CI1GA51Oh9deew2jRo2Sao7hRt3h4eFYtmwZjh49imHDhsHDw4M/0hBVYqwvRCRXlboKHxHZt7Ju1G2gUqlKvZgMb9RNRKVhfSEiuSx6EQkiInPLyMiAl5cXGjdujDFjxuDKlSvSvEfdqNswpqQbdZ88eRLXrl2zXCJEZHNYX4gI4B4oIqpEevTogb59+yIgIABnzpzBu+++i6ioKGRmZsLR0dFsN+rWarXQarXS48LCQgD374n14NVCH2aYp3Io/bDn8iprfeZgWJ+c9aocTZenqZUnD1tVVXKwVn6sL7b93jJlfTFsM1NtO1vebuZgz7VIbsxsoIio0oiJiZH+Pzg4GC1atEBgYCAyMjLQrVs3s603OTkZiYmJxaanp6fD1dX1kc+f0UZvslg2btxosmWVh0ajeeSY2e0sEEgFGeKXk4etq+w53Lp1y4KR/B/WF+vVFznMUV9Mte1sebuZkz3WIrn1hQ0UEVVaDRs2RO3atXH69Gl069bNbDfqnjx5stFtFAoLC+Hn54eIiAio1epS49PpdNBoNJh6yAFavWlu7HwsIdIky5HLkEP37t0feaPn5gmbLRRV+R1+r6vsPGxVeV4LWyUnB8MeGGtjfbEtpqwvKgeBGW30Jtt2trzdzMGea5Hc+sIGiogqrT///BNXrlxB3bp1ARjfqDskJARAyTfqfu+996DT6aTC/6gbdatUqmJX4wIAJycnWX88tHoFtEWm+YJjrT9WcnI1VY7mYIhd7mtmyyp7DraSG+uLbTFHfTHVtrPl7WZO9liL5MbLi0gQkd0o60bdN27cwIQJE7Bv3z6cO3cOW7duRe/evdGoUSNERt7/9Y836iai0rC+EJFcbKCIyG6UdaNuR0dHHDlyBC+88AKeeuopDB8+HCEhIdi1a5fRr7e8UTcRlYT1hYjk4iF8RGQ3HnWj7s2bH30MPG/UTUQlYX0hIrm4B4qIiIiIiEgmNlBEREREREQysYEiIiIiIiKSiQ0UERERERGRTLyIhAwN3tlg7RCIiIiIiMgGcA8UERERERGRTNwDRUREVV7zhM2Y3e7+f7VFisde3rmZ0SaIiogqA1MfycT6Yn3cA0VERERERCQTGygiIiIiIiKZ2EARERERERHJxAaKiIiIiIhIJjZQREREREREMrGBIiIiIiIikokNFBERERERkUxsoIiIiIiIiGRiA0VERERERCRTNWsHQETFPXjXcpWjwOx2QPOEzdAWKSq0PN61nIiIiMg0uAeKiIiIiIhIJjZQREREREREMrGBIiIiIiIikokNFBERERERkUxsoIiIiIiIiGRiA0VERERERCQTGygiIiIiIiKZ2EARkd3YuXMnevXqBV9fXygUCqxdu9ZovhAC06ZNQ926deHi4oLw8HCcOnXKaMzVq1cxaNAgqNVqeHh4YPjw4bhx44bRmCNHjqBTp05wdnaGn58fZs+ebe7UiMjKWF+ISC42UERkN27evImWLVti8eLFJc6fPXs2Fi5ciGXLlmH//v1wc3NDZGQk7ty5I40ZNGgQcnJyoNFosH79euzcuROjRo2S5hcWFiIiIgL+/v7IysrCRx99hISEBHz66admz4+IrIf1hYjkqmbtAIiI5IqKikJUVFSJ84QQmD9/PqZMmYLevXsDAL766it4e3tj7dq1iImJwYkTJ7Bp0yYcPHgQbdq0AQAsWrQIPXv2xMcffwxfX1+kpqbi7t27+OKLL6BUKtGsWTNkZ2dj7ty5Rl+EiKhyYX0hIrnYQBFRpXD27Fnk5uYiPDxcmubu7o7Q0FBkZmYiJiYGmZmZ8PDwkL7cAEB4eDgcHBywf/9+vPjii8jMzETnzp2hVCqlMZGRkZg1axauXbuGmjVrFlu3VquFVquVHhcWFgIAdDoddDpdqTEb5qkcRMUTL2WZlmJYn5z1qhxNl6epGV4DU70Wln4dHlynNdZtKnJysEZ+rC/Gy7RFpqwvpq4HpmbLrwNg37VIbsxsoIioUsjNzQUAeHt7G0339vaW5uXm5sLLy8tofrVq1eDp6Wk0JiAgoNgyDPNK+oKTnJyMxMTEYtPT09Ph6ur6yNhntNE/coxcGzduNNmyykOj0TxyzOx2FgjkMZnqtbDW6wDIey1sXVk53Lp1y4KR3Mf6cp8139ePYo76YsptZ0q2/Do8yB5rkdz6wgaKiOgxTZ48GePHj5ceFxYWws/PDxEREVCr1aU+T6fTQaPRYOohB2j1CpPEciwh0iTLkcuQQ/fu3eHk5FTm2OYJmy0UVfmpHARmtNGb7LWw9OsAlO+1sFVycjDsgakqqnJ9KQ9T1hdT1wNTs+XXAbDvWiS3vrCBIqJKwcfHBwCQl5eHunXrStPz8vLQqlUracylS5eMnnfv3j1cvXpVer6Pjw/y8vKMxhgeG8Y8TKVSQaVSFZvu5OQk64+HVq+Atsg0f6St9cdKTq6mytGcTPVaWPNLg9z3nS0rKwdr5Mb68n/rtFXmqC+m3HamZMuvw4PssRbJjZdX4SOiSiEgIAA+Pj7YunWrNK2wsBD79+9HWFgYACAsLAz5+fnIysqSxmzbtg16vR6hoaHSmJ07dxodB63RaNC4ceMSD68hosqP9YWIHsQGiojsxo0bN5CdnY3s7GwA90/szs7OxoULF6BQKDB27Fi8//77WLduHY4ePYohQ4bA19cXffr0AQA0bdoUPXr0wMiRI3HgwAHs2bMH8fHxiImJga+vLwBg4MCBUCqVGD58OHJycrBy5UosWLDA6BAaIqp8WF+ISC4ewkdEduPQoUN47rnnpMeGLx2xsbFISUnBxIkTcfPmTYwaNQr5+fno2LEjNm3aBGdnZ+k5qampiI+PR7du3eDg4IB+/fph4cKF0nx3d3ekp6cjLi4OISEhqF27NqZNm8ZLDBNVcqwvRCQXGygishtdunSBEKVfVlahUCApKQlJSUmljvH09ERaWlqZ62nRogV27dpV4TiJyP6wvhCRXDyEj4iIiIiISCarNFAJCQlQKBRG/5o0aSLNv3PnDuLi4lCrVi1Ur14d/fr1K3bVmgsXLiA6Ohqurq7w8vLChAkTcO/ePUunQkREREREVYjVDuFr1qwZtmzZ8n+BVPu/UMaNG4cNGzZg9erVcHd3R3x8PPr27Ys9e/YAAIqKihAdHQ0fHx/s3bsXFy9exJAhQ+Dk5IQPP/zQ4rkQEREREVHVYLUGqlq1aiXe86CgoACff/450tLS0LVrVwDA8uXL0bRpU+zbtw/t27dHeno6jh8/ji1btsDb2xutWrXCjBkzMGnSJCQkJECpVFo6HSIiIiIiqgKsdg7UqVOn4Ovri4YNG2LQoEG4cOECACArKws6nQ7h4eHS2CZNmqB+/frIzMwEAGRmZiI4OBje3t7SmMjISBQWFiInJ8eyiRARERERUZVhlT1QoaGhSElJQePGjXHx4kUkJiaiU6dOOHbsGHJzc6FUKuHh4WH0HG9vb+Tm5gIAcnNzjZonw3zDvNJotVpotVrpcWFhIQBAp9MZ3dTuYSrH0q/KY0oqB2H0X3tgbzHbW7yAaWIu6/1tapZcFxEREZGlWaWBioqKkv6/RYsWCA0Nhb+/P1atWgUXFxezrTc5ORmJiYnFpqenp8PV1bXU581uZ7aQSjSjjd6yKzQBe4vZ3uIFHi/mjRs3mjASIiIioqrLJu4D5eHhgaeeegqnT59G9+7dcffuXeTn5xvthcrLy5POmfLx8cGBAweMlmG4Sl9J51UZTJ482ehu34WFhfDz80NERATUanWpz2uesLkiaZWbykFgRhs9ph5ygFavsMg6H5e9xWxv8QKmiflYQqSJoyqdTqfDjz/+aLH1EREREVmSTTRQN27cwJkzZzB48GCEhITAyckJW7duRb9+/QAAJ0+exIULFxAWFgYACAsLwwcffIBLly7By8sLAKDRaKBWqxEUFFTqelQqFVQqVbHpTk5OcHJyKvV52iLLftHW6hUWX+fjsreY7S1e4PFiLuv9TURERETyWaWBevvtt9GrVy/4+/vj77//xvTp0+Ho6IgBAwbA3d0dw4cPx/jx4+Hp6Qm1Wo0333wTYWFhaN++PQAgIiICQUFBGDx4MGbPno3c3FxMmTIFcXFxJTZIRERVRYN3NphsWedmRptsWURk/1hfiO6zSgP1559/YsCAAbhy5Qrq1KmDjh07Yt++fahTpw4AYN68eXBwcEC/fv2g1WoRGRmJJUuWSM93dHTE+vXrMWbMGISFhcHNzQ2xsbFISkqyRjpERERERFRFWKWBWrFiRZnznZ2dsXjxYixevLjUMf7+/jwxnoiIiIiILMpq94EiIiIiIiKyNzZxEQkiIrI9cs53UDkKzG53/2ql9nZhFiKyHlOeT0VkaWygiKoAnvhLREREZBo8hI+IiIiIiEgmNlBEREREREQysYEiIiIiIiKSiedAERERmRjPOyQic2F9sT7ugSIiIiIiIpKJDRQREREREZFMbKCIiIiIiIhkYgNFREREREQkExsoIqpUEhISoFAojP41adJEmn/nzh3ExcWhVq1aqF69Ovr164e8vDyjZVy4cAHR0dFwdXWFl5cXJkyYgHv37lk6FSKyIawtRGTAq/ARUaXTrFkzbNmyRXpcrdr/lbpx48Zhw4YNWL16Ndzd3REfH4++fftiz549AICioiJER0fDx8cHe/fuxcWLFzFkyBA4OTnhww8/tHguRGQ7WFuICGADRUSVULVq1eDj41NsekFBAT7//HOkpaWha9euAIDly5ejadOm2LdvH9q3b4/09HQcP34cW7Zsgbe3N1q1aoUZM2Zg0qRJSEhIgFKptHQ6RGQjWFuICGADRUSV0KlTp+Dr6wtnZ2eEhYUhOTkZ9evXR1ZWFnQ6HcLDw6WxTZo0Qf369ZGZmYn27dsjMzMTwcHB8Pb2lsZERkZizJgxyMnJQevWra2RElVhcu/5onIUmN0OaJ6wGdoiRanjeN+XimNtocrGlPeUAqpOfWEDRUSVSmhoKFJSUtC4cWNcvHgRiYmJ6NSpE44dO4bc3FwolUp4eHgYPcfb2xu5ubkAgNzcXKMvOIb5hnkl0Wq10Gq10uPCwkIAgE6ng06nKzVWwzyVgyhfkjbEELs95wBUjjzk5lDWe9LaDLHJ+dxYmjVqC1C164u1VIZ6YC0Pvi9tudaURm7MbKCIqFKJioqS/r9FixYIDQ2Fv78/Vq1aBRcXF7OsMzk5GYmJicWmp6enw9XV9ZHPn9FGb46wLKoy5ABUjjwelcPGjRstFEnFaTSaUufdunXLgpH8H2vUFoD1xZq47crvwfpS1ufYVsmtL2ygiKhS8/DwwFNPPYXTp0+je/fuuHv3LvLz841+Kc7Ly5POa/Dx8cGBAweMlmG4klZJ5z4AwOTJkzF+/HjpcWFhIfz8/BAREQG1Wl1qbDqdDhqNBlMPOUCrL/2QK1umchCY0UZv1zkAlSMPuTkcS4i0YFTlY/hMdO/eHU5OTiWOMeyBsTZL1BagatcXa6kM9cBajiVEyvoc2yq59YUNFBFVajdu3MCZM2cwePBghISEwMnJCVu3bkW/fv0AACdPnsSFCxcQFhYGAAgLC8MHH3yAS5cuwcvLC8D9X9HUajWCgoJKXIdKpYJKpSo23cnJSdYfD61eUeY5K/agMuQAVI48HpWDPXyhKeuzYyvxW6K2AKwv1sRtV34Pviflvkdtidx42UARUaXy9ttvo1evXvD398fff/+N6dOnw9HREQMGDIC7uzuGDx+O8ePHw9PTE2q1Gm+++SbCwsLQvn17AEBERASCgoIwePBgzJ49G7m5uZgyZQri4uJK/BJDRFUDawsRGbCBIqJK5c8//8SAAQNw5coV1KlTBx07dsS+fftQp04dAMC8efPg4OCAfv36QavVIjIyEkuWLJGe7+joiPXr12PMmDEICwuDm5sbYmNjkZSUZK2UiMgGsLYQkQEbKCKqVFasWFHmfGdnZyxevBiLFy8udYy/v79dnGhPVBGmvGxxVblkMcDaQiRHg3c2yL6lwqPYcn1xsHYARERERERE9oINFBERERERkUxsoIiIiIiIiGRiA0VERERERCQTGygiIiIiIiKZ2EARERERERHJxAaKiIiIiIhIJjZQREREREREMrGBIiIiIiIikokNFBERERERkUxsoIiIiIiIiGRiA0VERERERCQTGygiIiIiIiKZ2EARERERERHJxAaKiIiIiIhIJjZQREREREREMrGBIiIiIiIikokNFBERERERkUxsoIiIiIiIiGRiA0VERERERCQTGygiIiIiIiKZqlk7ACIiIrJPDd7ZYNLlnZoRYdLlEZH9MnV9OTcz2mTL4h4oIiIiIiIimdhAERERERERyWT3DdTixYvRoEEDODs7IzQ0FAcOHLB2SERUSbC+EJG5sL4Q2S+7bqBWrlyJ8ePHY/r06fjll1/QsmVLREZG4tKlS9YOjYjsHOsLEZkL6wuRfbPrBmru3LkYOXIkXnvtNQQFBWHZsmVwdXXFF198Ye3QiMjOsb4QkbmwvhDZN7u9Ct/du3eRlZWFyZMnS9McHBwQHh6OzMzMEp+j1Wqh1WqlxwUFBQCAq1evQqfTlbquavdumijqslXTC9y6pUc1nQOK9AqLrPNx2VvM9hYvYHsxX7lypcz5Op0Ot27dAgAIISwRksmVt75UtLYYtpWtvLYVYWvvz4qqDHlUhhyuXLmCW7du4cqVK3BycipxzPXr1wGwvlSF+mItleGzZE22uv0e9f0FkF9f7LaBunz5MoqKiuDt7W003dvbG7/99luJz0lOTkZiYmKx6QEBAWaJsSIGWjuACrC3mO0tXsC2Yq49R/7Y69evw93d3XzBmEl564s91BZzsqX35+OoDHnYew51WV+Kja/q9cVa7P2zZG22uP1M+f3Fbhuoipg8eTLGjx8vPdbr9bh69Spq1aoFhcL6HXJhYSH8/Pzwv//9D2q12trhyGJvMdtbvID9xWyI9/jx4/D19bV2OBZR0dpib69tSSpDDkDlyKOq5CCEwPXr11lfqkB9sRZuu8djz9tPbn2x2waqdu3acHR0RF5entH0vLw8+Pj4lPgclUoFlUplNM3Dw8NcIVaYWq22uzecvcVsb/EC9hfzE088AQcH+zzNsrz15XFri729tiWpDDkAlSOPqpCDPe55MmB9sR/cdo/HXrefnPpin99uACiVSoSEhGDr1q3SNL1ej61btyIsLMyKkRGRvWN9ISJzYX0hsn92uwcKAMaPH4/Y2Fi0adMG7dq1w/z583Hz5k289tpr1g6NiOwc6wsRmQvrC5F9s+sG6pVXXsE///yDadOmITc3F61atcKmTZuKnZhpL1QqFaZPn15sV70ts7eY7S1ewP5itrd4S2OJ+lIZtlVlyAGoHHkwB/vB+mLbuO0eT1XYfgphr9cBJSIiIiIisjC7PQeKiIiIiIjI0thAERERERERycQGioiIiIiISCY2UERERERERDKxgTKz5ORktG3bFjVq1ICXlxf69OmDkydPGo3p0qULFAqF0b/Ro0cbjblw4QKio6Ph6uoKLy8vTJgwAffu3TNLzAkJCcXiadKkiTT/zp07iIuLQ61atVC9enX069ev2A0BLRlvgwYNisWrUCgQFxcHwDa2786dO9GrVy/4+vpCoVBg7dq1RvOFEJg2bRrq1q0LFxcXhIeH49SpU0Zjrl69ikGDBkGtVsPDwwPDhw/HjRs3jMYcOXIEnTp1grOzM/z8/DB79myTx6vT6TBp0iQEBwfDzc0Nvr6+GDJkCP7++2+jZZT0usycOdMs8dqrxYsXo0GDBnB2dkZoaCgOHDhglTgs9ZnPyMjA008/DZVKhUaNGiElJaXCMdvSZ2r16tVo0qQJnJ2dERwcjI0bN5osj6FDhxZ7bXr06GEzecj5G2fJ94+tfKZsQVXfFvZY16ylstRTixJkVpGRkWL58uXi2LFjIjs7W/Ts2VPUr19f3LhxQxrz7LPPipEjR4qLFy9K/woKCqT59+7dE82bNxfh4eHi8OHDYuPGjaJ27dpi8uTJZol5+vTpolmzZkbx/PPPP9L80aNHCz8/P7F161Zx6NAh0b59e/HMM89YLd5Lly4ZxarRaAQAsX37diGEbWzfjRs3ivfee0+sWbNGABA//PCD0fyZM2cKd3d3sXbtWvHrr7+KF154QQQEBIjbt29LY3r06CFatmwp9u3bJ3bt2iUaNWokBgwYIM0vKCgQ3t7eYtCgQeLYsWPi22+/FS4uLuI///mPSePNz88X4eHhYuXKleK3334TmZmZol27diIkJMRoGf7+/iIpKclouz/4vjdlvPZoxYoVQqlUii+++ELk5OSIkSNHCg8PD5GXl2fxWCzxmf/jjz+Eq6urGD9+vDh+/LhYtGiRcHR0FJs2bapQzLbymdqzZ49wdHQUs2fPFsePHxdTpkwRTk5O4ujRoybJIzY2VvTo0cPotbl69arRGGvmIedvnKXeP7b0mbI2bgv7rGvWUlnqqSWxgbKwS5cuCQBix44d0rRnn31W/Otf/yr1ORs3bhQODg4iNzdXmrZ06VKhVquFVqs1eYzTp08XLVu2LHFefn6+cHJyEqtXr5amnThxQgAQmZmZVon3Yf/6179EYGCg0Ov1Qgjb274PFye9Xi98fHzERx99JE3Lz88XKpVKfPvtt0IIIY4fPy4AiIMHD0pjfv75Z6FQKMRff/0lhBBiyZIlombNmkYxT5o0STRu3Nik8ZbkwIEDAoA4f/68NM3f31/Mmzev1OeYK1570a5dOxEXFyc9LioqEr6+viI5OdnisVjiMz9x4kTRrFkzo2W/8sorIjIy8rHjt+Znqn///iI6OtoontDQUPH6668/dh5C3G+gevfuXepzbC2Ph//GWfL9Y0ufKWvjtrD/umYtlaWemhsP4bOwgoICAICnp6fR9NTUVNSuXRvNmzfH5MmTcevWLWleZmYmgoODjW6wFxkZicLCQuTk5JglzlOnTsHX1xcNGzbEoEGDcOHCBQBAVlYWdDodwsPDpbFNmjRB/fr1kZmZabV4De7evYtvvvkGw4YNg0KhkKbb2vZ90NmzZ5Gbm2u0Td3d3REaGmq0TT08PNCmTRtpTHh4OBwcHLB//35pTOfOnaFUKo3yOHnyJK5du2bWHAoKCqBQKODh4WE0febMmahVqxZat26Njz76yOjQB2vGa213795FVlaW0Wvu4OCA8PBw6TW3NHN/5jMzM42WYRhjjnwt+ZmyRF4ZGRnw8vJC48aNMWbMGFy5ckWaZ2t5PPw3zlLvH1v8TFkLt8X/qUx1zVoqWz01lWrWDqAq0ev1GDt2LDp06IDmzZtL0wcOHAh/f3/4+vriyJEjmDRpEk6ePIk1a9YAAHJzc4vdndzwODc31+RxhoaGIiUlBY0bN8bFixeRmJiITp064dixY8jNzYVSqSz2Rdnb21uKxdLxPmjt2rXIz8/H0KFDpWm2tn0fZlhHSTE8uE29vLyM5lerVg2enp5GYwICAootwzCvZs2aZon/zp07mDRpEgYMGAC1Wi1Nf+utt/D000/D09MTe/fuxeTJk3Hx4kXMnTvXqvHagsuXL6OoqKjE1/y3336zeDyW+MyXNqawsBC3b9+Gi4uLyfKx5GeqtLxMVTt69OiBvn37IiAgAGfOnMG7776LqKgoZGZmwtHR0abyKOlvnKXeP9euXbOpz5Q12Vp9sZbKVtespTLVU1NiA2VBcXFxOHbsGHbv3m00fdSoUdL/BwcHo27duujWrRvOnDmDwMBAS4eJqKgo6f9btGiB0NBQ+Pv7Y9WqVTZfDD7//HNERUXB19dXmmZr27cy0el06N+/P4QQWLp0qdG88ePHS//fokULKJVKvP7660hOToZKpbJ0qFQGe/7MV3YxMTHS/wcHB6NFixYIDAxERkYGunXrZsXIiivtbxyRNbCukTnxED4LiY+Px/r167F9+3bUq1evzLGhoaEAgNOnTwMAfHx8il0ZxvDYx8fHDNEa8/DwwFNPPYXTp0/Dx8cHd+/eRX5+frF4DLFYK97z589jy5YtGDFiRJnjbG37GtZRUgwPbtNLly4Zzb937x6uXr1qte1uaJ7Onz8PjUZjtPepJKGhobh37x7OnTtnlXhtSe3ateHo6Fjma25N5vjMlzZGrVab/MuMJT9TpY0x1+vYsGFD1K5d26h+2UIepf2Ns9T7x9Y/U5bEbVEye69r1lKZ6+njYANlZkIIxMfH44cffsC2bduK7b4sSXZ2NgCgbt26AICwsDAcPXrU6M1p+MIaFBRklrgfdOPGDZw5cwZ169ZFSEgInJycsHXrVmn+yZMnceHCBYSFhVk13uXLl8PLywvR0dFljrO17RsQEAAfHx+jbVpYWIj9+/cbbdP8/HxkZWVJY7Zt2wa9Xi81hGFhYdi5cyd0Op1RHo0bNzb54XCG5unUqVPYsmULatWq9cjnZGdnw8HBQdrNb8l4bY1SqURISIjRa67X67F161bpNbcmc3zmw8LCjJZhGGOOfC35mbJkXgDw559/4sqVK0b1y5p5POpvnKXeP7b+mbIkbouS2Xtds5bKXE8fi5UvYlHpjRkzRri7u4uMjAyjS2neunVLCCHE6dOnRVJSkjh06JA4e/as+PHHH0XDhg1F586dpWUYLqUZEREhsrOzxaZNm0SdOnXMdlnwf//73yIjI0OcPXtW7NmzR4SHh4vatWuLS5cuCSHuX/qzfv36Ytu2beLQoUMiLCxMhIWFWS1eIe5fYah+/fpi0qRJRtNtZftev35dHD58WBw+fFgAEHPnzhWHDx+Wrlo3c+ZM4eHhIX788Udx5MgR0bt37xIvEdq6dWuxf/9+sXv3bvHkk08aXSI0Pz9feHt7i8GDB4tjx46JFStWCFdX1wpdFryseO/evSteeOEFUa9ePZGdnW30vjZcXWfv3r1i3rx5Ijs7W5w5c0Z88803ok6dOmLIkCFmidcerVixQqhUKpGSkiKOHz8uRo0aJTw8PIyu+GQplvjMGy73O2HCBHHixAmxePHix7rcr618pvbs2SOqVasmPv74Y3HixAkxffr0cl12t6w8rl+/Lt5++22RmZkpzp49K7Zs2SKefvpp8eSTT4o7d+7YRB6P+hsnhOXeP7b0mbI2bgv7rGvWUlnqqSWxgTIzACX+W758uRBCiAsXLojOnTsLT09PoVKpRKNGjcSECROM7lMkhBDnzp0TUVFRwsXFRdSuXVv8+9//Fjqdziwxv/LKK6Ju3bpCqVSKJ554Qrzyyivi9OnT0vzbt2+LN954Q9SsWVO4urqKF198UVy8eNFq8QohxObNmwUAcfLkSaPptrJ9t2/fXuL7IDY2Vghx/zKhU6dOFd7e3kKlUolu3boVy+XKlStiwIABonr16kKtVovXXntNXL9+3WjMr7/+Kjp27ChUKpV44oknxMyZM00e79mzZ0t9XxvuvZWVlSVCQ0OFu7u7cHZ2Fk2bNhUffvih0Zc+U8ZrrxYtWiTq168vlEqlaNeundi3b59V4rDUZ3779u2iVatWQqlUioYNG0p1sCJs6TO1atUq8dRTTwmlUimaNWsmNmzYYJI8bt26JSIiIkSdOnWEk5OT8Pf3FyNHjiz2JdiaeTzqb5wQln3/2MpnyhZU9W1hj3XNWipLPbUkhRBCmHy3FhERERERUSXEc6CIiIiIiIhkYgNFREREREQkExsoIiIiIiIimdhAERERERERycQGioiIiIiISCY2UERERERERDKxgSIiIiIiIpKJDRQREREREZFMbKCIiIiIiIhkYgNFREREREQkExsoIiIiIiIimdhAERERERERycQGioiIiIiISCY2UERERERERDKxgSIiIiIiIpKJDRQREREREZFMbKCIiIiIiIhkYgNFREREREQkExsoIiIiIiIimdhAERERERERycQGqpJr0KABhg4dKj3OyMiAQqFARkZGuZdleO53331nugBNTKFQICEhwdphlMiWYyMqD3utKykpKVAoFDh37pzZ10VEpsOaY1kPb28qjg2UHTN8MEv6984771g1trS0NMyfP7/Y9HPnzhnF6eTkhNq1a+OZZ57Bu+++iwsXLlg+2HJ4cJvv3r272HwhBPz8/KBQKPD8889bIUKix2NvdaVLly6lxvvgP2v/ePGoL21Dhw5F9erVLRwVkfWx5piHoeYoFAp88803JY7p0KEDFAoFmjdvbuHo7F81awdAjy8pKQkBAQFG00r7MHTu3Bm3b9+GUqk0a0xpaWk4duwYxo4dW+L8AQMGoGfPntDr9bh27RoOHjyI+fPnY8GCBfj8888RExNj1vgel7OzM9LS0tCxY0ej6Tt27MCff/4JlUpV7Dm3b99GtWr8yJF9sJe68t5772HEiBHS44MHD2LhwoV499130bRpU2l6ixYt0KxZM8TExJT4+SQi62LNMQ/D95VXX33VaPq5c+ewd+9eODs7F3vOyZMn4eDAfSxl4be5SiAqKgpt2rSRNdbBwaHED4ulPf3008U+zOfPn0dERARiY2PRtGlTtGzZ0krRPVrPnj2xevVqLFy40KgpSktLQ0hICC5fvlzsObaw3Ynkspe60r17d6PHzs7OWLhwIbp3744uXboUG+/o6GihyOzDnTt3oFQq+WWJrI41xzx69uyJdevW4fLly6hdu7Y0PS0tDd7e3njyySdx7do1o+fwR6ZHY8WsYko7bnjx4sVo2LAhXFxc0K5dO+zatQtdunQpsRjo9Xp88MEHqFevHpydndGtWzecPn1amt+lSxds2LAB58+fl3YfN2jQ4JGx+fv7IyUlBXfv3sXs2bON5uXn52Ps2LHw8/ODSqVCo0aNMGvWLOj1+jKXef78ebzxxhto3LgxXFxcUKtWLbz88stGxyP/8ccfUCgUmDdvXrHn7927FwqFAt9++63R9AEDBuDKlSvQaDTStLt37+K7777DwIEDS4zl4V36CQkJUCgUOH36NIYOHQoPDw+4u7vjtddew61bt8rMi8iW2HJdeVBJ5yM0aNAAzz//PDIyMtCmTRu4uLggODhYymXNmjUIDg6Gs7MzQkJCcPjw4WLL/e233/DSSy/B09MTzs7OaNOmDdatW1eu2EqzZMkSNGvWDCqVCr6+voiLi0N+fr7RmNLOV3h4WxtepxUrVmDKlCl44okn4OrqisLCQpPESmQprDnya07v3r2hUqmwevVqo+lpaWno379/iQ3ewzXFkMeePXswfvx41KlTB25ubnjxxRfxzz//lGubVBbcA1UJFBQUFNvj8eCvDI+ydOlSxMfHo1OnThg3bhzOnTuHPn36oGbNmqhXr16x8TNnzoSDgwPefvttFBQUYPbs2Rg0aBD2798P4P7u7YKCAvz5559SUyL32P6wsDAEBgYaNSa3bt3Cs88+i7/++guvv/466tevj71792Ly5Mm4ePFiiedaGRw8eBB79+5FTEwM6tWrh3PnzmHp0qXo0qULjh8/DldXVzRs2BAdOnRAamoqxo0bZ/T81NRU1KhRA7179zaa3qBBA4SFheHbb79FVFQUAODnn39GQUEBYmJisHDhQln5AkD//v0REBCA5ORk/PLLL/jss8/g5eWFWbNmyV4GkalVprryKKdPn8bAgQPx+uuv49VXX8XHH3+MXr16YdmyZXj33XfxxhtvAACSk5PRv39/o8NbcnJy0KFDBzzxxBN455134ObmhlWrVqFPnz74/vvv8eKLLxqt6/r16yXuodZqtcWmJSQkIDExEeHh4RgzZgxOnjyJpUuX4uDBg9izZw+cnJwqlO+MGTOgVCrx9ttvQ6vVmv0wKCI5WHPMU3NcXV3Ru3dvfPvttxgzZgwA4Ndff0VOTg4+++wzHDlyRHbcb775JmrWrInp06fj3LlzmD9/PuLj47Fy5UqTbBe7IshuLV++XAAo8Z+Bv7+/iI2NlR5v375dABDbt28XQgih1WpFrVq1RNu2bYVOp5PGpaSkCADi2WefLfbcpk2bCq1WK01fsGCBACCOHj0qTYuOjhb+/v7FYj579qwAID766KNS8+rdu7cAIAoKCoQQQsyYMUO4ubmJ33//3WjcO++8IxwdHcWFCxekaQDE9OnTpce3bt0qtvzMzEwBQHz11VfStP/85z8CgDhx4oQ07e7du6J27dpG28+wzQ8ePCg++eQTUaNGDWkdL7/8snjuueeEEPe3e3R0tNF6H45t+vTpAoAYNmyY0bgXX3xR1KpVq9TtQ2RO9lhXHrR69WqjWErK7ezZs0a5ABB79+6Vpm3evFkAEC4uLuL8+fPSdEOdeHDZ3bp1E8HBweLOnTvSNL1eL5555hnx5JNPFsuzrH9ubm7S+EuXLgmlUikiIiJEUVGRNP2TTz4RAMQXX3xhlMODr4fBs88+W+K2btiwYYm1kcgaWHPMW3NWr14t1q9fLxQKhfR9acKECaJhw4ZCiPt1olmzZkZxP7y9DXmEh4cLvV4vTR83bpxwdHQU+fn5ZW6jyoiH8FUCixcvhkajMfon16FDh3DlyhWMHDnS6FyeQYMGoWbNmiU+57XXXjP6xbJTp04A7h8KZwqGX3iuX78OAFi9ejU6deqEmjVr4vLly9K/8PBwFBUVYefOnaUuy8XFRfp/nU6HK1euoFGjRvDw8MAvv/wizevfvz+cnZ2RmpoqTdu8eTMuX75c7FytB59z+/ZtrF+/HtevX8f69etLPXyvLKNHjzZ63KlTJ1y5coWH1ZBVVba6UpagoCCEhYVJj0NDQwEAXbt2Rf369YtNN8R09epVbNu2Df3795f2LF2+fBlXrlxBZGQkTp06hb/++stoXdOmTSu2XTUaDSIiIozGbdmyBXfv3sXYsWONzk8aOXIk1Go1NmzYUOF8Y2NjjWojkS1gzTFPzQGAiIgIeHp6YsWKFRBCYMWKFRgwYEC54x41ahQUCoX0uFOnTigqKsL58+fLvSx7x0P4KoF27drJPvHyYYY3faNGjYymV6tWrdRjfR/8cAOQitPDJyFW1I0bNwAANWrUAACcOnUKR44cQZ06dUocf+nSpVKXdfv2bSQnJ2P58uX466+/IISQ5hUUFEj/7+HhgV69eiEtLQ0zZswAcP/wvSeeeAJdu3Ytcdl16tRBeHg40tLScOvWLRQVFeGll14qX7Ioe3uq1epyL4/IFCpbXSnLw+t2d3cHAPj5+ZU43RDT6dOnIYTA1KlTMXXq1BKXfenSJTzxxBPS4+DgYISHhxcb9/Blhg3bsHHjxkbTlUolGjZs+FhfWB6+0hmRLWDNMU/NAQAnJye8/PLLSEtLQ7t27fC///2vQj/4WnOb2Ro2UFRupV1R5sHm5HEcO3YMXl5eUvOg1+vRvXt3TJw4scTxTz31VKnLevPNN7F8+XKMHTsWYWFhcHd3h0KhQExMTLELUAwZMgSrV6/G3r17ERwcjHXr1uGNN94o8+pUAwcOxMiRI5Gbm4uoqCh4eHiUO19zb08ie2DNz0Fp635UTIYa8vbbbyMyMrLEsQ9/oTOHB38RflBRUVGJOXDvE1HVqzkDBw7EsmXLkJCQgJYtWyIoKKi8YfP7ygPYQFVx/v7+AO7/qvHcc89J0+/du4dz586hRYsWFVpuaX/QHyUzMxNnzpwxOmwuMDAQN27cKPFX20f57rvvEBsbizlz5kjT7ty5U+wqVgDQo0cP1KlTB6mpqQgNDcWtW7cwePDgMpf/4osv4vXXX8e+ffuq5kmURCWwtbpiLg0bNgRw/9fditSnshi24cmTJ6X1APev9nn27Fmj9dWsWbPEmnb+/Hmj5xJVVqw5j9axY0fUr18fGRkZvEiVCfAcqCquTZs2qFWrFv773//i3r170vTU1NTH2iXr5uZmdIicHOfPn8fQoUOhVCoxYcIEaXr//v2RmZmJzZs3F3tOfn6+UdwPc3R0LPbLyKJFi1BUVFRsbLVq1TBgwACsWrUKKSkpCA4OfmTRrV69OpYuXYqEhAT06tXrUSkSVQm2VFfMycvLC126dMF//vMfXLx4sdj8x7m8b3h4OJRKJRYuXGhUwz7//HMUFBQgOjpamhYYGIh9+/bh7t270rT169fjf//7X4XXT2RPWHPuK6vmKBQKLFy4ENOnT3/kj8P0aNwDVcUplUokJCTgzTffRNeuXdG/f3+cO3cOKSkpCAwMrPCvLyEhIVi5ciXGjx+Ptm3bonr16kYNxi+//IJvvvkGer0e+fn5OHjwIL7//nsoFAp8/fXXRo3LhAkTsG7dOjz//PMYOnQoQkJCcPPmTRw9ehTfffcdzp07V+qlTp9//nl8/fXXcHd3R1BQEDIzM7FlyxbUqlWrxPFDhgzBwoULsX37dtm/0MTGxpZjyxBVftaqK9awePFidOzYEcHBwRg5ciQaNmyIvLw8ZGZm4s8//8Svv/5aoeXWqVMHkydPRmJiInr06IEXXngBJ0+exJIlS9C2bVujvfQjRozAd999hx49eqB///44c+YMvvnmGwQGBpoqTSKbxpojr+b07t272G1ZqGLYQBHi4+MhhMCcOXPw9ttvo2XLlli3bh3eeuutCt/p+4033kB2djaWL1+OefPmwd/f36jofPvtt/j2229RrVo1qNVqPPnkkxg7dixGjx5d7CRFV1dX7NixAx9++CFWr16Nr776Cmq1Gk899RQSExOlkyxLsmDBAjg6OiI1NRV37txBhw4dsGXLllKPHQ4JCUGzZs1w4sQJDBo0qEK5E5F16oo1BAUF4dChQ0hMTERKSgquXLkCLy8vtG7dGtOmTXusZSckJKBOnTr45JNPMG7cOHh6emLUqFH48MMPje4BFRkZiTlz5mDu3LkYO3Ys2rRpg/Xr1+Pf//7346ZHZDdYcx6/5pB8ClEVz/yiR9Lr9ahTpw769u2L//73v9YOx6Jat24NT09PbN261dqhEFUqVbmuEJHlseaQufAcKMKdO3eKnSf01Vdf4erVq+jSpYt1grKSQ4cOITs7G0OGDLF2KER2jXWFiCyJNYcsiXugCBkZGRg3bhxefvll1KpVC7/88gs+//xzNG3aFFlZWUY3mqusjh07hqysLMyZMweXL1/GH3/8UeFd/kTEukJElsWaQ5bEc6AIDRo0gJ+fHxYuXIirV6/C09MTQ4YMwcyZM6tMwfnuu++QlJSExo0b49tvv2XzRPSYWFeIyJJYc8iSuAeKiIiIiIhIJp4DRUREREREJBMbKCIiIiIiIpmq9DlQer0ef//9N2rUqFHhm6wRUXFCCFy/fh2+vr5wcKh6v9OwthCZD+sL6wuRucitL1W6gfr777/h5+dn7TCIKq3//e9/qFevnrXDsDjWFiLzY30hInN5VH2p0g1UjRo1ANzfSGq1usQxOp0O6enpiIiIMLrze2VQWXNjXtZXWFgIPz8/6TNW1cipLYB9vaamxLyrTt7myJn1pWrWl8qUD3OxXXLrS5VuoAy7vtVqdZkNlKurK9RqdaV4YzyosubGvGxHVT28RE5tAezzNTUF5l118jZnzqwvVau+VKZ8mIvte1R9qXoHDxMREREREVUQGygiIiIiIiKZ2EARERERERHJxAaKiIiIiIhIpnI3UDt37kSvXr3g6+sLhUKBtWvXGs0XQmDatGmoW7cuXFxcEB4ejlOnThmNuXr1KgYNGgS1Wg0PDw8MHz4cN27cMBpz5MgRdOrUCc7OzvDz88Ps2bOLxbJ69Wo0adIEzs7OCA4OxsaNG8ubDhERERERkWzlbqBu3ryJli1bYvHixSXOnz17NhYuXIhly5Zh//79cHNzQ2RkJO7cuSONGTRoEHJycqDRaLB+/Xrs3LkTo0aNkuYXFhYiIiIC/v7+yMrKwkcffYSEhAR8+umn0pi9e/diwIABGD58OA4fPow+ffqgT58+OHbsWHlTIiIiIiIikqXclzGPiopCVFRUifOEEJg/fz6mTJmC3r17AwC++uoreHt7Y+3atYiJicGJEyewadMmHDx4EG3atAEALFq0CD179sTHH38MX19fpKam4u7du/jiiy+gVCrRrFkzZGdnY+7cuVKjtWDBAvTo0QMTJkwAAMyYMQMajQaffPIJli1bVqGNQUREREREVBaTngN19uxZ5ObmIjw8XJrm7u6O0NBQZGZmAgAyMzPh4eEhNU8AEB4eDgcHB+zfv18a07lzZyiVSmlMZGQkTp48iWvXrkljHlyPYYxhPURERERERKZm0hvp5ubmAgC8vb2Npnt7e0vzcnNz4eXlZRxEtWrw9PQ0GhMQEFBsGYZ5NWvWRG5ubpnrKYlWq4VWq5UeFxYWArh/EzCdTlficwzTQ5I2Qas3zU37jiVEmmQ5j8uQW2m52yvmZX32ECM9WoN3Nph0eedmRpt0eURkv8pbX1SOArPbAc0TNkNbVPz7GOsLWZJJGyhbl5ycjMTExGLT09PT4erqWuZzZ7TRmywOW7vYhUajsXYIZsG8rOfWrVvWDoGIiIjILEzaQPn4+AAA8vLyULduXWl6Xl4eWrVqJY25dOmS0fPu3buHq1evSs/38fFBXl6e0RjD40eNMcwvyeTJkzF+/HjpcWFhIfz8/BAREQG1Wl3ic3Q6HTQaDaYecqiUe6A0Gg26d+8OJycna4djMszL+gx7d4mIiIgqG5M2UAEBAfDx8cHWrVulhqmwsBD79+/HmDFjAABhYWHIz89HVlYWQkJCAADbtm2DXq9HaGioNOa9996DTqeTvihqNBo0btwYNWvWlMZs3boVY8eOldav0WgQFhZWanwqlQoqlarYdCcnp0d+IdXqFSXuMq4IW/vyKyd/e8S8rMfW4yMiIiKqqHJfROLGjRvIzs5GdnY2gPsXjsjOzsaFCxegUCgwduxYvP/++1i3bh2OHj2KIUOGwNfXF3369AEANG3aFD169MDIkSNx4MAB7NmzB/Hx8YiJiYGvry8AYODAgVAqlRg+fDhycnKwcuVKLFiwwGjv0b/+9S9s2rQJc+bMwW+//YaEhAQcOnQI8fHxj79ViIiIiIiISlDuPVCHDh3Cc889Jz02NDWxsbFISUnBxIkTcfPmTYwaNQr5+fno2LEjNm3aBGdnZ+k5qampiI+PR7du3eDg4IB+/fph4cKF0nx3d3ekp6cjLi4OISEhqF27NqZNm2Z0r6hnnnkGaWlpmDJlCt599108+eSTWLt2LZo3b16hDUFERERERPQo5W6gunTpAiFEqfMVCgWSkpKQlJRU6hhPT0+kpaWVuZ4WLVpg165dZY55+eWX8fLLL5cdMBERERERkYmY9D5QRERERERElRkbKCIiIiIiIpnYQBGR3Vi6dClatGgBtVoNtVqNsLAw/Pzzz9L8O3fuIC4uDrVq1UL16tXRr1+/Yrc7uHDhAqKjo+Hq6govLy9MmDAB9+7dMxqTkZGBp59+GiqVCo0aNUJKSool0iMiK2J9ISK52EARkd2oV68eZs6ciaysLBw6dAhdu3ZF7969kZOTAwAYN24cfvrpJ6xevRo7duzA33//jb59+0rPLyoqQnR0NO7evYu9e/fiyy+/REpKCqZNmyaNOXv2LKKjo/Hcc88hOzsbY8eOxYgRI7B582aL50tElsP6QkRymfQ+UERE5tSrVy+jxx988AGWLl2Kffv2oV69evj888+RlpaGrl27AgCWL1+Opk2bYt++fWjfvj3S09Nx/PhxbNmyBd7e3mjVqhVmzJiBSZMmISEhAUqlEsuWLUNAQADmzJkD4P6tF3bv3o158+YhMtI2boJNRKbH+kJEcrGBIiK7VFRUhNWrV+PmzZsICwtDVlYWdDodwsPDpTFNmjRB/fr1kZmZifbt2yMzMxPBwcHw9vaWxkRGRmLMmDHIyclB69atkZmZabQMw5gHb9r9MK1WC61WKz0uLCwEAOh0Ouh0ulKfZ5hX1hhrUjmWfsXVing4X1vN21yqYt7myNkS24/1xfzKW19UDsLovw+z1TxLYuuvTXlUplwA+XmwgSIiu3L06FGEhYXhzp07qF69On744QcEBQUhOzsbSqUSHh4eRuO9vb2Rm5sLAMjNzTX6cmOYb5hX1pjCwkLcvn0bLi4uxWJKTk5GYmJisenp6elwdXV9ZE4ajeaRY6xhdjvTLm/jxo1Gj201b3OrinmbMudbt26ZbFkPY32xnIrWlxlt9CVOf7i+2ANbfW0qorLkIre+sIEiIrvSuHFjZGdno6CgAN999x1iY2OxY8cOq8Y0efJk6abiwP1fiP38/BAREQG1Wl3q83Q6HTQaDbp37w4nJydLhFouzRNMe17GsYT7hyjZet7mUhXzNkfOhj0w5sD6YjnlrS8qB4EZbfSYesgBWr2i2HxDfbEHtv7alEdlygWQX1/YQBGRXVEqlWjUqBEAICQkBAcPHsSCBQvwyiuv4O7du8jPzzf6lTgvLw8+Pj4AAB8fHxw4cMBoeYaraD045uEra+Xl5UGtVpf46zAAqFQqqFSqYtOdnJxk/UGRO87StEXFv6Q8jodztNW8za0q5m3KnM257VhfLKei9UWrV5T4XFvM8VFs9bWpiMqSi9wceBU+IrJrer0eWq0WISEhcHJywtatW6V5J0+exIULFxAWFgYACAsLw9GjR3Hp0iVpjEajgVqtRlBQkDTmwWUYxhiWQURVB+sLEZWEe6CIyG5MnjwZUVFRqF+/Pq5fv460tDRkZGRg8+bNcHd3x/DhwzF+/Hh4enpCrVbjzTffRFhYGNq3bw8AiIiIQFBQEAYPHozZs2cjNzcXU6ZMQVxcnPQL7+jRo/HJJ59g4sSJGDZsGLZt24ZVq1Zhw4YN1kydiMyM9YWI5GIDRUR249KlSxgyZAguXrwId3d3tGjRAps3b0b37t0BAPPmzYODgwP69esHrVaLyMhILFmyRHq+o6Mj1q9fjzFjxiAsLAxubm6IjY1FUlKSNCYgIAAbNmzAuHHjsGDBAtSrVw+fffYZLzFMVMmxvhCRXGygiMhufP7552XOd3Z2xuLFi7F48eJSx/j7+z/yak1dunTB4cOHKxQjEdkn1hcikovnQBEREREREcnEBoqIiIiIiEgmNlBEREREREQy8RwoIiIra56w2WT3XDo3M9okyyGiyoH1hcj0uAeKiIiIiIhIJjZQREREREREMrGBIiIiIiIikokNFBERERERkUxsoIiIiIiIiGRiA0VERERERCQTGygiIiIiIiKZ2EARERERERHJxAaKiIiIiIhIJjZQREREREREMrGBIiIiIiIikokNFBERERERkUxsoIiIiIiIiGQyeQNVVFSEqVOnIiAgAC4uLggMDMSMGTMghJDGCCEwbdo01K1bFy4uLggPD8epU6eMlnP16lUMGjQIarUaHh4eGD58OG7cuGE05siRI+jUqROcnZ3h5+eH2bNnmzodIiIiIiIiickbqFmzZmHp0qX45JNPcOLECcyaNQuzZ8/GokWLpDGzZ8/GwoULsWzZMuzfvx9ubm6IjIzEnTt3pDGDBg1CTk4ONBoN1q9fj507d2LUqFHS/MLCQkRERMDf3x9ZWVn46KOPkJCQgE8//dTUKREREREREQEAqpl6gXv37kXv3r0RHR0NAGjQoAG+/fZbHDhwAMD9vU/z58/HlClT0Lt3bwDAV199BW9vb6xduxYxMTE4ceIENm3ahIMHD6JNmzYAgEWLFqFnz574+OOP4evri9TUVNy9exdffPEFlEolmjVrhuzsbMydO9eo0SIiIiIiIjIVkzdQzzzzDD799FP8/vvveOqpp/Drr79i9+7dmDt3LgDg7NmzyM3NRXh4uPQcd3d3hIaGIjMzEzExMcjMzISHh4fUPAFAeHg4HBwcsH//frz44ovIzMxE586doVQqpTGRkZGYNWsWrl27hpo1axaLTavVQqvVSo8LCwsBADqdDjqdrsR8DNNVDqLE+RVR2roszRCHrcRjKszL+uwhRiIiIqKKMHkD9c4776CwsBBNmjSBo6MjioqK8MEHH2DQoEEAgNzcXACAt7e30fO8vb2lebm5ufDy8jIOtFo1eHp6Go0JCAgotgzDvJIaqOTkZCQmJhabnp6eDldX1zLzmtFGX+b88ti4caPJlmUKGo3G2iGYBfOynlu3bpllucnJyVizZg1+++03uLi44JlnnsGsWbPQuHFjaUyXLl2wY8cOo+e9/vrrWLZsmfT4woULGDNmDLZv347q1asjNjYWycnJqFbt/0piRkYGxo8fj5ycHPj5+WHKlCkYOnSoWfKqKhq8swEAoHIUmN0OaJ6wGdoiRYWXd25mtKlCI2J9sXOG+mIKrC30KCZvoFatWoXU1FSkpaVJh9WNHTsWvr6+iI2NNfXqymXy5MkYP3689LiwsBB+fn6IiIiAWq0u8Tk6nQ4ajQZTDzlAq6/4H/oHHUuINMlyHpcht+7du8PJycna4ZgM87I+w95dU9uxYwfi4uLQtm1b3Lt3D++++y4iIiJw/PhxuLm5SeNGjhyJpKQk6fGDP5AUFRUhOjoaPj4+2Lt3Ly5evIghQ4bAyckJH374IYD7e8qjo6MxevRopKamYuvWrRgxYgTq1q2LyEjb+PwSkWmxvhCRXCZvoCZMmIB33nkHMTExAIDg4GCcP38eycnJiI2NhY+PDwAgLy8PdevWlZ6Xl5eHVq1aAQB8fHxw6dIlo+Xeu3cPV69elZ7v4+ODvLw8ozGGx4YxD1OpVFCpVMWmOzk5PfILqVaveKxfSh9eny2Rk789Yl7WY674Nm3aZPQ4JSUFXl5eyMrKQufOnaXprq6updaB9PR0HD9+HFu2bIG3tzdatWqFGTNmYNKkSUhISIBSqcSyZcsQEBCAOXPmAACaNm2K3bt3Y968efyCQ1RJsb4QkVwmb6Bu3boFBwfji/s5OjpCr79/CFxAQAB8fHywdetWqWEqLCzE/v37MWbMGABAWFgY8vPzkZWVhZCQEADAtm3boNfrERoaKo157733oNPppC9rGo0GjRs3LvHwPSKqfAoKCgAAnp6eRtNTU1PxzTffwMfHB7169cLUqVOlX4kzMzMRHBxsdBhxZGQkxowZg5ycHLRu3RqZmZlG52kaxowdO7bEOCpyfqVhPmC751iqHE0Xl9Fy/3++j5u3vZ1rZ0/nMZqKOXK21PZjfSl9maZQ3vpiqrohh7nfY5WpFlSmXAD5eZi8gerVqxc++OAD1K9fH82aNcPhw4cxd+5cDBs2DACgUCgwduxYvP/++3jyyScREBCAqVOnwtfXF3369AFw/9eYHj16YOTIkVi2bBl0Oh3i4+MRExMDX19fAMDAgQORmJiI4cOHY9KkSTh27BgWLFiAefPmmTolIrJBer0eY8eORYcOHdC8eXNp+sCBA+Hv7w9fX18cOXIEkyZNwsmTJ7FmzRoA98+RLOkcTMO8ssYUFhbi9u3bcHFxMZr3OOdXArZ7juXsdiZbVIkeN29bO59ULns4j9HUTJmzuc6xfBDrS8lsob6YMp/SWKq2VKZaUFlykVtfTN5ALVq0CFOnTsUbb7yBS5cuwdfXF6+//jqmTZsmjZk4cSJu3ryJUaNGIT8/Hx07dsSmTZvg7OwsjUlNTUV8fDy6desGBwcH9OvXDwsXLpTmu7u7Iz09HXFxcQgJCUHt2rUxbdo0XsKcqIqIi4vDsWPHsHv3bqPpD9aA4OBg1K1bF926dcOZM2cQGBhollgqcn4lYPvnWDZP2GyyZT1I5SAwo43+sfO2lfNJ5bKn8xhNxRw5m+scywexvpTMmvXFVHVDDnPXlspUCypTLoD8+mLyBqpGjRqYP38+5s+fX+oYhUKBpKQko5MwH+bp6Ym0tLQy19WiRQvs2rWroqESkZ2Kj4+XbrBdr169MscaDvs9ffo0AgMD4ePjI92XzuDh8ydLO8dSrVYX+3UYeLzzKwHbPcfSVDGVuvzHzNte/1jbw3mMpmbKnM297VhfSmcL9cWU+ZTGUp/PylQLKksucnNwePQQIiLbIIRAfHw8fvjhB2zbtq3YrQxKkp2dDQDSRWvCwsJw9OhRowvVaDQaqNVqBAUFSWO2bt1qtByNRoOwsDATZUJEtob1hYjkYgNFRHYjLi4O33zzDdLS0lCjRg3k5uYiNzcXt2/fBgCcOXMGM2bMQFZWFs6dO4d169ZhyJAh6Ny5M1q0aAEAiIiIQFBQEAYPHoxff/0VmzdvxpQpUxAXFyf9yjt69Gj88ccfmDhxIn777TcsWbIEq1atwrhx46yWOxGZF+sLEcnFBoqI7MbSpUtRUFCALl26oG7dutK/lStXAgCUSiW2bNmCiIgINGnSBP/+97/Rr18//PTTT9IyHB0dsX79ejg6OiIsLAyvvvoqhgwZYnRIcUBAADZs2ACNRoOWLVtizpw5+Oyzz3iJYaJKjPWFiOQy+TlQRETmIkTZl6/18/PDjh07Hrkcf3//R15lqUuXLjh8+HC54iMi+8X6QkRycQ8UERERERGRTGygiIiIiIiIZGIDRUREREREJBMbKCIiIiIiIpnYQBEREREREcnEBoqIiIiIiEgmNlBEREREREQysYEiIiIiIiKSiQ0UERERERGRTGygiIiIiIiIZGIDRUREREREJBMbKCIiIiIiIpnYQBEREREREcnEBoqIiIiIiEgmNlBEREREREQysYEiIiIiIiKSiQ0UERERERGRTGygiIiIiIiIZGIDRUREREREJBMbKCIiIiIiIpnYQBGR3UhOTkbbtm1Ro0YNeHl5oU+fPjh58qTRmDt37iAuLg61atVC9erV0a9fP+Tl5RmNuXDhAqKjo+Hq6govLy9MmDAB9+7dMxqTkZGBp59+GiqVCo0aNUJKSoq50yMiK2J9ISK52EARkd3YsWMH4uLisG/fPmg0Guh0OkRERODmzZvSmHHjxuGnn37C6tWrsWPHDvz999/o27evNL+oqAjR0dG4e/cu9u7diy+//BIpKSmYNm2aNObs2bOIjo7Gc889h+zsbIwdOxYjRozA5s2bLZovEVkO6wsRyVXN2gEQEcm1adMmo8cpKSnw8vJCVlYWOnfujIKCAnz++edIS0tD165dAQDLly9H06ZNsW/fPrRv3x7p6ek4fvw4tmzZAm9vb7Rq1QozZszApEmTkJCQAKVSiWXLliEgIABz5swBADRt2hS7d+/GvHnzEBkZafG8icj8WF+ISC7ugSIiu1VQUAAA8PT0BABkZWVBp9MhPDxcGtOkSRPUr18fmZmZAIDMzEwEBwfD29tbGhMZGYnCwkLk5ORIYx5chmGMYRlEVPmxvhBRabgHiojskl6vx9ixY9GhQwc0b94cAJCbmwulUgkPDw+jsd7e3sjNzZXGPPjlxjDfMK+sMYWFhbh9+zZcXFyM5mm1Wmi1WulxYWEhAECn00Gn05Wag2GeykHIylmOstZXXipH08VltNz/n+/j5m3KXC3BEK+9xf04zJGzJbYf60vZyzSF8tYXU9UNOcz9HqtMtaAy5QLIz8MsDdRff/2FSZMm4eeff8atW7fQqFEjLF++HG3atAEACCEwffp0/Pe//0V+fj46dOiApUuX4sknn5SWcfXqVbz55pv46aef4ODggH79+mHBggWoXr26NObIkSOIi4vDwYMHUadOHbz55puYOHGiOVIiIhsTFxeHY8eOYffu3dYOBcnJyUhMTCw2PT09Ha6uro98/ow2epPFsnHjRpMta3Y7ky2qRI+btylztSSNRmPtECzOlDnfunXLZMsqDetLyWyhvpgyn9JYqrZUplpQWXKRW19M3kBdu3YNHTp0wHPPPYeff/4ZderUwalTp1CzZk1pzOzZs7Fw4UJ8+eWXCAgIwNSpUxEZGYnjx4/D2dkZADBo0CBcvHhROpHztddew6hRo5CWlgbg/i8wERERCA8Px7Jly3D06FEMGzYMHh4eGDVqlKnTIiIbEh8fj/Xr12Pnzp2oV6+eNN3Hxwd3795Ffn6+0a/EeXl58PHxkcYcOHDAaHmGq2g9OObhK2vl5eVBrVYX+3UYACZPnozx48dLjwsLC+Hn54eIiAio1epS89DpdNBoNJh6yAFavUJm9mU7lmC6cyiaJ5jnpHaVg8CMNvrHztuUuVqC4fXu3r07nJycrB2ORZgjZ8MeGHNhfSmdNeuLqeqGHOauLZWpFlSmXAD59cXkDdSsWbPg5+eH5cuXS9MCAgKk/xdCYP78+ZgyZQp69+4NAPjqq6/g7e2NtWvXIiYmBidOnMCmTZtw8OBBaa/VokWL0LNnT3z88cfw9fVFamoq7t69iy+++AJKpRLNmjVDdnY25s6dywaKqJISQuDNN9/EDz/8gIyMDKPaAgAhISFwcnLC1q1b0a9fPwDAyZMnceHCBYSFhQEAwsLC8MEHH+DSpUvw8vICcP+XM7VajaCgIGnMw79AajQaaRkPU6lUUKlUxaY7OTnJ+oOi1SugLTLNFwJT/gEzVUylLv8x87bXP9Zy3xeViSlzNte2Y315NFuoL6bMpzSW+nxWplpQWXKRm4PJLyKxbt06tGnTBi+//DK8vLzQunVr/Pe//5Xmnz17Frm5uUYnULq7uyM0NNToJEwPDw+peQKA8PBwODg4YP/+/dKYzp07Q6lUSmMiIyNx8uRJXLt2zdRpEZENiIuLwzfffIO0tDTUqFEDubm5yM3Nxe3btwHcryXDhw/H+PHjsX37dmRlZeG1115DWFgY2rdvDwCIiIhAUFAQBg8ejF9//RWbN2/GlClTEBcXJ31JGT16NP744w9MnDgRv/32G5YsWYJVq1Zh3LhxVsudiMyL9YWI5DL5Hqg//vgDS5cuxfjx4/Huu+/i4MGDeOutt6BUKhEbGyudRFnSCZQPnmBp+OVGCrRaNXh6ehqNefjXoQdP1HzwkEGDipyIaesnYT6OynbinwHzsj5zxbh06VIAQJcuXYymL1++HEOHDgUAzJs3TzpvUqvVIjIyEkuWLJHGOjo6Yv369RgzZgzCwsLg5uaG2NhYJCUlSWMCAgKwYcMGjBs3DgsWLEC9evXw2Wef8RLDRJUY6wsRyWXyBkqv16NNmzb48MMPAQCtW7fGsWPHsGzZMsTGxpp6deXyOCdi2upJmKZQWU78exjzsh5zneQtxKN/yHB2dsbixYuxePHiUsf4+/s/8nPYpUsXHD58uNwxEpF9Yn0hIrlM3kDVrVtXOs7XoGnTpvj+++8B/N9JlHl5eahbt640Ji8vD61atZLGXLp0yWgZ9+7dw9WrVx95EuaD63hYRU7EtPWTMB9HZTvxz4B5WZ+5T/ImIiIishaTN1AdOnTAyZMnjab9/vvv8Pf3B3B/17WPjw+2bt0qNUyFhYXYv38/xowZA+D+CZb5+fnIyspCSEgIAGDbtm3Q6/UIDQ2Vxrz33nvQ6XTSl0mNRoPGjRuXePge8HgnYtrqSZimUFlO/HsY87IeW4+PiIiIqKJMfhGJcePGYd++ffjwww9x+vRppKWl4dNPP0VcXBwAQKFQYOzYsXj//fexbt06HD16FEOGDIGvry/69OkD4P4eqx49emDkyJE4cOAA9uzZg/j4eMTExMDX1xcAMHDgQCiVSgwfPhw5OTlYuXIlFixYYLSHiYiIiIiIyJRMvgeqbdu2+OGHHzB58mQkJSUhICAA8+fPx6BBg6QxEydOxM2bNzFq1Cjk5+ejY8eO2LRpk3QPKABITU1FfHw8unXrJp2wuXDhQmm+u7s70tPTERcXh5CQENSuXRvTpk3jJcyJiIiIiMhsTN5AAcDzzz+P559/vtT5CoUCSUlJRleleZinp6d009zStGjRArt27apwnEREREREROVh8kP4iIiIiIiIKis2UERERERERDKxgSIiIiIiIpKJDRQREREREZFMbKCIiIiIiIhkYgNFREREREQkExsoIiIiIiIimdhAERERERERycQGioiIiIiISCY2UERERERERDKxgSIiIiIiIpKJDRQREREREZFM1awdABERmU6DdzZYOwQiqqRYX4ju4x4oIiIiIiIimdhAERERERERycQGioiIiIiISCY2UERkN3bu3IlevXrB19cXCoUCa9euNZo/dOhQKBQKo389evQwGnP16lUMGjQIarUaHh4eGD58OG7cuGE05siRI+jUqROcnZ3h5+eH2bNnmzs1IrIy1hcikosNFBHZjZs3b6Jly5ZYvHhxqWN69OiBixcvSv++/fZbo/mDBg1CTk4ONBoN1q9fj507d2LUqFHS/MLCQkRERMDf3x9ZWVn46KOPkJCQgE8//dRseRGR9bG+EJFcvAofEdmNqKgoREVFlTlGpVLBx8enxHknTpzApk2bcPDgQbRp0wYAsGjRIvTs2RMff/wxfH19kZqairt37+KLL76AUqlEs2bNkJ2djblz5xp9ESLrM+UVwc7NjDbZssg+sb6QgamvNsj6UvmwgSKiSiUjIwNeXl6oWbMmunbtivfffx+1atUCAGRmZsLDw0P6cgMA4eHhcHBwwP79+/Hiiy8iMzMTnTt3hlKplMZERkZi1qxZuHbtGmrWrFlsnVqtFlqtVnpcWFgIANDpdNDpdKXGapinchCPl7SdMeRrS3mX9TqZeh2WWJetMEfO1tx+rC/WY4t1Q66HX6fKVAsqUy6A/DzYQBFRpdGjRw/07dsXAQEBOHPmDN59911ERUUhMzMTjo6OyM3NhZeXl9FzqlWrBk9PT+Tm5gIAcnNzERAQYDTG29tbmlfSF5zk5GQkJiYWm56eng5XV9dHxj2jjV52jpWJLeW9ceNGi61Lo9FYbF22wpQ537p1y2TLKg/WF9tgj/mUVl8qUy2oLLnIrS9soIio0oiJiZH+Pzg4GC1atEBgYCAyMjLQrVs3s6138uTJGD9+vPS4sLAQfn5+iIiIgFqtLvV5Op0OGo0GUw85QKtXmC0+W6NyEJjRRm9TeR9LiDT7Ogyvd/fu3eHk5GT29dkCc+Rs2ANjaawv1mWLdUOuh+tLZaoFlSkXQH59YQNF/6+9e4+Oor7/P/7a3DYESMItCSkBgygX5WaCYbkVJSRgtFJpFaWAluJXGvwWU7XSn+UitlEUUDSKVgVtpaA9gggUEoNcDSCRlIuWguI3UkkQkISAJJtkfn94MnXNhQE2u9nN83FOzmFnPjv7fk+ST/bF7MwAfqtr165q3769Dh8+rBEjRigmJkbHjx93GVNZWalTp06Z5zXExMSouLjYZUzN4/rOfbDb7bLb7bWWBwcHW/qDUl5tU3mVb70hcIem1Lcn//Bb/bnwJ+7suansO+YX7/DFfur7PvnTXOAvvVjtgavwAfBbR48e1cmTJ9WxY0dJksPh0OnTp5Wfn2+O2bhxo6qrq5WUlGSO2bJli8vnoHNyctS9e/c6P14DoHlifgGaLwIUAJ9RVlamgoICFRQUSJKOHDmigoICFRYWqqysTA899JB27NihL774Qrm5ubr11lvVrVs3paZ+9/GJnj17atSoUZoyZYp27dql7du3a9q0aRo3bpxiY2MlSXfddZdCQkI0efJkHThwQCtWrNCzzz7r8hEaAP6H+QWAVQQoAD5j9+7d6t+/v/r37y9JysjIUP/+/TVz5kwFBgZq7969+slPfqKrr75akydPVkJCgrZu3ery8Zc333xTPXr00IgRI3TTTTdpyJAhLvdgiYiIUHZ2to4cOaKEhAT99re/1cyZM7nEMODnmF8AWMU5UAB8xvDhw2UY9V/CdsOGDRfcRtu2bbVs2bIGx/Tp00dbt2696PoA+C7mFwBWcQQKAAAAACwiQAEAAACARQQoAAAAALCo0QPUE088IZvNpunTp5vLzp8/r/T0dLVr106tWrXS2LFja90XobCwUGlpaQoLC1NUVJQeeughVVZWuozZtGmTrrvuOtntdnXr1k1Lly5t7HYAAAAANGONGqA++ugjvfTSS+rTp4/L8gceeEDvvfee3n77bW3evFlfffWVbrvtNnN9VVWV0tLSVFFRoQ8//FCvv/66li5dqpkzZ5pjjhw5orS0NN1www0qKCjQ9OnT9atf/crSSZ4AAAAAcCkaLUCVlZVp/Pjx+vOf/+xyc7iSkhK9+uqrWrBggW688UYlJCRoyZIl+vDDD7Vjxw5JUnZ2tj755BP99a9/Vb9+/TR69GjNnTtXWVlZqqiokCQtXrxY8fHxmj9/vnr27Klp06bpZz/7mRYuXNhYLQEAAABo5hrtMubp6elKS0tTcnKyHn/8cXN5fn6+nE6nkpOTzWU9evRQ586dlZeXp4EDByovL0+9e/dWdHS0OSY1NVVTp07VgQMH1L9/f+Xl5blso2bM9z8q+EPl5eUqLy83H5eWlkqSnE6ny13Bv69muT2g/kubXqz6XsvTaupoKvW4C315ny/UCAAAcCkaJUAtX75cH3/8sT766KNa64qKihQSEqLIyEiX5dHR0SoqKjLHfD881ayvWdfQmNLSUn377bdq0aJFrdfOzMzUnDlzai3Pzs5WWFhYgz3NTaxucP3FWLdundu25Q45OTneLqFR0Jf3nDt3ztslAAAANAq3B6gvv/xSv/nNb5STk6PQ0FB3b/6yzJgxQxkZGebj0tJSxcXFKSUlReHh4XU+x+l0KicnR3/YHaDyaptb6tg/O9Ut27lcNb2NHDlSwcHB3i7HbejL+2qO7gIAAPgbtweo/Px8HT9+XNddd525rKqqSlu2bNHzzz+vDRs2qKKiQqdPn3Y5ClVcXKyYmBhJUkxMjHbt2uWy3Zqr9H1/zA+v3FdcXKzw8PA6jz5Jkt1ul91ur7U8ODj4gm9Iy6ttKq9yT4Bqam9+rfTvi+jLe5p6fQAAAJfK7ReRGDFihPbt26eCggLzKzExUePHjzf/HRwcrNzcXPM5Bw8eVGFhoRwOhyTJ4XBo3759On78uDkmJydH4eHh6tWrlznm+9uoGVOzDQAAAABwN7cfgWrdurWuvfZal2UtW7ZUu3btzOWTJ09WRkaG2rZtq/DwcN1///1yOBwaOHCgJCklJUW9evXShAkTNG/ePBUVFenRRx9Venq6eQTpvvvu0/PPP6+HH35Yv/zlL7Vx40a99dZbWrt2rbtbAgAAAABJjXgVvoYsXLhQAQEBGjt2rMrLy5WamqoXXnjBXB8YGKg1a9Zo6tSpcjgcatmypSZNmqTHHnvMHBMfH6+1a9fqgQce0LPPPqtOnTrplVdeUWpq0zi/CAAAAID/8UiA2rRpk8vj0NBQZWVlKSsrq97ndOnS5YJXqxs+fLj27NnjjhIBAAAA4IIa7Ua6AAAAAOBvCFAAAAAAYBEBCgAAAAAsIkABAAAAgEUEKAAAAACwiAAFAAAAABYRoAAAAADAIgIUAJ+xZcsW3XLLLYqNjZXNZtOqVatc1huGoZkzZ6pjx45q0aKFkpOTdejQIZcxp06d0vjx4xUeHq7IyEhNnjxZZWVlLmP27t2roUOHKjQ0VHFxcZo3b15jtwbAy5hfAFhFgALgM86ePau+ffvWexPuefPmadGiRVq8eLF27typli1bKjU1VefPnzfHjB8/XgcOHFBOTo7WrFmjLVu26N577zXXl5aWKiUlRV26dFF+fr6eeuopzZ49Wy+//HKj9wfAe5hfAFgV5O0CAMCq0aNHa/To0XWuMwxDzzzzjB599FHdeuutkqQ33nhD0dHRWrVqlcaNG6dPP/1U69ev10cffaTExERJ0nPPPaebbrpJTz/9tGJjY/Xmm2+qoqJCr732mkJCQnTNNdeooKBACxYscHkjBMC/ML8AsIoABcAvHDlyREVFRUpOTjaXRUREKCkpSXl5eRo3bpzy8vIUGRlpvrmRpOTkZAUEBGjnzp366U9/qry8PA0bNkwhISHmmNTUVD355JP65ptv1KZNm1qvXV5ervLycvNxaWmpJMnpdMrpdNZbc806e4Bx6Y37oJp+m1LfDX2f3P0annitpqIxevbG/mN+8b6mOG9Y9cPvkz/NBf7Ui2S9DwIUAL9QVFQkSYqOjnZZHh0dba4rKipSVFSUy/qgoCC1bdvWZUx8fHytbdSsq+sNTmZmpubMmVNreXZ2tsLCwi5Y+9zE6guO8UdNqe9169Z57LVycnI89lpNhTt7PnfunNu2ZRXzS9Phi/3UN7/401zgL71YnV8IUABwmWbMmKGMjAzzcWlpqeLi4pSSkqLw8PB6n+d0OpWTk6M/7A5QebXNE6U2CfYAQ3MTq5tU3/tnpzb6a9R8v0eOHKng4OBGf72moDF6rjkC01wwv3ynKc4bVv1wfvGnucCfepGszy8EKAB+ISYmRpJUXFysjh07msuLi4vVr18/c8zx48ddnldZWalTp06Zz4+JiVFxcbHLmJrHNWN+yG63y26311oeHBxs6Q9KebVN5VW+9YbAHZpS3578w2/158KfuLNnb+w75pemwxf7qe/75E9zgb/0YrUHrsIHwC/Ex8crJiZGubm55rLS0lLt3LlTDodDkuRwOHT69Gnl5+ebYzZu3Kjq6molJSWZY7Zs2eLyOeicnBx17969zo/XAPB/zC8Avo8ABcBnlJWVqaCgQAUFBZK+O7G7oKBAhYWFstlsmj59uh5//HGtXr1a+/bt08SJExUbG6sxY8ZIknr27KlRo0ZpypQp2rVrl7Zv365p06Zp3Lhxio2NlSTdddddCgkJ0eTJk3XgwAGtWLFCzz77rMtHaAD4H+YXAFbxET4APmP37t264YYbzMc1bzomTZqkpUuX6uGHH9bZs2d177336vTp0xoyZIjWr1+v0NBQ8zlvvvmmpk2bphEjRiggIEBjx47VokWLzPURERHKzs5Wenq6EhIS1L59e82cOZNLDAN+jvkFgFUEKAA+Y/jw4TKM+i9ha7PZ9Nhjj+mxxx6rd0zbtm21bNmyBl+nT58+2rp16yXXCcD3ML8AsIqP8AEAAACARQQoAAAAALCIAAUAAAAAFhGgAAAAAMAiAhQAAAAAWESAAgAAAACLCFAAAAAAYBEBCgAAAAAsIkABAAAAgEUEKAAAAACwKMjbBQAA4G1XPLLWrdv74ok0t24PgO/64fxiDzQ073rp2tkbVF5lu+jtMb94n9uPQGVmZmrAgAFq3bq1oqKiNGbMGB08eNBlzPnz55Wenq527dqpVatWGjt2rIqLi13GFBYWKi0tTWFhYYqKitJDDz2kyspKlzGbNm3SddddJ7vdrm7dumnp0qXubgcAAAAATG4PUJs3b1Z6erp27NihnJwcOZ1OpaSk6OzZs+aYBx54QO+9957efvttbd68WV999ZVuu+02c31VVZXS0tJUUVGhDz/8UK+//rqWLl2qmTNnmmOOHDmitLQ03XDDDSooKND06dP1q1/9Shs2bHB3SwAAAAAgqRE+wrd+/XqXx0uXLlVUVJTy8/M1bNgwlZSU6NVXX9WyZct04403SpKWLFminj17aseOHRo4cKCys7P1ySef6P3331d0dLT69eunuXPn6ne/+51mz56tkJAQLV68WPHx8Zo/f74kqWfPntq2bZsWLlyo1NRUd7cFAAAAAI1/EYmSkhJJUtu2bSVJ+fn5cjqdSk5ONsf06NFDnTt3Vl5eniQpLy9PvXv3VnR0tDkmNTVVpaWlOnDggDnm+9uoGVOzDQAAAABwt0a9iER1dbWmT5+uwYMH69prr5UkFRUVKSQkRJGRkS5jo6OjVVRUZI75fniqWV+zrqExpaWl+vbbb9WiRYta9ZSXl6u8vNx8XFpaKklyOp1yOp119lCz3B5gWOrZivpey9Nq6mgq9bgLfXmfL9QIAABwKRo1QKWnp2v//v3atm1bY76MZZmZmZozZ06t5dnZ2QoLC2vwuXMTq91Wx7p169y2LXfIycnxdgmNgr6859y5c94uAQAAoFE0WoCaNm2a1qxZoy1btqhTp07m8piYGFVUVOj06dMuR6GKi4sVExNjjtm1a5fL9mqu0vf9MT+8cl9xcbHCw8PrPPokSTNmzFBGRob5uLS0VHFxcUpJSVF4eHidz3E6ncrJydEfdgeovPriLzVZl/2zm8Y5WjW9jRw5UsHBwd4ux23oy/tqju4CAAD4G7cHKMMwdP/992vlypXatGmT4uPjXdYnJCQoODhYubm5Gjt2rCTp4MGDKiwslMPhkCQ5HA798Y9/1PHjxxUVFSXpu/91Dw8PV69evcwxPzySk5OTY26jLna7XXa7vdby4ODgC74hLa+2XdK1+uvS1N78WunfF9GX9zT1+gAAAC6V2wNUenq6li1bpnfffVetW7c2z1mKiIhQixYtFBERocmTJysjI0Nt27ZVeHi47r//fjkcDg0cOFCSlJKSol69emnChAmaN2+eioqK9Oijjyo9Pd0MQPfdd5+ef/55Pfzww/rlL3+pjRs36q233tLate69GSIAAAAA1HD7VfhefPFFlZSUaPjw4erYsaP5tWLFCnPMwoULdfPNN2vs2LEaNmyYYmJi9M4775jrAwMDtWbNGgUGBsrhcOgXv/iFJk6cqMcee8wcEx8fr7Vr1yonJ0d9+/bV/Pnz9corr3AJc6CZmz17tmw2m8tXjx49zPXuupE3gOaFuQVAjUb5CN+FhIaGKisrS1lZWfWO6dKlywUvtjB8+HDt2bPnomsE4N+uueYavf/+++bjoKD/TnUPPPCA1q5dq7ffflsRERGaNm2abrvtNm3fvl3Sf2/kHRMTow8//FDHjh3TxIkTFRwcrD/96U8e7wVA08HcAkBq5KvwAYA3BAUFmRec+T533cgbQPPE3AJA8sCNdAHA0w4dOqTY2Fh17dpV48ePV2FhoST33cgbQPPE3AJA4ggUAD+TlJSkpUuXqnv37jp27JjmzJmjoUOHav/+/W67kfcPXcpNumvWS+69UbcvqOnXn/uu6/vuSzfDdpfG6Nlb+88bc4vE/FLDn+aNy+2lKc0h/javWe2DAAXAr4wePdr8d58+fZSUlKQuXbrorbfeqvcecZfrcm7SLbn3Rt2+xJ/7bugcXl+4Gba7ubNnb92o2xtzi8T88kP+1M+l9nKhawR4g7/Ma1bnFwIUAL8WGRmpq6++WocPH9bIkSPdciPvH7qUm3RLjXOjbl9gDzA0N7Har/uu64bpvnQzbHdpjJ6byo26PTG3SMwvNfxp3rjcXuqaX7zF3+Y1q/MLAQqAXysrK9Nnn32mCRMmuO1G3j90OTfpltx7o25f4s99N/R994WbYbubO3tuKvvOE3OLxPzyQ/7Uz6X20lR+B77PX+Y1qz0QoAD4lQcffFC33HKLunTpoq+++kqzZs1SYGCg7rzzTrfdyBtA88PcAqAGAQqAXzl69KjuvPNOnTx5Uh06dNCQIUO0Y8cOdejQQdJ3N/IOCAjQ2LFjVV5ertTUVL3wwgvm82tu5D116lQ5HA61bNlSkyZNcrmRN4Dmh7kFQA0CFAC/snz58gbXu+tG3gCaF+YWADW4DxQAAAAAWESAAgAAAACLCFAAAAAAYBEBCgAAAAAsIkABAAAAgEUEKAAAAACwiMuYAwDgZlc8srbWMnugoXnXS9fO3qDyKpvlbX3xRJo7SwPg4+qaXy4V88ul4QgUAAAAAFhEgAIAAAAAiwhQAAAAAGARAQoAAAAALCJAAQAAAIBFBCgAAAAAsIgABQAAAAAWEaAAAAAAwCJupAsAQBPmzptmStw4E8B/Xe788sMbhDeX+YUABbgBb3AAAACaBwKUH7jUN+8//F8DqWm/cbfaZ1191aUp9+pu7gx4zWm/AQAA/BDnQAEAAACARRyBQrPl7o/dAQAAwP8RoLygKb9xb8q1NSd1fR+sfjQRAAAAjcfnP8KXlZWlK664QqGhoUpKStKuXbu8XRIAP8H8AqCxML8Avsunj0CtWLFCGRkZWrx4sZKSkvTMM88oNTVVBw8eVFRUlLfLA+DDmF/gr7iojPcxv8BfNZf5xaePQC1YsEBTpkzRPffco169emnx4sUKCwvTa6+95u3SAPg45hcAjYX5BfBtPnsEqqKiQvn5+ZoxY4a5LCAgQMnJycrLy6vzOeXl5SovLzcfl5SUSJJOnTolp9NZ53OcTqfOnTunIGeAqqr967yToGpD585V+11v9NW4Tp48ecExZ86ckSQZhtHY5TSKi51fLmVukfx7fmlIU/lZ9jR/7PtC80HNz/jJkycVHBzsltdkfmme84s//f7QizVW3m+4m9X5xWcD1IkTJ1RVVaXo6GiX5dHR0frXv/5V53MyMzM1Z86cWsvj4+MbpUZfcJe3C2gk9NV42s+3PvbMmTOKiIhovGIaycXOL8wtF68p/Cx7g7/1fTHzgbsxvzS/+cWffn/o5cKa8vziswHqUsyYMUMZGRnm4+rqap06dUrt2rWTzVZ3ai4tLVVcXJy+/PJLhYeHe6pUj/DX3ujL+wzD0JkzZxQbG+vtUjziUuYWybe+p+5E382n78bomfmlec4v/tQPvTRdVucXnw1Q7du3V2BgoIqLi12WFxcXKyYmps7n2O122e12l2WRkZGWXi88PNwvfjDq4q+90Zd3+eL/DNe42PnlcuYWyXe+p+5G382Hu3tmfom0/Hr+9vPmT/3QS9NkZX7x2YtIhISEKCEhQbm5ueay6upq5ebmyuFweLEyAL6O+QVAY2F+AXyfzx6BkqSMjAxNmjRJiYmJuv766/XMM8/o7Nmzuueee7xdGgAfx/wCoLEwvwC+zacD1B133KGvv/5aM2fOVFFRkfr166f169fXOjHzctjtds2aNavW4XN/4K+90Rfcgfml8dB38+m7OfZsBfPLxfOnfujF99kMX70OKAAAAAB4mM+eAwUAAAAAnkaAAgAAAACLCFAAAAAAYBEBCgAAAAAsIkBdQFZWlq644gqFhoYqKSlJu3bt8nZJDdqyZYtuueUWxcbGymazadWqVS7rDcPQzJkz1bFjR7Vo0ULJyck6dOiQy5hTp05p/PjxCg8PV2RkpCZPnqyysjIPdlFbZmamBgwYoNatWysqKkpjxozRwYMHXcacP39e6enpateunVq1aqWxY8fWulFhYWGh0tLSFBYWpqioKD300EOqrKz0ZCsuXnzxRfXp08e8AZ3D4dA//vEPc70v9gTrfG1+uVjumI98jbvmKl/jjrkM7tXU55fZs2fLZrO5fPXo0cNc39T//nnq/dbevXs1dOhQhYaGKi4uTvPmzfN4L3fffXet79WoUaOaZC8eY6Bey5cvN0JCQozXXnvNOHDggDFlyhQjMjLSKC4u9nZp9Vq3bp3x//7f/zPeeecdQ5KxcuVKl/VPPPGEERERYaxatcr45z//afzkJz8x4uPjjW+//dYcM2rUKKNv377Gjh07jK1btxrdunUz7rzzTg934io1NdVYsmSJsX//fqOgoMC46aabjM6dOxtlZWXmmPvuu8+Ii4szcnNzjd27dxsDBw40Bg0aZK6vrKw0rr32WiM5OdnYs2ePsW7dOqN9+/bGjBkzvNGSYRiGsXr1amPt2rXGv//9b+PgwYPG73//eyM4ONjYv3+/YRi+2ROs8cX55WK5Yz7yNe6Yq3zR5c5lcC9fmF9mzZplXHPNNcaxY8fMr6+//tpc39T//nni/VZJSYkRHR1tjB8/3ti/f7/xt7/9zWjRooXx0ksvebSXSZMmGaNGjXL5Xp06dcplTFPpxVMIUA24/vrrjfT0dPNxVVWVERsba2RmZnqxKut++EtQXV1txMTEGE899ZS57PTp04bdbjf+9re/GYZhGJ988okhyfjoo4/MMf/4xz8Mm81m/Oc///FY7Rdy/PhxQ5KxefNmwzC+6yM4ONh4++23zTGffvqpIcnIy8szDOO7CSIgIMAoKioyx7z44otGeHi4UV5e7tkGGtCmTRvjlVde8aueUJuvzy8X61LmI39wKXOVv7iYuQzu5Qvzy6xZs4y+ffvWuc7X/v411vutF154wWjTpo1LP7/73e+M7t27e6wXw/guQN166631Pqep9tKY+AhfPSoqKpSfn6/k5GRzWUBAgJKTk5WXl+fFyi7dkSNHVFRU5NJTRESEkpKSzJ7y8vIUGRmpxMREc0xycrICAgK0c+dOj9dcn5KSEklS27ZtJUn5+flyOp0uvfXo0UOdO3d26a13794uNypMTU1VaWmpDhw44MHq61ZVVaXly5fr7NmzcjgcftET6uaP88vFsjIf+YNLmat83aXMZXAfX5pfDh06pNjYWHXt2lXjx49XYWGhJN//m+6u91t5eXkaNmyYQkJCzDGpqak6ePCgvvnmGw91851NmzYpKipK3bt319SpU3Xy5Elzna/14g4EqHqcOHFCVVVVte4KHh0draKiIi9VdXlq6m6op6KiIkVFRbmsDwoKUtu2bZtM39XV1Zo+fboGDx6sa6+9VtJ3dYeEhCgyMtJl7A97q6v3mnXesm/fPrVq1Up2u1333XefVq5cqV69evl0T2iYP84vF8vKfOTrLnWu8lWXM5fBfXxlfklKStLSpUu1fv16vfjiizpy5IiGDh2qM2fO+PzfP3e932oqPY4aNUpvvPGGcnNz9eSTT2rz5s0aPXq0qqqqzFp8pRd3CfJ2AcDFSk9P1/79+7Vt2zZvl+IW3bt3V0FBgUpKSvT3v/9dkyZN0ubNm71dFoDL5G9z1YUwl+FijB492vx3nz59lJSUpC5duuitt95SixYtvFgZfmjcuHHmv3v37q0+ffroyiuv1KZNmzRixAgvVuY9HIGqR/v27RUYGFjrii/FxcWKiYnxUlWXp6buhnqKiYnR8ePHXdZXVlbq1KlTTaLvadOmac2aNfrggw/UqVMnc3lMTIwqKip0+vRpl/E/7K2u3mvWeUtISIi6deumhIQEZWZmqm/fvnr22Wd9uic0zB/nl4tlZT7yZZczV/mqy5nL4D6+Or9ERkbq6quv1uHDh33+75+73m811R67du2q9u3b6/Dhw2YtvtrLpSJA1SMkJEQJCQnKzc01l1VXVys3N1cOh8OLlV26+Ph4xcTEuPRUWlqqnTt3mj05HA6dPn1a+fn55piNGzequrpaSUlJHq+5hmEYmjZtmlauXKmNGzcqPj7eZX1CQoKCg4Ndejt48KAKCwtdetu3b5/LL3lOTo7Cw8PVq1cvzzRiQXV1tcrLy/2qJ7jyx/nlYlmZj3yRO+Yqf3Excxncx1fnl7KyMn322Wfq2LGjz//9c9f7LYfDoS1btsjpdJpjcnJy1L17d7Vp08ZD3dR29OhRnTx5Uh07dpTk271cMm9fxaIpW758uWG3242lS5can3zyiXHvvfcakZGRLld8aWrOnDlj7Nmzx9izZ48hyViwYIGxZ88e4//+7/8Mw/juspqRkZHGu+++a+zdu9e49dZb67ysZv/+/Y2dO3ca27ZtM6666iqvX8Z86tSpRkREhLFp0yaXy2ieO3fOHHPfffcZnTt3NjZu3Gjs3r3bcDgchsPhMNfXXPI0JSXFKCgoMNavX2906NDBq5f8fuSRR4zNmzcbR44cMfbu3Ws88sgjhs1mM7Kzsw3D8M2eYI0vzi8Xyx3zka9xx1zliy53LoN7+cL88tvf/tbYtGmTceTIEWP79u1GcnKy0b59e+P48eOGYTT9v3+eeL91+vRpIzo62pgwYYKxf/9+Y/ny5UZYWJjbL/3dUC9nzpwxHnzwQSMvL884cuSI8f777xvXXXedcdVVVxnnz59vcr14CgHqAp577jmjc+fORkhIiHH99dcbO3bs8HZJDfrggw8MSbW+Jk2aZBjGd5fW/MMf/mBER0cbdrvdGDFihHHw4EGXbZw8edK48847jVatWhnh4eHGPffcY5w5c8YL3fxXXT1JMpYsWWKO+fbbb41f//rXRps2bYywsDDjpz/9qXHs2DGX7XzxxRfG6NGjjRYtWhjt27c3fvvb3xpOp9PD3fzXL3/5S6NLly5GSEiI0aFDB2PEiBHmGw7D8M2eYJ2vzS8Xyx3zka9x11zla9wxl8G9mvr8cscddxgdO3Y0QkJCjB/96EfGHXfcYRw+fNhc39T//nnq/dY///lPY8iQIYbdbjd+9KMfGU888YRHezl37pyRkpJidOjQwQgODja6dOliTJkypVYYbyq9eIrNMAyjcY9xAQAAAIB/4BwoAAAAALCIAAUAAAAAFhGgAAAAAMAiAhQAAAAAWESAAgAAAACLCFAAAAAAYBEBCgAAAAAsIkABAAAAgEUEKAAAAACwiAAFAAAAABYRoAAAAADAIgIUAAAAAFhEgAIAAAAAiwhQAAAAAGARAQoAAAAALCJAAQAAAIBFBCgAAAAAsIgABQAAAAAWEaAAAAAAwCICFAAAAABYRICCi9mzZ8tms3m7DBeVlZV6+OGHFRcXp4CAAI0ZM8bbJdXyxRdfyGaz6emnn/Z2KQAAAGhEBCh4nNPp1KJFizRgwAC1bt1arVq10oABA7Ro0SI5nc5a41977TU99dRT+tnPfqbXX39dDzzwgMLDw3XrrbfWGrtw4ULZbDZNmjSp1rqZM2fKZrPp3//+d6P0BQAAAP8X5O0C0LycPXtWaWlp2rx5s26++WbdfffdCggI0Pr16/Wb3/xG77zzjtauXauWLVuaz9m4caN+9KMfaeHCheaygQMH6sMPP6y1/e3btysoKEjbt2+vc11UVJSuvvrqxmkOAAAAfo8jUPCojIwMbd68Wc8995zee+89paena+rUqXr33Xf1/PPPa/PmzXrwwQddnnP8+HFFRka6LBsyZIhOnDihTz/91GX59u3bdfvtt+uzzz5TUVGRubyyslI7d+7U4MGDG603AAAA+D8CVDO2bds2DRgwQKGhobryyiv10ksv1RqzZMkS3XjjjYqKipLdblevXr304osvuoyZNGmS2rdvX+fH71JSUtS9e3dJ0tGjR/Xqq6/qxhtv1LRp02qNTU9P1w033KBXXnlFR48eNc8r+uCDD3TgwAHZbDbZbDZt2rRJQ4YMkSSXI02ff/65ioqKNG3aNIWGhrqsKygo0NmzZ83nSdK//vUv/exnP1Pbtm0VGhqqxMRErV69ulZdp0+f1vTp0xUXFye73a5u3brpySefVHV1dYP71zAM3XvvvQoJCdE777zT4FgAAAD4BgJUM7Vv3z6lpKTo+PHjmj17tu655x7NmjVLK1eudBn34osvqkuXLvr973+v+fPnKy4uTr/+9a+VlZVljpkwYYJOnjypDRs2uDy3qKhIGzdu1C9+8QtJ0j/+8Q9VVVVp4sSJ9dY1ceJEVVZWav369erQoYP+8pe/qEePHurUqZP+8pe/6C9/+Yt69uypgQMHKigoSNu2bTOfu337drVs2VIDBgxQYmKiS4Cq+XdNgDpw4IAGDhyoTz/9VI888ojmz5+vli1basyYMS774Ny5c/rxj3+sv/71r5o4caIWLVqkwYMHa8aMGcrIyKi3j6qqKt1999164403tHLlSt122231jgUAAIAPMdAsjRkzxggNDTX+7//+z1z2ySefGIGBgcb3fyzOnTtX67mpqalG165dzcdVVVVGp06djDvuuMNl3IIFCwybzWZ8/vnnhmEYxvTp0w1Jxp49e+qt6+OPPzYkGRkZGeayH//4x8Y111xTa+yAAQOMK6+80nz8P//zP8YNN9xgGIZhPPzww8aAAQPMdT/72c+MsLAww+l0GoZhGCNGjDB69+5tnD9/3hxTXV1tDBo0yLjqqqvMZXPnzjVatmxp/Pvf/3Z57UceecQIDAw0CgsLDcMwjCNHjhiSjKeeespwOp3GHXfcYbRo0cLYsGFDvb0CAADA93AEqhmqqqrShg0bNGbMGHXu3Nlc3rNnT6WmprqMbdGihfnvkpISnThxQj/+8Y/1+eefq6SkRJIUEBCg8ePHa/Xq1Tpz5ow5/s0339SgQYMUHx8vSea61q1b11tbzbrS0tIL9jFkyBCXc522b9+uQYMGSZIGDx6sPXv26Ny5c+a6pKQkBQUF6dSpU9q4caNuv/12nTlzRidOnNCJEyd08uRJpaam6tChQ/rPf/4jSXr77bc1dOhQtWnTxhx34sQJJScnq6qqSlu2bHGpqaKiQj//+c+1Zs0arVu3TikpKRfsAwAAAL6DANUMff311/r222911VVX1VpXc75Sje3btys5OVktW7ZUZGSkOnTooN///veSZAYo6buP3n377bfmx98OHjyo/Px8TZgwwRxTE46+H7J+yErIqvH986BOnz6tAwcOmBeJGDRokCorK7Vr1y4dOXJEx44dM8cfPnxYhmHoD3/4gzp06ODyNWvWLEnfXbhCkg4dOmR+nPD7X8nJyS7jamRmZmrVqlX6+9//ruHDh1+wBwAAAPgWLmOOen322WcaMWKEevTooQULFiguLk4hISFat26dFi5c6HIRhV69eikhIcE8V+ivf/2rQkJCdPvtt5tjevbsKUnau3ev+vXrV+dr7t2719zehdQEom3btiksLEyS5HA4JEnt27fXVVddpW3btunLL790GV9T94MPPljriFuNbt26mWNHjhyphx9+uM5xP7wkempqqtavX6958+Zp+PDhCg0NvWAfAAAA8B0EqGaoQ4cOatGihQ4dOlRr3cGDB81/v/feeyovL9fq1atdPur3wQcf1LndiRMnKiMjQ8eOHdOyZcuUlpamNm3amOtHjx6twMBA/eUvf6n3QhJvvPGGgoKCNGrUqAv2ERUVZYakli1bqlevXi6XOx80aJC2b9+uo0ePKjAw0AxXXbt2lSQFBwebR5Lqc+WVV6qsrOyC42oMHDhQ9913n26++Wb9/Oc/18qVKxUUxK8ZAACAv+AjfM1QYGCgUlNTtWrVKhUWFprLP/30U5cr6QUGBkr67nLcNUpKSrRkyZI6t3vnnXfKZrPpN7/5jT7//HPz6ns14uLidM899+j999+vdSl0SVq8eLE2btyoyZMnq1OnTpZ6GTJkiAoKCpSdnW2e/1Rj0KBBysvL09atW9WnTx/zY4FRUVEaPny4XnrpJR07dqzWNr/++mvz37fffrvy8vJqXWFQ+u7y5pWVlbWWJycna/ny5Vq/fr0mTJhwwcudAwAAwHfwX+PN1Jw5c7R+/XoNHTpUv/71r1VZWannnntO11xzjfkxupSUFIWEhOiWW27R//zP/6isrEx//vOfFRUVVWfw6NChg0aNGqW3335bkZGRSktLqzVm4cKF+te//qVf//rXWr9+vXmkacOGDXr33Xf14x//WPPnz7fcx5AhQ7RkyRJ99NFHSk9Pd1k3aNAglZSUqKSkRPfff7/LuqysLA0ZMkS9e/fWlClT1LVrVxUXFysvL09Hjx7VP//5T0nSQw89pNWrV+vmm2/W3XffrYSEBJ09e1b79u3T3//+d33xxRdq3759rbrGjBmjJUuWaOLEiQoPD6/zHlsAAADwQd6+DCC8Z/PmzUZCQoIREhJidO3a1Vi8eLExa9Ysl8uYr1692ujTp48RGhpqXHHFFcaTTz5pvPbaa4Yk48iRI7W2+dZbbxmSjHvvvbfe1y0vLzcWLlxoJCQkGC1btjTCwsKM6667znjmmWeMioqKWuPru4y5YRjGwYMHDUmGpFqXGq+urjYiIyMNScaKFStqPfezzz4zJk6caMTExBjBwcHGj370I+Pmm282/v73v7uMO3PmjDFjxgyjW7duRkhIiNG+fXtj0KBBxtNPP23W+/3LmH/fCy+8YEgyHnzwwXr3BwAAAHyHzTC+9/ks4DK9++67GjNmjLZs2aKhQ4d6uxwAAADArQhQcKubb75Zn376qQ4fPiybzebtcgAAAAC34hwouMXy5cu1d+9erV27Vs8++yzhCQAAAH6JI1BwC5vNplatWumOO+7Q4sWLuXQ3AAAA/BLvcuEW5HAAAAA0B9wHCgAAAAAsIkABAAAAgEXN+iN81dXV+uqrr9S6dWsuegC4kWEYOnPmjGJjYxUQwP/TAAAA/9GsA9RXX32luLg4b5cB+K0vv/xSnTp18nYZAAAAbtOsA1Tr1q0lffcmLzw8vM4xTqdT2dnZSklJUXBwsCfLa1LYD+wDyfo+KC0tVVxcnPk7BgAA4C+adYCq+dheeHh4gwEqLCxM4eHhzfZNs8R+kNgH0sXvAz4aCwAA/A0nJwAAAACARQQoAAAAALCIAAUAAAAAFhGgAAAAAMAiAhQAAAAAWESAAgAAAACL3B6gMjMzNWDAALVu3VpRUVEaM2aMDh486DLm/PnzSk9PV7t27dSqVSuNHTtWxcXFLmMKCwuVlpamsLAwRUVF6aGHHlJlZaXLmE2bNum6666T3W5Xt27dtHTpUne3AwAAAAAmtweozZs3Kz09XTt27FBOTo6cTqdSUlJ09uxZc8wDDzyg9957T2+//bY2b96sr776Srfddpu5vqqqSmlpaaqoqNCHH36o119/XUuXLtXMmTPNMUeOHFFaWppuuOEGFRQUaPr06frVr36lDRs2uLslAAAAAJDUCDfSXb9+vcvjpUuXKioqSvn5+Ro2bJhKSkr06quvatmyZbrxxhslSUuWLFHPnj21Y8cODRw4UNnZ2frkk0/0/vvvKzo6Wv369dPcuXP1u9/9TrNnz1ZISIgWL16s+Ph4zZ8/X5LUs2dPbdu2TQsXLlRqaqq729K1szeovMo9NwX94ok0t2wHAAAAgGc1+jlQJSUlkqS2bdtKkvLz8+V0OpWcnGyO6dGjhzp37qy8vDxJUl5ennr37q3o6GhzTGpqqkpLS3XgwAFzzPe3UTOmZhsAAAAA4G5uPwL1fdXV1Zo+fboGDx6sa6+9VpJUVFSkkJAQRUZGuoyNjo5WUVGROeb74almfc26hsaUlpbq22+/VYsWLWrVU15ervLycvNxaWmpJMnpdMrpdNbZQ81ye4BhqWcr6nutpqymZl+s3V3YB9b3QXPeRwAAwL81aoBKT0/X/v37tW3btsZ8GcsyMzM1Z86cWsuzs7MVFhbW4HPnJla7rY5169a5bVuelpOT4+0SvI59cOF9cO7cOQ9VAgAA4FmNFqCmTZumNWvWaMuWLerUqZO5PCYmRhUVFTp9+rTLUaji4mLFxMSYY3bt2uWyvZqr9H1/zA+v3FdcXKzw8PA6jz5J0owZM5SRkWE+Li0tVVxcnFJSUhQeHl7nc5xOp3JycvSH3QEqr3bPOVD7Z7v/HK3GVrMfRo4cqeDgYG+X4xbXzr64C47YAwzNTayu82fBF7+nl8Lqz0HN0V0AAAB/4/YAZRiG7r//fq1cuVKbNm1SfHy8y/qEhAQFBwcrNzdXY8eOlSQdPHhQhYWFcjgckiSHw6E//vGPOn78uKKioiR99z/e4eHh6tWrlznmh0dycnJyzG3UxW63y26311oeHBx8wVBQXm1z20UkfDmAWNlXvuJSv591/Sz4yz6x6kI/B81tfwAAgObD7QEqPT1dy5Yt07vvvqvWrVub5yxFRESoRYsWioiI0OTJk5WRkaG2bdsqPDxc999/vxwOhwYOHChJSklJUa9evTRhwgTNmzdPRUVFevTRR5Wenm4GoPvuu0/PP/+8Hn74Yf3yl7/Uxo0b9dZbb2nt2rXubgkAAAAAJDXCVfhefPFFlZSUaPjw4erYsaP5tWLFCnPMwoULdfPNN2vs2LEaNmyYYmJi9M4775jrAwMDtWbNGgUGBsrhcOgXv/iFJk6cqMcee8wcEx8fr7Vr1yonJ0d9+/bV/Pnz9corrzTKJcwBAAAAQGqkj/BdSGhoqLKyspSVlVXvmC5dulzwYgvDhw/Xnj17LrpG1O+KR+o+gmcPNDTv+ou/Hxb3vAIAAIA/adSr8KFu9YWUS0VIAQAAADyj0W+kCwAAAAD+giNQ8BnuPnLXlHGUEgAAoGniCBQAAAAAWESAAgAAAACLCFAAAAAAYBEBCgAAAAAsIkABAAAAgEUEKAAAAACwiAAFAAAAABYRoAAAAADAIgIUAAAAAFhEgAIAAAAAiwhQAAAAAGARAQoAAAAALCJAAQAAAIBFBCgAAAAAsIgABQAAAAAWEaAAAAAAwCICFAAAAABYRIACAAAAAIsIUAAAAABgEQEKAAAAACwiQAEAAACARQQoAAAAALCIAAUAAAAAFhGgAAAAAMAiAhQAAAAAWESAAgAAAACLCFAAAAAAYBEBCgAAAAAsIkABAAAAgEUEKAAAAACwiAAFAAAAABYRoAAAAADAIgIUAAAAAFhEgAIAAAAAiwhQAAAAAGARAQoAAAAALCJAAQAAAIBFbg9QW7Zs0S233KLY2FjZbDatWrXKZf3dd98tm83m8jVq1CiXMadOndL48eMVHh6uyMhITZ48WWVlZS5j9u7dq6FDhyo0NFRxcXGaN2+eu1sBAAAAABduD1Bnz55V3759lZWVVe+YUaNG6dixY+bX3/72N5f148eP14EDB5STk6M1a9Zoy5Ytuvfee831paWlSklJUZcuXZSfn6+nnnpKs2fP1ssvv+zudgAAAADAFOTuDY4ePVqjR49ucIzdbldMTEyd6z799FOtX79eH330kRITEyVJzz33nG666SY9/fTTio2N1ZtvvqmKigq99tprCgkJ0TXXXKOCggItWLDAJWgBAAAAgDu5PUBZsWnTJkVFRalNmza68cYb9fjjj6tdu3aSpLy8PEVGRprhSZKSk5MVEBCgnTt36qc//any8vI0bNgwhYSEmGNSU1P15JNP6ptvvlGbNm3qfN3y8nKVl5ebj0tLSyVJTqdTTqezzufULLcHGJfXdCOqr/ZLYQ+su8+a/i92P3iiNk9paB+4s0/J/b26q76a7Vxoe+7eHwAAAE2FxwPUqFGjdNtttyk+Pl6fffaZfv/732v06NHKy8tTYGCgioqKFBUV5VpkUJDatm2roqIiSVJRUZHi4+NdxkRHR5vr6gtQmZmZmjNnTq3l2dnZCgsLa7DuuYnVlnv0tHXr1rltW/Oub3j9xe4HT9bmKXXtA3f2Kbm/V3fXl5OT0+D6c+fOufX1AAAAmgqPB6hx48aZ/+7du7f69OmjK6+8Ups2bdKIESMa9bVnzJihjIwM83Fpaani4uKUkpKi8PDwOp/jdDqVk5OjP+wOUHm1rVHru1T7Z6e6bVvXzt5Q53J7gKG5idUXvR88UZunNLQP3Nmn5P5e3VVfze/DyJEjFRwcXO+4mqO7AAAA/sYrH+H7vq5du6p9+/Y6fPiwRowYoZiYGB0/ftxlTGVlpU6dOmWeNxUTE6Pi4mKXMTWP6zu3Svru3Cu73V5reXBwcINvBiWpvNqm8qqmGaAuVPvFuFCPF7sfPFmbp9S1D9zZp+T+Xt1d34V+Z9z9egAAAE2F1+8DdfToUZ08eVIdO3aUJDkcDp0+fVr5+fnmmI0bN6q6ulpJSUnmmC1btricZ5GTk6Pu3bvX+/E9AAAAALhcbg9QZWVlKigoUEFBgSTpyJEjKigoUGFhocrKyvTQQw9px44d+uKLL5Sbm6tbb71V3bp1U2rqdx8x6tmzp0aNGqUpU6Zo165d2r59u6ZNm6Zx48YpNjZWknTXXXcpJCREkydP1oEDB7RixQo9++yzLh/PAwAAAAB3c3uA2r17t/r376/+/ftLkjIyMtS/f3/NnDlTgYGB2rt3r37yk5/o6quv1uTJk5WQkKCtW7e6fLTuzTffVI8ePTRixAjddNNNGjJkiMs9niIiIpSdna0jR44oISFBv/3tbzVz5kwuYQ4AAACgUbn9HKjhw4fLMOq/BPOGDRc+Ob5t27ZatmxZg2P69OmjrVu3XnR9AAAAAHCpvH4OFAAAAAD4CgIUAAAAAFhEgAIAAAAAiwhQAAAAAGARAQoAAAAALCJAAQAAAIBFBCgAAAAAsIgABQAAAAAWEaAAAAAAwCICFAAAAABYRIACAAAAAIsIUAAAAABgUZC3CwDQ+K54ZK1btmMPNDTverdsCgAAwCdxBAoAAAAALCJAAQAAAIBFBCgAAAAAsIgABQAAAAAWEaAAAAAAwCICFAAAAABYRIACAAAAAIsIUAAAAABgEQEKAAAAACwiQAEAAACARQQoAAAAALCIAAUAAAAAFhGgAAAAAMAiAhQAAAAAWESAAgAAAACLCFAAAAAAYBEBCgAAAAAsIkABAAAAgEUEKAAAAACwiAAFAAAAABYRoAAAAADAIgIUAAAAAFhEgAIAAAAAiwhQAAAAAGARAQoAAAAALCJAAQAAAIBFbg9QW7Zs0S233KLY2FjZbDatWrXKZb1hGJo5c6Y6duyoFi1aKDk5WYcOHXIZc+rUKY0fP17h4eGKjIzU5MmTVVZW5jJm7969Gjp0qEJDQxUXF6d58+a5uxUAAAAAcOH2AHX27Fn17dtXWVlZda6fN2+eFi1apMWLF2vnzp1q2bKlUlNTdf78eXPM+PHjdeDAAeXk5GjNmjXasmWL7r33XnN9aWmpUlJS1KVLF+Xn5+upp57S7Nmz9fLLL7u7HQAAAAAwBbl7g6NHj9bo0aPrXGcYhp555hk9+uijuvXWWyVJb7zxhqKjo7Vq1SqNGzdOn376qdavX6+PPvpIiYmJkqTnnntON910k55++mnFxsbqzTffVEVFhV577TWFhITommuuUUFBgRYsWOAStAAAAADAndweoBpy5MgRFRUVKTk52VwWERGhpKQk5eXlady4ccrLy1NkZKQZniQpOTlZAQEB2rlzp376058qLy9Pw4YNU0hIiDkmNTVVTz75pL755hu1adOmztcvLy9XeXm5+bi0tFSS5HQ65XQ663xOzXJ7gHHpjTey+mq/FPbAuvus6f9i94MnavOUhvaBO/uUvN9rfWp6v1C/7t4fAAAATYVHA1RRUZEkKTo62mV5dHS0ua6oqEhRUVEu64OCgtS2bVuXMfHx8bW2UbOuvgCVmZmpOXPm1FqenZ2tsLCwBmufm1jd4HpvWrdundu2Ne/6htdf7H7wZG2eUtc+cGefUtPptT45OTkNrj937pyHKgEAAPAsjwYob5sxY4YyMjLMx6WlpYqLi1NKSorCw8PrfI7T6VROTo7+sDtA5dU2T5V6UfbPTnXbtq6dvaHO5fYAQ3MTqy96P3iiNk9paB+4s0/J+73Wp2YfjBw5UsHBwfWOqzm6CwAA4G88GqBiYmIkScXFxerYsaO5vLi4WP369TPHHD9+3OV5lZWVOnXqlPn8mJgYFRcXu4ypeVwzpi52u112u73W8uDg4AbfDEpSebVN5VVNM0BdqPaLcaEeL3Y/eLI2T6lrH7izT6np9FqfC/3OuHt/AAAANBUevQ9UfHy8YmJilJubay4rLS3Vzp075XA4JEkOh0OnT59Wfn6+OWbjxo2qrq5WUlKSOWbLli0u51nk5OSoe/fu9X58DwAAAAAul9sDVFlZmQoKClRQUCDpuwtHFBQUqLCwUDabTdOnT9fjjz+u1atXa9++fZo4caJiY2M1ZswYSVLPnj01atQoTZkyRbt27dL27ds1bdo0jRs3TrGxsZKku+66SyEhIZo8ebIOHDigFStW6Nlnn3X5eB4AAAAAuJvbP8K3e/du3XDDDebjmlAzadIkLV26VA8//LDOnj2re++9V6dPn9aQIUO0fv16hYaGms958803NW3aNI0YMUIBAQEaO3asFi1aZK6PiIhQdna20tPTlZCQoPbt22vmzJlcwhwAAABAo3J7gBo+fLgMo/5LMNtsNj322GN67LHH6h3Ttm1bLVu2rMHX6dOnj7Zu3XrJdQIAAADAxfLoOVAAAAAA4MsIUAAAAABgEQEKAAAAACwiQAEAAACARQQoAAAAALCIAAUAAAAAFhGgAAAAAMAiAhQAAAAAWESAAgAAAACLCFAAAAAAYBEBCgAAAAAsIkABAAAAgEUEKAAAAACwiAAFAAAAABYRoAAAAADAIgIUAAAAAFhEgAIAAAAAiwhQAAAAAGARAQoAAAAALCJAAQAAAIBFBCgAAAAAsIgABQAAAAAWEaAAAAAAwCICFAAAAABYRIACAAAAAIsIUAAAAABgEQEKAAAAACwiQAEAAACARQQoAAAAALCIAAUAAAAAFhGgAAAAAMAiAhQAAAAAWESAAgAAAACLCFAAAAAAYBEBCgAAAAAsIkABAAAAgEUEKAAAAACwiAAFAAAAABYRoAAAAADAIq8EqNmzZ8tms7l89ejRw1x//vx5paenq127dmrVqpXGjh2r4uJil20UFhYqLS1NYWFhioqK0kMPPaTKykpPtwIAAACgGQny1gtfc801ev/99/9bSNB/S3nggQe0du1avf3224qIiNC0adN02223afv27ZKkqqoqpaWlKSYmRh9++KGOHTumiRMnKjg4WH/605883gsAAACA5sFrASooKEgxMTG1lpeUlOjVV1/VsmXLdOONN0qSlixZop49e2rHjh0aOHCgsrOz9cknn+j9999XdHS0+vXrp7lz5+p3v/udZs+erZCQEE+3AwAAAKAZ8FqAOnTokGJjYxUaGiqHw6HMzEx17txZ+fn5cjqdSk5ONsf26NFDnTt3Vl5engYOHKi8vDz17t1b0dHR5pjU1FRNnTpVBw4cUP/+/et8zfLycpWXl5uPS0tLJUlOp1NOp7PO59QstwcYl91zY6mv9kthD6y7z5r+L3Y/eKI2T2loH7izT8n7vdanpvcL9evu/QEAANBUeCVAJSUlaenSperevbuOHTumOXPmaOjQodq/f7+KiooUEhKiyMhIl+dER0erqKhIklRUVOQSnmrW16yrT2ZmpubMmVNreXZ2tsLCwhqseW5itZXWvGLdunVu29a86xtef7H7wZO1eUpd+8CdfUpNp9f65OTkNLj+3LlzHqoEAADAs7wSoEaPHm3+u0+fPkpKSlKXLl301ltvqUWLFo32ujNmzFBGRob5uLS0VHFxcUpJSVF4eHidz3E6ncrJydEfdgeovNrWaLVdjv2zU922rWtnb6hzuT3A0NzE6oveD56ozVMa2gfu7FPyfq/1qdkHI0eOVHBwcL3jao7uAgAA+BuvfYTv+yIjI3X11Vfr8OHDGjlypCoqKnT69GmXo1DFxcXmOVMxMTHatWuXyzZqrtJX13lVNex2u+x2e63lwcHBDb4ZlKTyapvKq5pmgLpQ7RfjQj1e7H7wZG2eUtc+cGefUtPptT4X+p1x9/4AAABoKprEfaDKysr02WefqWPHjkpISFBwcLByc3PN9QcPHlRhYaEcDockyeFwaN++fTp+/Lg5JicnR+Hh4erVq5fH6wcAAADQPHjlCNSDDz6oW265RV26dNFXX32lWbNmKTAwUHfeeaciIiI0efJkZWRkqG3btgoPD9f9998vh8OhgQMHSpJSUlLUq1cvTZgwQfPmzVNRUZEeffRRpaen13mECQAAAADcwSsB6ujRo7rzzjt18uRJdejQQUOGDNGOHTvUoUMHSdLChQsVEBCgsWPHqry8XKmpqXrhhRfM5wcGBmrNmjWaOnWqHA6HWrZsqUmTJumxxx7zRjsAAAAAmgmvBKjly5c3uD40NFRZWVnKysqqd0yXLl3cfuUzAAAAAGhIkzgHCgAAAAB8AQEKAAAAACwiQAEAAACARQQoAAAAALCIAAUAAAAAFhGgAAAAAMAiAhQAAAAAWESAAgAAAACLCFAAAAAAYBEBCgAAAAAsIkABAAAAgEUEKAAAAACwiAAFAAAAABYRoAAAAADAIgIUAAAAAFhEgAIAAAAAiwhQAAAAAGARAQoAAAAALCJAAQAAAIBFBCgAAAAAsIgABQAAAAAWEaAAAAAAwCICFAAAAABYRIACAAAAAIsIUAAAAABgEQEKAAAAACwiQAEAAACARQQoAAAAALCIAAUAAAAAFhGgAAAAAMAiAhQAAAAAWESAAgAAAACLCFAAAAAAYBEBCgAAAAAsIkABAAAAgEUEKAAAAACwiAAFAAAAABYRoAAAAADAIgIUAAAAAFjk8wEqKytLV1xxhUJDQ5WUlKRdu3Z5uyQAAAAAfsqnA9SKFSuUkZGhWbNm6eOPP1bfvn2Vmpqq48ePe7s0AAAAAH7IpwPUggULNGXKFN1zzz3q1auXFi9erLCwML322mveLg0AAACAHwrydgGXqqKiQvn5+ZoxY4a5LCAgQMnJycrLy6vzOeXl5SovLzcfl5SUSJJOnTolp9NZ53OcTqfOnTunIGeAqqptbuzAfU6ePOm2bQVVnq17ebWhc+eqL3o/eKI2T2loH7izT8n7vdanZh+cPHlSwcHB9Y47c+aMJMkwDE+VBgAA4BE+G6BOnDihqqoqRUdHuyyPjo7Wv/71rzqfk5mZqTlz5tRaHh8f3yg1ekr7+Z55nbsu4Tmeqs1T6tsH/tZnQy7m5+DMmTOKiIhotFoAAAA8zWcD1KWYMWOGMjIyzMfV1dU6deqU2rVrJ5ut7qMqpaWliouL05dffqnw8HBPldrksB/YB5L1fWAYhs6cOaPY2FgPVgcAAND4fDZAtW/fXoGBgSouLnZZXlxcrJiYmDqfY7fbZbfbXZZFRkZaer3w8PBm+6b5+9gP7APJ2j7gyBMAAPBHPnsRiZCQECUkJCg3N9dcVl1drdzcXDkcDi9WBgAAAMBf+ewRKEnKyMjQpEmTlJiYqOuvv17PPPOMzp49q3vuucfbpQEAAADwQz4doO644w59/fXXmjlzpoqKitSvXz+tX7++1oUlLofdbtesWbNqffSvuWE/sA8k9gEAAIDN4DrDAAAAAGCJz54DBQAAAACeRoACAAAAAIsIUAAAAABgEQEKAAAAACwiQF1AVlaWrrjiCoWGhiopKUm7du3ydkkek5mZqQEDBqh169aKiorSmDFjdPDgQW+X5VVPPPGEbDabpk+f7u1SPO4///mPfvGLX6hdu3Zq0aKFevfurd27d3u7LAAAAI8iQDVgxYoVysjI0KxZs/Txxx+rb9++Sk1N1fHjx71dmkds3rxZ6enp2rFjh3JycuR0OpWSkqKzZ896uzSv+Oijj/TSSy+pT58+3i7F47755hsNHjxYwcHB+sc//qFPPvlE8+fPV5s2bbxdGgAAgEdxGfMGJCUlacCAAXr++eclSdXV1YqLi9P999+vRx55xMvVed7XX3+tqKgobd68WcOGDfN2OR5VVlam6667Ti+88IIef/xx9evXT88884y3y/KYRx55RNu3b9fWrVu9XQoAAIBXcQSqHhUVFcrPz1dycrK5LCAgQMnJycrLy/NiZd5TUlIiSWrbtq2XK/G89PR0paWlufw8NCerV69WYmKifv7znysqKkr9+/fXn//8Z2+XBQAA4HEEqHqcOHFCVVVVio6OdlkeHR2toqIiL1XlPdXV1Zo+fboGDx6sa6+91tvleNTy5cv18ccfKzMz09uleM3nn3+uF198UVdddZU2bNigqVOn6n//93/1+uuve7s0AAAAjwrydgHwDenp6dq/f7+2bdvm7VI86ssvv9RvfvMb5eTkKDQ01NvleE11dbUSExP1pz/9SZLUv39/7d+/X4sXL9akSZO8XB0AAIDncASqHu3bt1dgYKCKi4tdlhcXFysmJsZLVXnHtGnTtGbNGn3wwQfq1KmTt8vxqPz8fB0/flzXXXedgoKCFBQUpM2bN2vRokUKCgpSVVWVt0v0iI4dO6pXr14uy3r27KnCwkIvVQQAAOAdBKh6hISEKCEhQbm5ueay6upq5ebmyuFweLEyzzEMQ9OmTdPKlSu1ceNGxcfHe7skjxsxYoT27dungoIC8ysxMVHjx49XQUGBAgMDvV2iRwwePLjWJez//e9/q0uXLl6qCAAAwDv4CF8DMjIyNGnSJCUmJur666/XM888o7Nnz+qee+7xdmkekZ6ermXLlundd99V69atzXO/IiIi1KJFCy9X5xmtW7eudc5Xy5Yt1a5du2Z1LtgDDzygQYMG6U9/+pNuv/127dq1Sy+//LJefvllb5cGAADgUVzG/AKef/55PfXUUyoqKlK/fv20aNEiJSUlebssj7DZbHUuX7Jkie6++27PFtOEDB8+vNldxlyS1qxZoxkzZujQoUOKj49XRkaGpkyZ4u2yAAAAPIoABQAAAAAWcQ4UAAAAAFhEgAIAAAAAiwhQAAAAAGARAQoAAAAALCJAAQAAAIBFBCgAAAAAsIgABQAAAAAWEaAAAAAAwCICFAAAAABYRIACAAAAAIsIUAAAAABgEQEKAAAAACz6/3iTn/BEFYojAAAAAElFTkSuQmCC\n"
+          },
+          "metadata": {}
+        }
+      ],
+      "source": [
+        "pd_flights.select_dtypes(include=np.number).hist(figsize=[10,10])\n",
+        "plt.show()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 58,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2021-12-15T20:25:01.270515Z",
+          "iopub.status.busy": "2021-12-15T20:25:01.269865Z",
+          "iopub.status.idle": "2021-12-15T20:25:02.205574Z",
+          "shell.execute_reply": "2021-12-15T20:25:02.205194Z"
+        },
+        "pycharm": {
+          "is_executing": false
+        },
+        "id": "VylFZ0feNRFp",
+        "outputId": "63b16fa7-8293-4460-f845-959aa93e3c7c",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 853
+        }
+      },
+      "outputs": [
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<Figure size 1000x1000 with 9 Axes>"
+            ],
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAA1AAAANECAYAAAC+XM68AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjcuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/bCgiHAAAACXBIWXMAAA9hAAAPYQGoP6dpAADRcElEQVR4nOzdeVhUdfs/8PeAzLDogKiAJCJiqSguoSK5ZIogkmlahppibmlQj/qkZrkAVqjlnsvTU0kL5FJmpqaMC664kaSimZrLUwnmAriOI/P5/eFvzteRxQPOCu/XdXnVnPOZc+77zMzN3HM2hRBCgIiIiIiIiB7JwdoBEBERERER2Qs2UERERERERDKxgSIiIiIiIpKJDRQREREREZFMbKCIiIiIiIhkYgNFREREREQkExsoIiIiIiIimdhAERERERERycQGioiIiIiISCY2UGRWDRo0wNChQ8v1nIyMDCgUCnz33XfmCcqEEhISoFAorB0GUYXw/Vu6Ll26oEuXLtLjc+fOQaFQICUlxWoxEdF9rF3yGL5PZWRkSNOGDh2KBg0aWC2myoINVCWyZMkSKBQKhIaGmm0dhg+jnH+2YsmSJSV+6Xk4FycnJzRs2BBDhgzBH3/8YflAiR5TSkqK0Xva2dkZvr6+iIyMxMKFC3H9+vXHXsfff/+NhIQEZGdnP37AFjZ06FBUr1692PQjR46gdu3aaNCgAc6dO2f5wEzoww8/xNq1a60dBlG5sHaVbejQoVAoFFCr1bh9+3ax+adOnZK23ccff2yFCKueatYOgEwnNTUVDRo0wIEDB3D69Gk0atTI5Oto2rQpvv76a6NpkydPRvXq1fHee+8VG3/y5Ek4OFi3T1+yZAlq165d6p6wt956C23btoVOp8Mvv/yCTz/9FBs2bMDRo0fh6+tb5rKnTJmCd955xwxRE1VcUlISAgICoNPpkJubi4yMDIwdOxZz587FunXr0KJFCwAVe//+/fffSExMRIMGDdCqVSszRG9Zx44dQ7du3eDm5obt27dLv8ymp6dbN7AK+vDDD/HSSy+hT58+1g6FqNxYu0pXrVo13Lp1Cz/99BP69+9vNC81NRXOzs64c+eO0fTOnTvj9u3bUCqVlgy1SmADVUmcPXsWe/fuxZo1a/D6668jNTUV06dPN/l6vL298eqrrxpNmzlzJmrXrl1sOgCoVCqTx2BqnTp1wksvvQQAeO211/DUU0/hrbfewpdffonJkyeX+JybN2/Czc0N1apVQ7Vq/BiRbYmKikKbNm2kx5MnT8a2bdvw/PPP44UXXsCJEyfg4uJS5d+/OTk56Nq1K1xcXLB9+3YEBARI8/iF4//cuXMHSqXS6j+GUeXH2lU6lUqFDh064Ntvvy3WQKWlpSE6Ohrff/+90XQHBwc4OztbMswqg9WwkkhNTUXNmjURHR2Nl156CampqQAAnU4HT09PvPbaa8WeU1hYCGdnZ7z99tvStPPnz+OFF16Am5sbvLy8MG7cOGzevLnYMbRylXQOVH5+PsaNG4cGDRpApVKhXr16GDJkCC5fvlzqcrRaLZ5//nm4u7tj7969AAC9Xo/58+ejWbNmcHZ2hre3N15//XVcu3bNaP05OTnYsWOHtHv7wfMaStK1a1cA95tS4P+OtT5+/DgGDhyImjVromPHjkbzHvbNN9+gXbt2cHV1Rc2aNdG5c+div2j//PPP6NSpE9zc3FCjRg1ER0cjJyenzNiIKqpr166YOnUqzp8/j2+++QZAye9fjUaDjh07wsPDA9WrV0fjxo3x7rvvArh/2Gvbtm0B3P+xwfCZMhwiu2vXLrz88suoX78+VCoV/Pz8MG7cuGKHnBgOpfvrr7/Qp08fVK9eHXXq1MHbb7+NoqIio7F6vR4LFixAcHAwnJ2dUadOHfTo0QOHDh0yGvfNN98gJCQELi4u8PT0RExMDP73v/+Vuj1OnDiBbt26QaVSYfv27WjYsKHR/IfPgSrNtm3bpM+xh4cHevfujRMnThiNMWzn33//Ha+++irc3d1Rp04dTJ06FUII/O9//0Pv3r2hVqvh4+ODOXPmFFuPVqvF9OnT0ahRI2nbTpw4EVqtVhqjUChw8+ZNfPnll9Jr82D9/euvvzBs2DB4e3tDpVKhWbNm+OKLL4zWYzi0ecWKFZgyZQqeeOIJuLq6orCwEDqdDomJiXjyySfh7OyMWrVqoWPHjtBoNI/cTkQVxdr1fwYOHIiff/4Z+fn50rSDBw/i1KlTGDhwYLHxJZ0DVRI536cA4NChQ4iMjETt2rXh4uKCgIAADBs2rMxlV1ZVq32vxFJTU9G3b18olUoMGDAAS5cuxcGDB9G2bVu8+OKLWLNmDf7zn/8Y/aq6du1aaLVaxMTEALi/V6Vr1664ePEi/vWvf8HHxwdpaWnYvn27yeK8ceMGOnXqhBMnTmDYsGF4+umncfnyZaxbtw5//vknateuXew5t2/fRu/evXHo0CFs2bJFKoKvv/46UlJS8Nprr+Gtt97C2bNn8cknn+Dw4cPYs2cPnJycMH/+fLz55ptGhxh6e3uXGeOZM2cAALVq1TKa/vLLL+PJJ5/Ehx9+CCFEqc9PTExEQkICnnnmGSQlJUGpVGL//v3Ytm0bIiIiAABff/01YmNjERkZiVmzZuHWrVtYunQpOnbsiMOHD/METzKLwYMH491330V6ejpGjhxZbH5OTg6ef/55tGjRAklJSVCpVDh9+jT27NkD4P4hvElJSZg2bRpGjRqFTp06AQCeeeYZAMDq1atx69YtjBkzBrVq1cKBAwewaNEi/Pnnn1i9erXRuoqKihAZGYnQ0FB8/PHH2LJlC+bMmYPAwECMGTNGGjd8+HCkpKQgKioKI0aMwL1797Br1y7s27dP+qX6gw8+wNSpU9G/f3+MGDEC//zzDxYtWoTOnTvj8OHD8PDwMFr3yZMn0bVrV1SrVg3bt29HYGBghbbnli1bEBUVhYYNGyIhIQG3b9/GokWL0KFDB/zyyy/FPsevvPIKmjZtipkzZ2LDhg14//334enpif/85z/o2rUrZs2ahdTUVLz99tto27YtOnfuDOD+l5sXXngBu3fvxqhRo9C0aVMcPXoU8+bNw++//y6d8/T1119jxIgRaNeuHUaNGgUAUm55eXlo3749FAoF4uPjUadOHfz8888YPnw4CgsLMXbsWKNYZ8yYAaVSibfffhtarRZKpRIJCQlITk6W1lFYWIhDhw7hl19+Qffu3Su0DYnkYO26r2/fvhg9ejTWrFkjNS5paWlo0qQJnn766QpvXznfpy5duoSIiAjUqVMH77zzDjw8PHDu3DmsWbOmwuu1a4Ls3qFDhwQAodFohBBC6PV6Ua9ePfGvf/1LCCHE5s2bBQDx008/GT2vZ8+eomHDhtLjOXPmCABi7dq10rTbt2+LJk2aCABi+/btJa6/WbNm4tlnny1xnr+/v4iNjZUeT5s2TQAQa9asKTZWr9cLIYTYvn27ACBWr14trl+/Lp599llRu3ZtcfjwYWnsrl27BACRmppqtIxNmzYVm15afIb1fPHFF+Kff/4Rf//9t9iwYYNo0KCBUCgU4uDBg0IIIaZPny4AiAEDBhRbhmGewalTp4SDg4N48cUXRVFRUYn5Xb9+XXh4eIiRI0cazc/NzRXu7u7FphPJtXz5cgFAeu+WxN3dXbRu3VoIUfz9O2/ePAFA/PPPP6U+/+DBgwKAWL58ebF5t27dKjYtOTlZKBQKcf78eWlabGysACCSkpKMxrZu3VqEhIRIj7dt2yYAiLfeeqvYcg2fp3PnzglHR0fxwQcfGM0/evSoqFatmtH02NhY4eTkJOrWrSt8fX3F77//Xmqezz77rFHdOHv2bLG8W7VqJby8vMSVK1ekab/++qtwcHAQQ4YMkaYZtvOoUaOkaffu3RP16tUTCoVCzJw5U5p+7do14eLiYlQ3v/76a+Hg4CB27dplFOOyZcsEALFnzx5pmpubm9FzDYYPHy7q1q0rLl++bDQ9JiZGuLu7S6+doS42bNiw2OvZsmVLER0dXcLWIno8rF3/p7Ta5ebmJoQQ4qWXXhLdunUTQghRVFQkfHx8RGJiolSjPvroI+l5hs/zg9/fYmNjhb+/v/RY7vepH3744ZGvUVXCQ/gqgdTUVHh7e+O5554DcP8wjldeeQUrVqxAUVERunbtitq1a2PlypXSc65duwaNRoNXXnlFmrZp0yY88cQTeOGFF6Rpzs7OJf7aU1Hff/89WrZsiRdffLHYvId3xxcUFCAiIgK//fYbMjIyjE76XL16Ndzd3dG9e3dcvnxZ+hcSEoLq1auXa6/ZsGHDUKdOHfj6+iI6Olo6BObB47ABYPTo0Y9c1tq1a6HX6zFt2rRi5wsY8tNoNMjPz8eAAQOMYnd0dERoaKhJ9/gRPax69eqlXtHK8Gvnjz/+CL1eX+5lu7i4SP9/8+ZNXL58Gc888wyEEDh8+HCx8Q9/pjp16mR0Bczvv/8eCoWixPM5DZ+nNWvWQK/Xo3///kafJx8fHzz55JPFPk9FRUW4fPkyPD09S9zjLdfFixeRnZ2NoUOHwtPTU5reokULdO/eHRs3biz2nBEjRkj/7+joiDZt2kAIgeHDh0vTPTw80LhxY6PtsHr1ajRt2hRNmjQxytFwuPGjaoYQAt9//z169eoFIYTRMiIjI1FQUIBffvnF6DmxsbFGr6chtpycHJw6dUrGFiIyrapeuwwGDhyIjIwM5ObmYtu2bcjNzS3x8D255H6fMmzj9evXQ6fTVXh9lQUP4bNzRUVFWLFiBZ577jnpnB0ACA0NxZw5c7B161ZERESgX79+SEtLg1arhUqlwpo1a6DT6YwaqPPnzyMwMLBYI2PKq/mdOXMG/fr1kzV27NixuHPnDg4fPoxmzZoZzTt16hQKCgrg5eVV4nMvXbokO6Zp06ahU6dOcHR0RO3atdG0adMST0598ATz0pw5cwYODg4ICgoqdYzhy4fhy8/D1Gq1zMiJyu/GjRulfm5eeeUVfPbZZxgxYgTeeecddOvWDX379sVLL70k6wICFy5cwLRp07Bu3bpix84XFBQYPTacE/CgmjVrGj3vzJkz8PX1NWpQHnbq1CkIIfDkk0+WON/JycnosYuLCz777DMMGjQI0dHR0Gg0cHNze2RuDzt//jwAoHHjxsXmNW3aFJs3b5YuNmNQv359o3Hu7u5wdnYu1si5u7vjypUr0uNTp07hxIkTxbaXwaPq3T///IP8/Hx8+umn+PTTT2Uto6R6l5SUhN69e+Opp55C8+bN0aNHDwwePFi6MhqROVX12mXQs2dP1KhRAytXrkR2djbatm2LRo0aVfgWDHK/Tz377LPo168fEhMTMW/ePHTp0gV9+vTBwIED7eKCYabGBsrObdu2DRcvXsSKFSuwYsWKYvNTU1MRERGBmJgY/Oc//8HPP/+MPn36YNWqVWjSpAlatmxphajl6d27N1asWIGZM2fiq6++MiqCer0eXl5e0sUyHlbaF42SBAcHIzw8/JHjHv41tqIMv459/fXX8PHxKTa/ql1ZiCznzz//REFBQak/iri4uGDnzp3Yvn07NmzYgE2bNmHlypXo2rUr0tPT4ejoWOqyi4qK0L17d1y9ehWTJk1CkyZN4Obmhr/++gtDhw4t9qtwWcsqD71eD4VCgZ9//rnEZZZ036eYmBhcu3YNb7zxBvr27YuffvrJIlfdKym+0raDeOA8S71ej+DgYMydO7fEsX5+fmWu17DtX331VcTGxpY45uEmqKR617lzZ5w5cwY//vgj0tPT8dlnn2HevHlYtmyZ0d41IlNj7fo/KpUKffv2xZdffok//vgDCQkJjx2HnO9TCoUC3333Hfbt24effvoJmzdvxrBhwzBnzhzs27ev1HgrK35Ts3Opqanw8vLC4sWLi81bs2YNfvjhByxbtgydO3dG3bp1sXLlSnTs2BHbtm0rdt8mf39/HD9+HEIIo71Qp0+fNlm8gYGBOHbsmKyxffr0QUREBIYOHYoaNWpg6dKlRsvZsmULOnTo8MjGxpI39Q0MDIRer8fx48dLvc+E4aRuLy8vWY0bkakY7uEWGRlZ6hgHBwd069YN3bp1w9y5c/Hhhx/ivffew/bt2xEeHl7q5+no0aP4/fff8eWXX2LIkCHS9Me5QltgYCA2b96Mq1evlvpLbmBgIIQQCAgIwFNPPSV72WPGjMHVq1cxZcoUvPrqq1ixYkW5LtPt7+8P4P4FKR7222+/oXbt2hXas1WSwMBA/Prrr+jWrdsj61lJ8+vUqYMaNWqgqKjosWuO4aqur732Gm7cuIHOnTsjISGBDRSZFWuXsYEDB+KLL76Ag4ODdCGwx4lV7vcpAGjfvj3at2+PDz74AGlpaRg0aBBWrFhR5WoAz4GyY7dv38aaNWvw/PPP46WXXir2Lz4+HtevX8e6devg4OCAl156CT/99BO+/vpr3Lt3z+jwPeB+Yfrrr7+wbt06adqdO3fw3//+12Qx9+vXD7/++it++OGHYvNECVe2GzJkCBYuXIhly5Zh0qRJ0vT+/fujqKgIM2bMKPace/fuGV3i083NzeixOfXp0wcODg5ISkoq9quVIb/IyEio1Wp8+OGHJR5H/M8//1gkVqpatm3bhhkzZiAgIACDBg0qcczVq1eLTTP8EGC4XLahKXj4M2X4BfXBz7EQAgsWLKhwzP369YMQAomJicXmGdbTt29fODo6IjExsVgNEUIYHQr3sPfeew/jxo3D6tWr8frrr5crtrp166JVq1b48ssvjbbFsWPHkJ6ejp49e5ZreWXp378//vrrrxJr8e3bt3Hz5k3pcUn1ztHREf369cP3339f4g9YcmvOw9uyevXqaNSokdGl1IlMjbWruOeeew4zZszAJ598UuKRLOUh9/vUtWvXisX58DauSrgHyo6tW7cO169fN7row4Pat2+POnXqIDU1Fa+88gpeeeUVLFq0CNOnT0dwcDCaNm1qNP7111/HJ598ggEDBuBf//oX6tatK93dGjDNnpwJEybgu+++w8svv4xhw4YhJCQEV69exbp167Bs2bISDymMj49HYWEh3nvvPbi7u+Pdd9/Fs88+i9dffx3JycnIzs5GREQEnJyccOrUKaxevRoLFiyQbo4bEhKCpUuX4v3330ejRo3g5eVV6vlHj6tRo0Z47733MGPGDHTq1Al9+/aFSqXCwYMH4evri+TkZKjVaixduhSDBw/G008/jZiYGNSpUwcXLlzAhg0b0KFDB3zyySdmiY+qhp9//hm//fYb7t27h7y8PGzbtg0ajQb+/v5Yt25dqTdWTEpKws6dOxEdHQ1/f39cunQJS5YsQb169aR7nwUGBsLDwwPLli1DjRo14ObmhtDQUDRp0gSBgYF4++238ddff0GtVuP7778vdj5BeTz33HMYPHgwFi5ciFOnTqFHjx7Q6/XYtWsXnnvuOcTHxyMwMBDvv/8+Jk+ejHPnzqFPnz6oUaMGzp49ix9++AGjRo0yutfdw+bMmYNr167hs88+g6enJ2bNmiU7vo8++ghRUVEICwvD8OHDpcuYu7u7P/ZhNQ8aPHgwVq1ahdGjR2P79u3o0KEDioqK8Ntvv2HVqlXYvHmzdNGbkJAQbNmyBXPnzoWvry8CAgIQGhqKmTNnYvv27QgNDcXIkSMRFBSEq1ev4pdffsGWLVtK/AL6sKCgIHTp0gUhISHw9PTEoUOH8N133yE+Pt5kuVLVxtolr3Y5ODhgypQpFY7vQXK/T3355ZdYsmQJXnzxRQQGBuL69ev473//C7VabdIfjOyGpS73R6bXq1cv4ezsLG7evFnqmKFDhwonJydx+fJlodfrhZ+fnwAg3n///RLH//HHHyI6Olq4uLiIOnXqiH//+9/i+++/FwDEvn37SnxOeS5jLoQQV65cEfHx8eKJJ54QSqVS1KtXT8TGxkqX133wMuYPmjhxogAgPvnkE2nap59+KkJCQoSLi4uoUaOGCA4OFhMnThR///23NCY3N1dER0eLGjVqCABSrKWt52GGy6WWdHnUhy+lavDFF1+I1q1bC5VKJWrWrCmeffZZ6TLzBtu3bxeRkZHC3d1dODs7i8DAQDF06FBx6NChMuMhKo3hUsCGf0qlUvj4+Iju3buLBQsWiMLCQqPxD79/t27dKnr37i18fX2FUqkUvr6+YsCAAcUu9/3jjz+KoKAgUa1aNaPLAh8/flyEh4eL6tWri9q1a4uRI0eKX3/9tdilgx+8JG9Z8Qhx/3LfH330kWjSpIlQKpWiTp06IioqSmRlZRmN+/7770XHjh2Fm5ubcHNzE02aNBFxcXHi5MmTj1zvvXv3RJ8+fQQAkZycLISQdxlzIYTYsmWL6NChg3BxcRFqtVr06tVLHD9+vMS8Hq4hpcXz7LPPimbNmhlNu3v3rpg1a5Zo1qyZVFdCQkJEYmKiKCgokMb99ttvonPnzsLFxUUAMKq/eXl5Ii4uTvj5+QknJyfh4+MjunXrJj799FNpTFl18f333xft2rUTHh4ewsXFRTRp0kR88MEH4u7du8XGEpUHa1fFateDKnoZc4NHfZ/65ZdfxIABA0T9+vWFSqUSXl5e4vnnn6+y31kUQpRxR1AiAPPnz8e4cePw559/4oknnrB2OEREREREVsMGiozcvn3b6CTCO3fuoHXr1igqKsLvv/9uxciIiIiIiKyP50CRkb59+6J+/fpo1aoVCgoK8M033+C3334r9fKWRERERERVCRsoMhIZGYnPPvsMqampKCoqQlBQEFasWFHsin1ERERERFURD+EjIiIiIiKSifeBIiIiIiIikokNFBERERERkUxV+hwovV6Pv//+GzVq1DDJTWKJ6D4hBK5fvw5fX184OFS932lYW4jMh/WF9YXIXOTWlyrdQP3999/w8/OzdhhEldb//vc/1KtXz9phWBxrC5H5sb4Qkbk8qr5U6QaqRo0aAO5vJLVabeVoAJ1Oh/T0dERERMDJycna4chibzHbW7yA/cWs0+mwdu1ajBgxQvqMVTVya4u9vbYlqQw5AJUjj6qSQ2FhIfz8/FhfqkB9sRZuu8djz9tPbn2p0g2UYde3Wq22mQbK1dUVarXabt5w9hazvcUL2F/MhngBVNnDS+TWFnt7bUtSGXIAKkceVS0H1pfKX1+shdvu8VSG7feo+lL1Dh4mIru1dOlStGjRQvriEBYWhp9//lmaf+fOHcTFxaFWrVqoXr06+vXrh7y8PKNlXLhwAdHR0XB1dYWXlxcmTJiAe/fuGY3JyMjA008/DZVKhUaNGiElJcUS6RGRFbG+EJFcbKCIyG7Uq1cPM2fORFZWFg4dOoSuXbuid+/eyMnJAQCMGzcOP/30E1avXo0dO3bg77//Rt++faXnFxUVITo6Gnfv3sXevXvx5ZdfIiUlBdOmTZPGnD17FtHR0XjuueeQnZ2NsWPHYsSIEdi8ebPF8yUiy2F9ISK5qvQhfERkX3r16mX0+IMPPsDSpUuxb98+1KtXD59//jnS0tLQtWtXAMDy5cvRtGlT7Nu3D+3bt0d6ejqOHz+OLVu2wNvbG61atcKMGTMwadIkJCQkQKlUYtmyZQgICMCcOXMAAE2bNsXu3bsxb948REZGWjxnIrIM1hcikosNFBHZpaKiIqxevRo3b95EWFgYsrKyoNPpEB4eLo1p0qQJ6tevj8zMTLRv3x6ZmZkIDg6Gt7e3NCYyMhJjxoxBTk4OWrdujczMTKNlGMaMHTu21Fi0Wi20Wq30uLCwEMD948B1Ol2pzzPMK2uMrasMOQCVI4+qkoMl8mN9qdq47R6PPW8/uTGzgSIiu3L06FGEhYXhzp07qF69On744QcEBQUhOzsbSqUSHh4eRuO9vb2Rm5sLAMjNzTX6cmOYb5hX1pjCwkLcvn0bLi4uxWJKTk5GYmJisenp6enSBTXKotFoHjnG1lWGHIDKkUdlz+HWrVtmWy/rCz2I2+7x2OP2k1tf2EARkV1p3LgxsrOzUVBQgO+++w6xsbHYsWOHVWOaPHkyxo8fLz02XAY1IiLikVfJ0mg06N69u91eqagy5ABUjjyqSg6GPTDmwPpCALfd47Ln7Se3vrCBIiK7olQq0ahRIwBASEgIDh48iAULFuCVV17B3bt3kZ+fb/QrcV5eHnx8fAAAPj4+OHDggNHyDFfRenDMw1fWysvLg1qtLvHXYQBQqVRQqVTFpjs5Ocn64yF3nC2rDDkAlSOPyp6DOXNjfaEHcds9HnvcfnLjZQNFVVaDdzaYbFnnZkabbFlUPnq9HlqtFiEhIXBycsLWrVvRr18/AMDJkydx4cIFhIWFAQDCwsLwwQcf4NKlS/Dy8gJw/xADtVqNoKAgaczGjRuN1qHRaKRlmEPzhM3QFpnmnjZ8LxKZDuuLMdYXovvYQBGR3Zg8eTKioqJQv359XL9+HWlpacjIyMDmzZvh7u6O4cOHY/z48fD09IRarcabb76JsLAwtG/fHgAQERGBoKAgDB48GLNnz0Zubi6mTJmCuLg46Rfe0aNH45NPPsHEiRMxbNgwbNu2DatWrcKGDaZruInI9rC+EJFcbKCIyG5cunQJQ4YMwcWLF+Hu7o4WLVpg8+bN6N69OwBg3rx5cHBwQL9+/aDVahEZGYklS5ZIz3d0dMT69esxZswYhIWFwc3NDbGxsUhKSpLGBAQEYMOGDRg3bhwWLFiAevXq4bPPPuMlhm2QKfcin5oRYbJlkX1ifSGD5gmbMbud6fbecc9d5cMGiojsxueff17mfGdnZyxevBiLFy8udYy/v3+xQ2ge1qVLFxw+fLhCMRKRfWJ9ISK5HKwdABERERERkb3gHiiyG6Y4XEflKKTd8oBpTqolIiIioqqDe6CIiIiIiIhkYgNFREREREQkExsoIiIiIiIimdhAERERERERycQGioiIiIiISCY2UERERERERDKxgSIiIiIiIpKJDRQREREREZFMbKCIiIiIiIhkqmbtAIgqgwbvbDDp8s7NjDbp8oiIiIjINLgHioiIiIiISCY2UERERERERDLxED4yK1Mf2kZEREREZE3cA0VERERERCQTGygiIiIiIiKZeAgfERFZBA/pJSJzMWV9UTmabFFUSXEPFBERERERkUxsoIiIiIiIiGRiA0VERERERCQTGygiIiIiIiKZ2EARERERERHJxAaKiOxGcnIy2rZtixo1asDLywt9+vTByZMnjcZ06dIFCoXC6N/o0aONxly4cAHR0dFwdXWFl5cXJkyYgHv37hmNycjIwNNPPw2VSoVGjRohJSXF3OkRkRWxvhCRXGygiMhu7NixA3Fxcdi3bx80Gg10Oh0iIiJw8+ZNo3EjR47ExYsXpX+zZ8+W5hUVFSE6Ohp3797F3r178eWXXyIlJQXTpk2Txpw9exbR0dF47rnnkJ2djbFjx2LEiBHYvHmzxXIlIstifSEiuXgfKCKyG5s2bTJ6nJKSAi8vL2RlZaFz587SdFdXV/j4+JS4jPT0dBw/fhxbtmyBt7c3WrVqhRkzZmDSpElISEiAUqnEsmXLEBAQgDlz5gAAmjZtit27d2PevHmIjIw0X4JEZDWsL0Qkl8n3QO3cuRO9evWCr68vFAoF1q5dazR/6NChxXZ/9+jRw2jM1atXMWjQIKjVanh4eGD48OG4ceOG0ZgjR46gU6dOcHZ2hp+fn9EvQERUNRQUFAAAPD09jaanpqaidu3aaN68OSZPnoxbt25J8zIzMxEcHAxvb29pWmRkJAoLC5GTkyONCQ8PN1pmZGQkMjMzzZUKEdkY1hciKo3J90DdvHkTLVu2xLBhw9C3b98Sx/To0QPLly+XHqtUKqP5gwYNwsWLF6Vd6K+99hpGjRqFtLQ0AEBhYSEiIiIQHh6OZcuW4ejRoxg2bBg8PDwwatQoU6dUpZT3Tt4qR4HZ7YDmCZuhLVKYKSqi4vR6PcaOHYsOHTqgefPm0vSBAwfC398fvr6+OHLkCCZNmoSTJ09izZo1AIDc3FyjLzcApMe5ublljiksLMTt27fh4uJiNE+r1UKr1UqPCwsLAQA6nQ46na7UHAzzVA6iXLmXpaz1mYNhfXLWq3I0XZ6mVp48bFVVycES+bG+lL1MW2TK+mLYZqbadra83czBnmuR3JhN3kBFRUUhKiqqzDEqlarU3d8nTpzApk2bcPDgQbRp0wYAsGjRIvTs2RMff/wxfH19kZqairt37+KLL76AUqlEs2bNkJ2djblz57KBIqoi4uLicOzYMezevdto+oM1IDg4GHXr1kW3bt1w5swZBAYGmiWW5ORkJCYmFpuenp4OV1fXRz5/Rhu9yWLZuHGjyZZVHhqN5pFjZrezQCAVZIhfTh62rrLn8OAeH3NhfSmZteqLHOaoL6badra83czJHmuR3PpilXOgMjIy4OXlhZo1a6Jr1654//33UatWLQD3d217eHhIzRMAhIeHw8HBAfv378eLL76IzMxMdO7cGUqlUhoTGRmJWbNm4dq1a6hZs6bFcyIiy4mPj8f69euxc+dO1KtXr8yxoaGhAIDTp08jMDAQPj4+OHDggNGYvLw8AJB+2PHx8ZGmPThGrVYX+3UYACZPnozx48dLjwsLC+Hn54eIiAio1epSY9PpdNBoNJh6yAFavWn24B5LsOw5FIYcunfvDicnpzLHNk+w3ZPkD7/XVXYetqo8r4WtkpODYQ+MubC+lM7S9aU8TFlfVA4CM9roTbbtbHm7mYM91yK59cXiDVSPHj3Qt29fBAQE4MyZM3j33XcRFRWFzMxMODo6Ijc3F15eXsZBVqsGT09Po93fAQEBRmMe3EVeWgNV0d3glmILuzzLuwvc1Lu5zc1e4n3wPWAL74vyMGecQgi8+eab+OGHH5CRkVGsDpQkOzsbAFC3bl0AQFhYGD744ANcunRJqjUajQZqtRpBQUHSmId/MdRoNAgLCytxHSqVqtihyADg5OQk64+HVq8w2SGw1vpjJSdXWz7M1xC73NfMllX2HMyVG+vLo9ny+8oc9cVU286Wt5s52WMtkhuvxRuomJgY6f+Dg4PRokULBAYGIiMjA926dTPruh93N7ilWHOXZ0V3gZvyEAFLsPV4S9rdb4+7wk0tLi4OaWlp+PHHH1GjRg3pRxV3d3e4uLjgzJkzSEtLQ8+ePVGrVi0cOXIE48aNQ+fOndGiRQsAQEREBIKCgjB48GDMnj0bubm5mDJlCuLi4qQvKaNHj8Ynn3yCiRMnYtiwYdi2bRtWrVqFDRvKd44gEdkP1hciksvqlzFv2LAhateujdOnT6Nbt27w8fHBpUuXjMbcu3cPV69efeTub8O80lR0N7il2MIuz/LuAjf1bm5zs5d4H9zdbwvvi/LQ6XT48ccfzbLspUuXArh/M8sHLV++HEOHDoVSqcSWLVswf/583Lx5E35+fujXrx+mTJkijXV0dMT69esxZswYhIWFwc3NDbGxsUhKSpLGBAQEYMOGDRg3bhwWLFiAevXq4bPPPuMlhokqMdYXIpLL6g3Un3/+iStXrhjt/s7Pz0dWVhZCQkIAANu2bYNer5eONQ4LC8N7770HnU4nfaHUaDRo3Lhxmec/Pe5ucEuxZjwV3VVtykMELMHW4y3p9be196k1CFH2oZd+fn7YsWPHI5fj7+//yJN6u3TpgsOHD5crPiKyX6wvRCSXye8DdePGDWRnZ0vHBZ89exbZ2dm4cOECbty4gQkTJmDfvn04d+4ctm7dit69e6NRo0bSLy9NmzZFjx49MHLkSBw4cAB79uxBfHw8YmJi4OvrC+D+ZUSVSiWGDx+OnJwcrFy5EgsWLDDau0RERERERGRqJm+gDh06hNatW6N169YAgPHjx6N169aYNm0aHB0dceTIEbzwwgt46qmnMHz4cISEhGDXrl1Ge4ZSU1PRpEkTdOvWDT179kTHjh3x6aefSvPd3d2Rnp6Os2fPIiQkBP/+978xbdo0XsKciIiIiIjMyuSH8HXp0qXM3eCbNz/6HBtPT0/pprmladGiBXbt2lXu+IiIiIiIiCrK5HugiIiIiIiIKis2UERERERERDJZ/Sp89PgavMN7RxARERERWQL3QBEREREREcnEBoqIiIiIiEgmNlBEREREREQysYEiIiIiIiKSiQ0UERERERGRTGygiIiIiIiIZGIDRUREREREJBMbKCIiIiIiIpnYQBEREREREcnEBoqIiIiIiEgmNlBEREREREQysYEiIiIiIiKSiQ0UERERERGRTGygiIiIiIiIZGIDRUREREREJBMbKCIiIiIiIpnYQBEREREREcnEBoqIiIiIiEgmNlBEZDeSk5PRtm1b1KhRA15eXujTpw9OnjxpNObOnTuIi4tDrVq1UL16dfTr1w95eXlGYy5cuIDo6Gi4urrCy8sLEyZMwL1794zGZGRk4Omnn4ZKpUKjRo2QkpJi7vSIyIpYX4hIrmrWDqAqavDOhhKnqxwFZrcDmidshrZIYeGoiGzfjh07EBcXh7Zt2+LevXt49913ERERgePHj8PNzQ0AMG7cOGzYsAGrV6+Gu7s74uPj0bdvX+zZswcAUFRUhOjoaPj4+GDv3r24ePEihgwZAicnJ3z44YcAgLNnzyI6OhqjR49Gamoqtm7dihEjRqBu3bqIjIy0Wv5EZD6sL0QkFxsoIrIbmzZtMnqckpICLy8vZGVloXPnzigoKMDnn3+OtLQ0dO3aFQCwfPlyNG3aFPv27UP79u2Rnp6O48ePY8uWLfD29karVq0wY8YMTJo0CQkJCVAqlVi2bBkCAgIwZ84cAEDTpk2xe/duzJs3j19wiCop1hcikosNFBHZrYKCAgCAp6cnACArKws6nQ7h4eHSmCZNmqB+/frIzMxE+/btkZmZieDgYHh7e0tjIiMjMWbMGOTk5KB169bIzMw0WoZhzNixY0uMQ6vVQqvVSo8LCwsBADqdDjqdrtT4DfNUDqIcWZetrPWZg2F9ctarcjRdnqZWnjxsVVXJwVL5sb6UvkxbZMr6Ythmptp2trzdzMGea5HcmNlAEZFd0uv1GDt2LDp06IDmzZsDAHJzc6FUKuHh4WE01tvbG7m5udKYB7/cGOYb5pU1prCwELdv34aLi4vRvOTkZCQmJhaLMT09Ha6uro/MZUYb/SPHyLVx40aTLas8NBrNI8fMbmeBQCrIEL+cPGxdZc/h1q1bZl8/60vJrFVf5DBHfTHVtrPl7WZO9liL5NYXNlBEZJfi4uJw7Ngx7N6929qhYPLkyRg/frz0uLCwEH5+foiIiIBarS71eTqdDhqNBlMPOUCrN815j8cSLHsIkCGH7t27w8nJqcyxzRM2Wyiq8jv8XlfZediq8rwWtkpODoY9MObE+lIyS9eX8jBlfVE5CMxoozfZtrPl7WYO9lyL5NYXNlBEZHfi4+Oxfv167Ny5E/Xq1ZOm+/j44O7du8jPzzf6lTgvLw8+Pj7SmAMHDhgtz3AVrQfHPHxlrby8PKjV6mK/DgOASqWCSqUqNt3JyUnWHw+tXmGyC8dY64+VnFxt+eI4htjlvma2rLLnYO7cWF9KZ8vvK3PUF1NtO1vebuZkj7VIbry8jDkR2Q0hBOLj4/HDDz9g27ZtCAgIMJofEhICJycnbN26VZp28uRJXLhwAWFhYQCAsLAwHD16FJcuXZLGaDQaqNVqBAUFSWMeXIZhjGEZRFT5sL4QkVzcA0VEdiMuLg5paWn48ccfUaNGDemcAnd3d7i4uMDd3R3Dhw/H+PHj4enpCbVajTfffBNhYWFo3749ACAiIgJBQUEYPHgwZs+ejdzcXEyZMgVxcXHSr7yjR4/GJ598gokTJ2LYsGHYtm0bVq1ahQ0bSr4FARHZP9YXIpKLe6CIyG4sXboUBQUF6NKlC+rWrSv9W7lypTRm3rx5eP7559GvXz907twZPj4+WLNmjTTf0dER69evh6OjI8LCwvDqq69iyJAhSEpKksYEBARgw4YN0Gg0aNmyJebMmYPPPvuMlxgmqsRYX4hILu6BIiK7IcSjLynr7OyMxYsXY/HixaWO8ff3f+RVkbp06YLDhw+XO0Yisk+sL0QkF/dAERERERERycQGioiIiIiISCY2UERERERERDKxgSIiIiIiIpKJDRQREREREZFMbKCIiIiIiIhkYgNFREREREQkExsoIiIiIiIimdhAERERERERycQGioiIiIiISCY2UERERERERDKxgSIiIiIiIpKJDRQREREREZFMbKCIiIiIiIhkMnkDtXPnTvTq1Qu+vr5QKBRYu3at0XwhBKZNm4a6devCxcUF4eHhOHXqlNGYq1evYtCgQVCr1fDw8MDw4cNx48YNozFHjhxBp06d4OzsDD8/P8yePdvUqRARERERERkxeQN18+ZNtGzZEosXLy5x/uzZs7Fw4UIsW7YM+/fvh5ubGyIjI3Hnzh1pzKBBg5CTkwONRoP169dj586dGDVqlDS/sLAQERER8Pf3R1ZWFj766CMkJCTg008/NXU6REREREREkmqmXmBUVBSioqJKnCeEwPz58zFlyhT07t0bAPDVV1/B29sba9euRUxMDE6cOIFNmzbh4MGDaNOmDQBg0aJF6NmzJz7++GP4+voiNTUVd+/exRdffAGlUolmzZohOzsbc+fONWq0iIiIiIiITMnkDVRZzp49i9zcXISHh0vT3N3dERoaiszMTMTExCAzMxMeHh5S8wQA4eHhcHBwwP79+/Hiiy8iMzMTnTt3hlKplMZERkZi1qxZuHbtGmrWrFni+rVaLbRarfS4sLAQAKDT6aDT6UydbqlUjqLk6Q7C6L/2wN5itpd4H3w/Gv7fku/Rx2EvcRIRERFVhEUbqNzcXACAt7e30XRvb29pXm5uLry8vIzmV6tWDZ6enkZjAgICii3DMK+0Bio5ORmJiYnFpqenp8PV1bUCGVXM7HZlz5/RRm+ZQEzI3mK29Xg3btxYbJpGo7FCJERERET0IIs2UNY2efJkjB8/XnpcWFgIPz8/REREQK1WWyyO5gmbS5yuchCY0UaPqYccoNUrLBbP47C3mO0l3mMJkdL/63Q6aDQadO/eHU5OTlaMSh6dTocff/zR2mEQERERmYVFGygfHx8AQF5eHurWrStNz8vLQ6tWraQxly5dMnrevXv3cPXqVen5Pj4+yMvLMxpjeGwYUxKVSgWVSlVsupOTk0W/mGqLyv7irtUrHjnG1thbzLYeb0nvR0u/T4mIiIioOIveByogIAA+Pj7YunWrNK2wsBD79+9HWFgYACAsLAz5+fnIysqSxmzbtg16vR6hoaHSmJ07dxqda6HRaNC4ceNSD98jIiIiIiJ6XCZvoG7cuIHs7GxkZ2cDuH/hiOzsbFy4cAEKhQJjx47F+++/j3Xr1uHo0aMYMmQIfH190adPHwBA06ZN0aNHD4wcORIHDhzAnj17EB8fj5iYGPj6+gIABg4cCKVSieHDhyMnJwcrV67EggULjA7PIyIiIiIiMjWTN1CHDh1C69at0bp1awDA+PHj0bp1a0ybNg0AMHHiRLz55psYNWoU2rZtixs3bmDTpk1wdnaWlpGamoomTZqgW7du6NmzJzp27Gh0jyd3d3ekp6fj7NmzCAkJwb///W9MmzaNlzAnquQedaPuoUOHQqFQGP3r0aOH0RjeqJuISsL6QkRymfwcqC5dukCI0i8RrVAokJSUhKSkpFLHeHp6Ii0trcz1tGjRArt27apwnERkfww36h42bBj69u1b4pgePXpg+fLl0uOHz3scNGgQLl68CI1GA51Oh9deew2jRo2Sao7hRt3h4eFYtmwZjh49imHDhsHDw4M/0hBVYqwvRCRXlboKHxHZt7Ju1G2gUqlKvZgMb9RNRKVhfSEiuSx6EQkiInPLyMiAl5cXGjdujDFjxuDKlSvSvEfdqNswpqQbdZ88eRLXrl2zXCJEZHNYX4gI4B4oIqpEevTogb59+yIgIABnzpzBu+++i6ioKGRmZsLR0dFsN+rWarXQarXS48LCQgD374n14NVCH2aYp3Io/bDn8iprfeZgWJ+c9aocTZenqZUnD1tVVXKwVn6sL7b93jJlfTFsM1NtO1vebuZgz7VIbsxsoIio0oiJiZH+Pzg4GC1atEBgYCAyMjLQrVs3s603OTkZiYmJxaanp6fD1dX1kc+f0UZvslg2btxosmWVh0ajeeSY2e0sEEgFGeKXk4etq+w53Lp1y4KR/B/WF+vVFznMUV9Mte1sebuZkz3WIrn1hQ0UEVVaDRs2RO3atXH69Gl069bNbDfqnjx5stFtFAoLC+Hn54eIiAio1epS49PpdNBoNJh6yAFavWlu7HwsIdIky5HLkEP37t0feaPn5gmbLRRV+R1+r6vsPGxVeV4LWyUnB8MeGGtjfbEtpqwvKgeBGW30Jtt2trzdzMGea5Hc+sIGiogqrT///BNXrlxB3bp1ARjfqDskJARAyTfqfu+996DT6aTC/6gbdatUqmJX4wIAJycnWX88tHoFtEWm+YJjrT9WcnI1VY7mYIhd7mtmyyp7DraSG+uLbTFHfTHVtrPl7WZO9liL5MbLi0gQkd0o60bdN27cwIQJE7Bv3z6cO3cOW7duRe/evdGoUSNERt7/9Y836iai0rC+EJFcbKCIyG6UdaNuR0dHHDlyBC+88AKeeuopDB8+HCEhIdi1a5fRr7e8UTcRlYT1hYjk4iF8RGQ3HnWj7s2bH30MPG/UTUQlYX0hIrm4B4qIiIiIiEgmNlBEREREREQysYEiIiIiIiKSiQ0UERERERGRTLyIhAwN3tlg7RCIiIiIiMgGcA8UERERERGRTNwDRUREVV7zhM2Y3e7+f7VFisde3rmZ0SaIiogqA1MfycT6Yn3cA0VERERERCQTGygiIiIiIiKZ2EARERERERHJxAaKiIiIiIhIJjZQREREREREMrGBIiIiIiIikokNFBERERERkUxsoIiIiIiIiGRiA0VERERERCRTNWsHQETFPXjXcpWjwOx2QPOEzdAWKSq0PN61nIiIiMg0uAeKiIiIiIhIJjZQREREREREMrGBIiIiIiIikokNFBERERERkUxsoIiIiIiIiGRiA0VERERERCQTGygiIiIiIiKZ2EARkd3YuXMnevXqBV9fXygUCqxdu9ZovhAC06ZNQ926deHi4oLw8HCcOnXKaMzVq1cxaNAgqNVqeHh4YPjw4bhx44bRmCNHjqBTp05wdnaGn58fZs+ebe7UiMjKWF+ISC42UERkN27evImWLVti8eLFJc6fPXs2Fi5ciGXLlmH//v1wc3NDZGQk7ty5I40ZNGgQcnJyoNFosH79euzcuROjRo2S5hcWFiIiIgL+/v7IysrCRx99hISEBHz66admz4+IrIf1hYjkqmbtAIiI5IqKikJUVFSJ84QQmD9/PqZMmYLevXsDAL766it4e3tj7dq1iImJwYkTJ7Bp0yYcPHgQbdq0AQAsWrQIPXv2xMcffwxfX1+kpqbi7t27+OKLL6BUKtGsWTNkZ2dj7ty5Rl+EiKhyYX0hIrnYQBFRpXD27Fnk5uYiPDxcmubu7o7Q0FBkZmYiJiYGmZmZ8PDwkL7cAEB4eDgcHBywf/9+vPjii8jMzETnzp2hVCqlMZGRkZg1axauXbuGmjVrFlu3VquFVquVHhcWFgIAdDoddDpdqTEb5qkcRMUTL2WZlmJYn5z1qhxNl6epGV4DU70Wln4dHlynNdZtKnJysEZ+rC/Gy7RFpqwvpq4HpmbLrwNg37VIbsxsoIioUsjNzQUAeHt7G0339vaW5uXm5sLLy8tofrVq1eDp6Wk0JiAgoNgyDPNK+oKTnJyMxMTEYtPT09Ph6ur6yNhntNE/coxcGzduNNmyykOj0TxyzOx2FgjkMZnqtbDW6wDIey1sXVk53Lp1y4KR3Mf6cp8139ePYo76YsptZ0q2/Do8yB5rkdz6wgaKiOgxTZ48GePHj5ceFxYWws/PDxEREVCr1aU+T6fTQaPRYOohB2j1CpPEciwh0iTLkcuQQ/fu3eHk5FTm2OYJmy0UVfmpHARmtNGb7LWw9OsAlO+1sFVycjDsgakqqnJ9KQ9T1hdT1wNTs+XXAbDvWiS3vrCBIqJKwcfHBwCQl5eHunXrStPz8vLQqlUracylS5eMnnfv3j1cvXpVer6Pjw/y8vKMxhgeG8Y8TKVSQaVSFZvu5OQk64+HVq+Atsg0f6St9cdKTq6mytGcTPVaWPNLg9z3nS0rKwdr5Mb68n/rtFXmqC+m3HamZMuvw4PssRbJjZdX4SOiSiEgIAA+Pj7YunWrNK2wsBD79+9HWFgYACAsLAz5+fnIysqSxmzbtg16vR6hoaHSmJ07dxodB63RaNC4ceMSD68hosqP9YWIHsQGiojsxo0bN5CdnY3s7GwA90/szs7OxoULF6BQKDB27Fi8//77WLduHY4ePYohQ4bA19cXffr0AQA0bdoUPXr0wMiRI3HgwAHs2bMH8fHxiImJga+vLwBg4MCBUCqVGD58OHJycrBy5UosWLDA6BAaIqp8WF+ISC4ewkdEduPQoUN47rnnpMeGLx2xsbFISUnBxIkTcfPmTYwaNQr5+fno2LEjNm3aBGdnZ+k5qampiI+PR7du3eDg4IB+/fph4cKF0nx3d3ekp6cjLi4OISEhqF27NqZNm8ZLDBNVcqwvRCQXGygishtdunSBEKVfVlahUCApKQlJSUmljvH09ERaWlqZ62nRogV27dpV4TiJyP6wvhCRXDyEj4iIiIiISCarNFAJCQlQKBRG/5o0aSLNv3PnDuLi4lCrVi1Ur14d/fr1K3bVmgsXLiA6Ohqurq7w8vLChAkTcO/ePUunQkREREREVYjVDuFr1qwZtmzZ8n+BVPu/UMaNG4cNGzZg9erVcHd3R3x8PPr27Ys9e/YAAIqKihAdHQ0fHx/s3bsXFy9exJAhQ+Dk5IQPP/zQ4rkQEREREVHVYLUGqlq1aiXe86CgoACff/450tLS0LVrVwDA8uXL0bRpU+zbtw/t27dHeno6jh8/ji1btsDb2xutWrXCjBkzMGnSJCQkJECpVFo6HSIiIiIiqgKsdg7UqVOn4Ovri4YNG2LQoEG4cOECACArKws6nQ7h4eHS2CZNmqB+/frIzMwEAGRmZiI4OBje3t7SmMjISBQWFiInJ8eyiRARERERUZVhlT1QoaGhSElJQePGjXHx4kUkJiaiU6dOOHbsGHJzc6FUKuHh4WH0HG9vb+Tm5gIAcnNzjZonw3zDvNJotVpotVrpcWFhIQBAp9MZ3dTuYSrH0q/KY0oqB2H0X3tgbzHbW7yAaWIu6/1tapZcFxEREZGlWaWBioqKkv6/RYsWCA0Nhb+/P1atWgUXFxezrTc5ORmJiYnFpqenp8PV1bXU581uZ7aQSjSjjd6yKzQBe4vZ3uIFHi/mjRs3mjASIiIioqrLJu4D5eHhgaeeegqnT59G9+7dcffuXeTn5xvthcrLy5POmfLx8cGBAweMlmG4Sl9J51UZTJ482ehu34WFhfDz80NERATUanWpz2uesLkiaZWbykFgRhs9ph5ygFavsMg6H5e9xWxv8QKmiflYQqSJoyqdTqfDjz/+aLH1EREREVmSTTRQN27cwJkzZzB48GCEhITAyckJW7duRb9+/QAAJ0+exIULFxAWFgYACAsLwwcffIBLly7By8sLAKDRaKBWqxEUFFTqelQqFVQqVbHpTk5OcHJyKvV52iLLftHW6hUWX+fjsreY7S1e4PFiLuv9TURERETyWaWBevvtt9GrVy/4+/vj77//xvTp0+Ho6IgBAwbA3d0dw4cPx/jx4+Hp6Qm1Wo0333wTYWFhaN++PQAgIiICQUFBGDx4MGbPno3c3FxMmTIFcXFxJTZIRERVRYN3NphsWedmRptsWURk/1hfiO6zSgP1559/YsCAAbhy5Qrq1KmDjh07Yt++fahTpw4AYN68eXBwcEC/fv2g1WoRGRmJJUuWSM93dHTE+vXrMWbMGISFhcHNzQ2xsbFISkqyRjpERERERFRFWKWBWrFiRZnznZ2dsXjxYixevLjUMf7+/jwxnoiIiIiILMpq94EiIiIiIiKyNzZxEQkiIrI9cs53UDkKzG53/2ql9nZhFiKyHlOeT0VkaWygiKoAnvhLREREZBo8hI+IiIiIiEgmNlBEREREREQysYEiIiIiIiKSiedAERERmRjPOyQic2F9sT7ugSIiIiIiIpKJDRQREREREZFMbKCIiIiIiIhkYgNFREREREQkExsoIqpUEhISoFAojP41adJEmn/nzh3ExcWhVq1aqF69Ovr164e8vDyjZVy4cAHR0dFwdXWFl5cXJkyYgHv37lk6FSKyIawtRGTAq/ARUaXTrFkzbNmyRXpcrdr/lbpx48Zhw4YNWL16Ndzd3REfH4++fftiz549AICioiJER0fDx8cHe/fuxcWLFzFkyBA4OTnhww8/tHguRGQ7WFuICGADRUSVULVq1eDj41NsekFBAT7//HOkpaWha9euAIDly5ejadOm2LdvH9q3b4/09HQcP34cW7Zsgbe3N1q1aoUZM2Zg0qRJSEhIgFKptHQ6RGQjWFuICGADRUSV0KlTp+Dr6wtnZ2eEhYUhOTkZ9evXR1ZWFnQ6HcLDw6WxTZo0Qf369ZGZmYn27dsjMzMTwcHB8Pb2lsZERkZizJgxyMnJQevWra2RElVhcu/5onIUmN0OaJ6wGdoiRanjeN+XimNtocrGlPeUAqpOfWEDRUSVSmhoKFJSUtC4cWNcvHgRiYmJ6NSpE44dO4bc3FwolUp4eHgYPcfb2xu5ubkAgNzcXKMvOIb5hnkl0Wq10Gq10uPCwkIAgE6ng06nKzVWwzyVgyhfkjbEELs95wBUjjzk5lDWe9LaDLHJ+dxYmjVqC1C164u1VIZ6YC0Pvi9tudaURm7MbKCIqFKJioqS/r9FixYIDQ2Fv78/Vq1aBRcXF7OsMzk5GYmJicWmp6enw9XV9ZHPn9FGb46wLKoy5ABUjjwelcPGjRstFEnFaTSaUufdunXLgpH8H2vUFoD1xZq47crvwfpS1ufYVsmtL2ygiKhS8/DwwFNPPYXTp0+je/fuuHv3LvLz841+Kc7Ly5POa/Dx8cGBAweMlmG4klZJ5z4AwOTJkzF+/HjpcWFhIfz8/BAREQG1Wl1qbDqdDhqNBlMPOUCrL/2QK1umchCY0UZv1zkAlSMPuTkcS4i0YFTlY/hMdO/eHU5OTiWOMeyBsTZL1BagatcXa6kM9cBajiVEyvoc2yq59YUNFBFVajdu3MCZM2cwePBghISEwMnJCVu3bkW/fv0AACdPnsSFCxcQFhYGAAgLC8MHH3yAS5cuwcvLC8D9X9HUajWCgoJKXIdKpYJKpSo23cnJSdYfD61eUeY5K/agMuQAVI48HpWDPXyhKeuzYyvxW6K2AKwv1sRtV34Pviflvkdtidx42UARUaXy9ttvo1evXvD398fff/+N6dOnw9HREQMGDIC7uzuGDx+O8ePHw9PTE2q1Gm+++SbCwsLQvn17AEBERASCgoIwePBgzJ49G7m5uZgyZQri4uJK/BJDRFUDawsRGbCBIqJK5c8//8SAAQNw5coV1KlTBx07dsS+fftQp04dAMC8efPg4OCAfv36QavVIjIyEkuWLJGe7+joiPXr12PMmDEICwuDm5sbYmNjkZSUZK2UiMgGsLYQkQEbKCKqVFasWFHmfGdnZyxevBiLFy8udYy/v79dnGhPVBGmvGxxVblkMcDaQiRHg3c2yL6lwqPYcn1xsHYARERERERE9oINFBERERERkUxsoIiIiIiIiGRiA0VERERERCQTGygiIiIiIiKZ2EARERERERHJxAaKiIiIiIhIJjZQREREREREMrGBIiIiIiIikokNFBERERERkUxsoIiIiIiIiGRiA0VERERERCQTGygiIiIiIiKZ2EARERERERHJxAaKiIiIiIhIJjZQREREREREMrGBIiIiIiIikokNFBERERERkUxsoIiIiIiIiGRiA0VERERERCQTGygiIiIiIiKZqlk7ACIiIrJPDd7ZYNLlnZoRYdLlEZH9MnV9OTcz2mTL4h4oIiIiIiIimdhAERERERERyWT3DdTixYvRoEEDODs7IzQ0FAcOHLB2SERUSbC+EJG5sL4Q2S+7bqBWrlyJ8ePHY/r06fjll1/QsmVLREZG4tKlS9YOjYjsHOsLEZkL6wuRfbPrBmru3LkYOXIkXnvtNQQFBWHZsmVwdXXFF198Ye3QiMjOsb4QkbmwvhDZN7u9Ct/du3eRlZWFyZMnS9McHBwQHh6OzMzMEp+j1Wqh1WqlxwUFBQCAq1evQqfTlbquavdumijqslXTC9y6pUc1nQOK9AqLrPNx2VvM9hYvYHsxX7lypcz5Op0Ot27dAgAIISwRksmVt75UtLYYtpWtvLYVYWvvz4qqDHlUhhyuXLmCW7du4cqVK3BycipxzPXr1wGwvlSF+mItleGzZE22uv0e9f0FkF9f7LaBunz5MoqKiuDt7W003dvbG7/99luJz0lOTkZiYmKx6QEBAWaJsSIGWjuACrC3mO0tXsC2Yq49R/7Y69evw93d3XzBmEl564s91BZzsqX35+OoDHnYew51WV+Kja/q9cVa7P2zZG22uP1M+f3Fbhuoipg8eTLGjx8vPdbr9bh69Spq1aoFhcL6HXJhYSH8/Pzwv//9D2q12trhyGJvMdtbvID9xWyI9/jx4/D19bV2OBZR0dpib69tSSpDDkDlyKOq5CCEwPXr11lfqkB9sRZuu8djz9tPbn2x2waqdu3acHR0RF5entH0vLw8+Pj4lPgclUoFlUplNM3Dw8NcIVaYWq22uzecvcVsb/EC9hfzE088AQcH+zzNsrz15XFri729tiWpDDkAlSOPqpCDPe55MmB9sR/cdo/HXrefnPpin99uACiVSoSEhGDr1q3SNL1ej61btyIsLMyKkRGRvWN9ISJzYX0hsn92uwcKAMaPH4/Y2Fi0adMG7dq1w/z583Hz5k289tpr1g6NiOwc6wsRmQvrC5F9s+sG6pVXXsE///yDadOmITc3F61atcKmTZuKnZhpL1QqFaZPn15sV70ts7eY7S1ewP5itrd4S2OJ+lIZtlVlyAGoHHkwB/vB+mLbuO0eT1XYfgphr9cBJSIiIiIisjC7PQeKiIiIiIjI0thAERERERERycQGioiIiIiISCY2UERERERERDKxgTKz5ORktG3bFjVq1ICXlxf69OmDkydPGo3p0qULFAqF0b/Ro0cbjblw4QKio6Ph6uoKLy8vTJgwAffu3TNLzAkJCcXiadKkiTT/zp07iIuLQ61atVC9enX069ev2A0BLRlvgwYNisWrUCgQFxcHwDa2786dO9GrVy/4+vpCoVBg7dq1RvOFEJg2bRrq1q0LFxcXhIeH49SpU0Zjrl69ikGDBkGtVsPDwwPDhw/HjRs3jMYcOXIEnTp1grOzM/z8/DB79myTx6vT6TBp0iQEBwfDzc0Nvr6+GDJkCP7++2+jZZT0usycOdMs8dqrxYsXo0GDBnB2dkZoaCgOHDhglTgs9ZnPyMjA008/DZVKhUaNGiElJaXCMdvSZ2r16tVo0qQJnJ2dERwcjI0bN5osj6FDhxZ7bXr06GEzecj5G2fJ94+tfKZsQVXfFvZY16ylstRTixJkVpGRkWL58uXi2LFjIjs7W/Ts2VPUr19f3LhxQxrz7LPPipEjR4qLFy9K/woKCqT59+7dE82bNxfh4eHi8OHDYuPGjaJ27dpi8uTJZol5+vTpolmzZkbx/PPPP9L80aNHCz8/P7F161Zx6NAh0b59e/HMM89YLd5Lly4ZxarRaAQAsX37diGEbWzfjRs3ivfee0+sWbNGABA//PCD0fyZM2cKd3d3sXbtWvHrr7+KF154QQQEBIjbt29LY3r06CFatmwp9u3bJ3bt2iUaNWokBgwYIM0vKCgQ3t7eYtCgQeLYsWPi22+/FS4uLuI///mPSePNz88X4eHhYuXKleK3334TmZmZol27diIkJMRoGf7+/iIpKclouz/4vjdlvPZoxYoVQqlUii+++ELk5OSIkSNHCg8PD5GXl2fxWCzxmf/jjz+Eq6urGD9+vDh+/LhYtGiRcHR0FJs2bapQzLbymdqzZ49wdHQUs2fPFsePHxdTpkwRTk5O4ujRoybJIzY2VvTo0cPotbl69arRGGvmIedvnKXeP7b0mbI2bgv7rGvWUlnqqSWxgbKwS5cuCQBix44d0rRnn31W/Otf/yr1ORs3bhQODg4iNzdXmrZ06VKhVquFVqs1eYzTp08XLVu2LHFefn6+cHJyEqtXr5amnThxQgAQmZmZVon3Yf/6179EYGCg0Ov1Qgjb274PFye9Xi98fHzERx99JE3Lz88XKpVKfPvtt0IIIY4fPy4AiIMHD0pjfv75Z6FQKMRff/0lhBBiyZIlombNmkYxT5o0STRu3Nik8ZbkwIEDAoA4f/68NM3f31/Mmzev1OeYK1570a5dOxEXFyc9LioqEr6+viI5OdnisVjiMz9x4kTRrFkzo2W/8sorIjIy8rHjt+Znqn///iI6OtoontDQUPH6668/dh5C3G+gevfuXepzbC2Ph//GWfL9Y0ufKWvjtrD/umYtlaWemhsP4bOwgoICAICnp6fR9NTUVNSuXRvNmzfH5MmTcevWLWleZmYmgoODjW6wFxkZicLCQuTk5JglzlOnTsHX1xcNGzbEoEGDcOHCBQBAVlYWdDodwsPDpbFNmjRB/fr1kZmZabV4De7evYtvvvkGw4YNg0KhkKbb2vZ90NmzZ5Gbm2u0Td3d3REaGmq0TT08PNCmTRtpTHh4OBwcHLB//35pTOfOnaFUKo3yOHnyJK5du2bWHAoKCqBQKODh4WE0febMmahVqxZat26Njz76yOjQB2vGa213795FVlaW0Wvu4OCA8PBw6TW3NHN/5jMzM42WYRhjjnwt+ZmyRF4ZGRnw8vJC48aNMWbMGFy5ckWaZ2t5PPw3zlLvH1v8TFkLt8X/qUx1zVoqWz01lWrWDqAq0ev1GDt2LDp06IDmzZtL0wcOHAh/f3/4+vriyJEjmDRpEk6ePIk1a9YAAHJzc4vdndzwODc31+RxhoaGIiUlBY0bN8bFixeRmJiITp064dixY8jNzYVSqSz2Rdnb21uKxdLxPmjt2rXIz8/H0KFDpWm2tn0fZlhHSTE8uE29vLyM5lerVg2enp5GYwICAootwzCvZs2aZon/zp07mDRpEgYMGAC1Wi1Nf+utt/D000/D09MTe/fuxeTJk3Hx4kXMnTvXqvHagsuXL6OoqKjE1/y3336zeDyW+MyXNqawsBC3b9+Gi4uLyfKx5GeqtLxMVTt69OiBvn37IiAgAGfOnMG7776LqKgoZGZmwtHR0abyKOlvnKXeP9euXbOpz5Q12Vp9sZbKVtespTLVU1NiA2VBcXFxOHbsGHbv3m00fdSoUdL/BwcHo27duujWrRvOnDmDwMBAS4eJqKgo6f9btGiB0NBQ+Pv7Y9WqVTZfDD7//HNERUXB19dXmmZr27cy0el06N+/P4QQWLp0qdG88ePHS//fokULKJVKvP7660hOToZKpbJ0qFQGe/7MV3YxMTHS/wcHB6NFixYIDAxERkYGunXrZsXIiivtbxyRNbCukTnxED4LiY+Px/r167F9+3bUq1evzLGhoaEAgNOnTwMAfHx8il0ZxvDYx8fHDNEa8/DwwFNPPYXTp0/Dx8cHd+/eRX5+frF4DLFYK97z589jy5YtGDFiRJnjbG37GtZRUgwPbtNLly4Zzb937x6uXr1qte1uaJ7Onz8PjUZjtPepJKGhobh37x7OnTtnlXhtSe3ateHo6Fjma25N5vjMlzZGrVab/MuMJT9TpY0x1+vYsGFD1K5d26h+2UIepf2Ns9T7x9Y/U5bEbVEye69r1lKZ6+njYANlZkIIxMfH44cffsC2bduK7b4sSXZ2NgCgbt26AICwsDAcPXrU6M1p+MIaFBRklrgfdOPGDZw5cwZ169ZFSEgInJycsHXrVmn+yZMnceHCBYSFhVk13uXLl8PLywvR0dFljrO17RsQEAAfHx+jbVpYWIj9+/cbbdP8/HxkZWVJY7Zt2wa9Xi81hGFhYdi5cyd0Op1RHo0bNzb54XCG5unUqVPYsmULatWq9cjnZGdnw8HBQdrNb8l4bY1SqURISIjRa67X67F161bpNbcmc3zmw8LCjJZhGGOOfC35mbJkXgDw559/4sqVK0b1y5p5POpvnKXeP7b+mbIkbouS2Xtds5bKXE8fi5UvYlHpjRkzRri7u4uMjAyjS2neunVLCCHE6dOnRVJSkjh06JA4e/as+PHHH0XDhg1F586dpWUYLqUZEREhsrOzxaZNm0SdOnXMdlnwf//73yIjI0OcPXtW7NmzR4SHh4vatWuLS5cuCSHuX/qzfv36Ytu2beLQoUMiLCxMhIWFWS1eIe5fYah+/fpi0qRJRtNtZftev35dHD58WBw+fFgAEHPnzhWHDx+Wrlo3c+ZM4eHhIX788Udx5MgR0bt37xIvEdq6dWuxf/9+sXv3bvHkk08aXSI0Pz9feHt7i8GDB4tjx46JFStWCFdX1wpdFryseO/evSteeOEFUa9ePZGdnW30vjZcXWfv3r1i3rx5Ijs7W5w5c0Z88803ok6dOmLIkCFmidcerVixQqhUKpGSkiKOHz8uRo0aJTw8PIyu+GQplvjMGy73O2HCBHHixAmxePHix7rcr618pvbs2SOqVasmPv74Y3HixAkxffr0cl12t6w8rl+/Lt5++22RmZkpzp49K7Zs2SKefvpp8eSTT4o7d+7YRB6P+hsnhOXeP7b0mbI2bgv7rGvWUlnqqSWxgTIzACX+W758uRBCiAsXLojOnTsLT09PoVKpRKNGjcSECROM7lMkhBDnzp0TUVFRwsXFRdSuXVv8+9//Fjqdziwxv/LKK6Ju3bpCqVSKJ554Qrzyyivi9OnT0vzbt2+LN954Q9SsWVO4urqKF198UVy8eNFq8QohxObNmwUAcfLkSaPptrJ9t2/fXuL7IDY2Vghx/zKhU6dOFd7e3kKlUolu3boVy+XKlStiwIABonr16kKtVovXXntNXL9+3WjMr7/+Kjp27ChUKpV44oknxMyZM00e79mzZ0t9XxvuvZWVlSVCQ0OFu7u7cHZ2Fk2bNhUffvih0Zc+U8ZrrxYtWiTq168vlEqlaNeundi3b59V4rDUZ3779u2iVatWQqlUioYNG0p1sCJs6TO1atUq8dRTTwmlUimaNWsmNmzYYJI8bt26JSIiIkSdOnWEk5OT8Pf3FyNHjiz2JdiaeTzqb5wQln3/2MpnyhZU9W1hj3XNWipLPbUkhRBCmHy3FhERERERUSXEc6CIiIiIiIhkYgNFREREREQkExsoIiIiIiIimdhAERERERERycQGioiIiIiISCY2UERERERERDKxgSIiIiIiIpKJDRQREREREZFMbKCIiIiIiIhkYgNFREREREQkExsoIiIiIiIimdhAERERERERycQGioiIiIiISCY2UERERERERDKxgSIiIiIiIpKJDRQREREREZFMbKCIiIiIiIhkYgNFREREREQkExsoIiIiIiIimdhAERERERERycQGqpJr0KABhg4dKj3OyMiAQqFARkZGuZdleO53331nugBNTKFQICEhwdphlMiWYyMqD3utKykpKVAoFDh37pzZ10VEpsOaY1kPb28qjg2UHTN8MEv6984771g1trS0NMyfP7/Y9HPnzhnF6eTkhNq1a+OZZ57Bu+++iwsXLlg+2HJ4cJvv3r272HwhBPz8/KBQKPD8889bIUKix2NvdaVLly6lxvvgP2v/ePGoL21Dhw5F9erVLRwVkfWx5piHoeYoFAp88803JY7p0KEDFAoFmjdvbuHo7F81awdAjy8pKQkBAQFG00r7MHTu3Bm3b9+GUqk0a0xpaWk4duwYxo4dW+L8AQMGoGfPntDr9bh27RoOHjyI+fPnY8GCBfj8888RExNj1vgel7OzM9LS0tCxY0ej6Tt27MCff/4JlUpV7Dm3b99GtWr8yJF9sJe68t5772HEiBHS44MHD2LhwoV499130bRpU2l6ixYt0KxZM8TExJT4+SQi62LNMQ/D95VXX33VaPq5c+ewd+9eODs7F3vOyZMn4eDAfSxl4be5SiAqKgpt2rSRNdbBwaHED4ulPf3008U+zOfPn0dERARiY2PRtGlTtGzZ0krRPVrPnj2xevVqLFy40KgpSktLQ0hICC5fvlzsObaw3Ynkspe60r17d6PHzs7OWLhwIbp3744uXboUG+/o6GihyOzDnTt3oFQq+WWJrI41xzx69uyJdevW4fLly6hdu7Y0PS0tDd7e3njyySdx7do1o+fwR6ZHY8WsYko7bnjx4sVo2LAhXFxc0K5dO+zatQtdunQpsRjo9Xp88MEHqFevHpydndGtWzecPn1amt+lSxds2LAB58+fl3YfN2jQ4JGx+fv7IyUlBXfv3sXs2bON5uXn52Ps2LHw8/ODSqVCo0aNMGvWLOj1+jKXef78ebzxxhto3LgxXFxcUKtWLbz88stGxyP/8ccfUCgUmDdvXrHn7927FwqFAt9++63R9AEDBuDKlSvQaDTStLt37+K7777DwIEDS4zl4V36CQkJUCgUOH36NIYOHQoPDw+4u7vjtddew61bt8rMi8iW2HJdeVBJ5yM0aNAAzz//PDIyMtCmTRu4uLggODhYymXNmjUIDg6Gs7MzQkJCcPjw4WLL/e233/DSSy/B09MTzs7OaNOmDdatW1eu2EqzZMkSNGvWDCqVCr6+voiLi0N+fr7RmNLOV3h4WxtepxUrVmDKlCl44okn4OrqisLCQpPESmQprDnya07v3r2hUqmwevVqo+lpaWno379/iQ3ewzXFkMeePXswfvx41KlTB25ubnjxxRfxzz//lGubVBbcA1UJFBQUFNvj8eCvDI+ydOlSxMfHo1OnThg3bhzOnTuHPn36oGbNmqhXr16x8TNnzoSDgwPefvttFBQUYPbs2Rg0aBD2798P4P7u7YKCAvz5559SUyL32P6wsDAEBgYaNSa3bt3Cs88+i7/++guvv/466tevj71792Ly5Mm4ePFiiedaGRw8eBB79+5FTEwM6tWrh3PnzmHp0qXo0qULjh8/DldXVzRs2BAdOnRAamoqxo0bZ/T81NRU1KhRA7179zaa3qBBA4SFheHbb79FVFQUAODnn39GQUEBYmJisHDhQln5AkD//v0REBCA5ORk/PLLL/jss8/g5eWFWbNmyV4GkalVprryKKdPn8bAgQPx+uuv49VXX8XHH3+MXr16YdmyZXj33XfxxhtvAACSk5PRv39/o8NbcnJy0KFDBzzxxBN455134ObmhlWrVqFPnz74/vvv8eKLLxqt6/r16yXuodZqtcWmJSQkIDExEeHh4RgzZgxOnjyJpUuX4uDBg9izZw+cnJwqlO+MGTOgVCrx9ttvQ6vVmv0wKCI5WHPMU3NcXV3Ru3dvfPvttxgzZgwA4Ndff0VOTg4+++wzHDlyRHbcb775JmrWrInp06fj3LlzmD9/PuLj47Fy5UqTbBe7IshuLV++XAAo8Z+Bv7+/iI2NlR5v375dABDbt28XQgih1WpFrVq1RNu2bYVOp5PGpaSkCADi2WefLfbcpk2bCq1WK01fsGCBACCOHj0qTYuOjhb+/v7FYj579qwAID766KNS8+rdu7cAIAoKCoQQQsyYMUO4ubmJ33//3WjcO++8IxwdHcWFCxekaQDE9OnTpce3bt0qtvzMzEwBQHz11VfStP/85z8CgDhx4oQ07e7du6J27dpG28+wzQ8ePCg++eQTUaNGDWkdL7/8snjuueeEEPe3e3R0tNF6H45t+vTpAoAYNmyY0bgXX3xR1KpVq9TtQ2RO9lhXHrR69WqjWErK7ezZs0a5ABB79+6Vpm3evFkAEC4uLuL8+fPSdEOdeHDZ3bp1E8HBweLOnTvSNL1eL5555hnx5JNPFsuzrH9ubm7S+EuXLgmlUikiIiJEUVGRNP2TTz4RAMQXX3xhlMODr4fBs88+W+K2btiwYYm1kcgaWHPMW3NWr14t1q9fLxQKhfR9acKECaJhw4ZCiPt1olmzZkZxP7y9DXmEh4cLvV4vTR83bpxwdHQU+fn5ZW6jyoiH8FUCixcvhkajMfon16FDh3DlyhWMHDnS6FyeQYMGoWbNmiU+57XXXjP6xbJTp04A7h8KZwqGX3iuX78OAFi9ejU6deqEmjVr4vLly9K/8PBwFBUVYefOnaUuy8XFRfp/nU6HK1euoFGjRvDw8MAvv/wizevfvz+cnZ2RmpoqTdu8eTMuX75c7FytB59z+/ZtrF+/HtevX8f69etLPXyvLKNHjzZ63KlTJ1y5coWH1ZBVVba6UpagoCCEhYVJj0NDQwEAXbt2Rf369YtNN8R09epVbNu2Df3795f2LF2+fBlXrlxBZGQkTp06hb/++stoXdOmTSu2XTUaDSIiIozGbdmyBXfv3sXYsWONzk8aOXIk1Go1NmzYUOF8Y2NjjWojkS1gzTFPzQGAiIgIeHp6YsWKFRBCYMWKFRgwYEC54x41ahQUCoX0uFOnTigqKsL58+fLvSx7x0P4KoF27drJPvHyYYY3faNGjYymV6tWrdRjfR/8cAOQitPDJyFW1I0bNwAANWrUAACcOnUKR44cQZ06dUocf+nSpVKXdfv2bSQnJ2P58uX466+/IISQ5hUUFEj/7+HhgV69eiEtLQ0zZswAcP/wvSeeeAJdu3Ytcdl16tRBeHg40tLScOvWLRQVFeGll14qX7Ioe3uq1epyL4/IFCpbXSnLw+t2d3cHAPj5+ZU43RDT6dOnIYTA1KlTMXXq1BKXfenSJTzxxBPS4+DgYISHhxcb9/Blhg3bsHHjxkbTlUolGjZs+FhfWB6+0hmRLWDNMU/NAQAnJye8/PLLSEtLQ7t27fC///2vQj/4WnOb2Ro2UFRupV1R5sHm5HEcO3YMXl5eUvOg1+vRvXt3TJw4scTxTz31VKnLevPNN7F8+XKMHTsWYWFhcHd3h0KhQExMTLELUAwZMgSrV6/G3r17ERwcjHXr1uGNN94o8+pUAwcOxMiRI5Gbm4uoqCh4eHiUO19zb08ie2DNz0Fp635UTIYa8vbbbyMyMrLEsQ9/oTOHB38RflBRUVGJOXDvE1HVqzkDBw7EsmXLkJCQgJYtWyIoKKi8YfP7ygPYQFVx/v7+AO7/qvHcc89J0+/du4dz586hRYsWFVpuaX/QHyUzMxNnzpwxOmwuMDAQN27cKPFX20f57rvvEBsbizlz5kjT7ty5U+wqVgDQo0cP1KlTB6mpqQgNDcWtW7cwePDgMpf/4osv4vXXX8e+ffuq5kmURCWwtbpiLg0bNgRw/9fditSnshi24cmTJ6X1APev9nn27Fmj9dWsWbPEmnb+/Hmj5xJVVqw5j9axY0fUr18fGRkZvEiVCfAcqCquTZs2qFWrFv773//i3r170vTU1NTH2iXr5uZmdIicHOfPn8fQoUOhVCoxYcIEaXr//v2RmZmJzZs3F3tOfn6+UdwPc3R0LPbLyKJFi1BUVFRsbLVq1TBgwACsWrUKKSkpCA4OfmTRrV69OpYuXYqEhAT06tXrUSkSVQm2VFfMycvLC126dMF//vMfXLx4sdj8x7m8b3h4OJRKJRYuXGhUwz7//HMUFBQgOjpamhYYGIh9+/bh7t270rT169fjf//7X4XXT2RPWHPuK6vmKBQKLFy4ENOnT3/kj8P0aNwDVcUplUokJCTgzTffRNeuXdG/f3+cO3cOKSkpCAwMrPCvLyEhIVi5ciXGjx+Ptm3bonr16kYNxi+//IJvvvkGer0e+fn5OHjwIL7//nsoFAp8/fXXRo3LhAkTsG7dOjz//PMYOnQoQkJCcPPmTRw9ehTfffcdzp07V+qlTp9//nl8/fXXcHd3R1BQEDIzM7FlyxbUqlWrxPFDhgzBwoULsX37dtm/0MTGxpZjyxBVftaqK9awePFidOzYEcHBwRg5ciQaNmyIvLw8ZGZm4s8//8Svv/5aoeXWqVMHkydPRmJiInr06IEXXngBJ0+exJIlS9C2bVujvfQjRozAd999hx49eqB///44c+YMvvnmGwQGBpoqTSKbxpojr+b07t272G1ZqGLYQBHi4+MhhMCcOXPw9ttvo2XLlli3bh3eeuutCt/p+4033kB2djaWL1+OefPmwd/f36jofPvtt/j2229RrVo1qNVqPPnkkxg7dixGjx5d7CRFV1dX7NixAx9++CFWr16Nr776Cmq1Gk899RQSExOlkyxLsmDBAjg6OiI1NRV37txBhw4dsGXLllKPHQ4JCUGzZs1w4sQJDBo0qEK5E5F16oo1BAUF4dChQ0hMTERKSgquXLkCLy8vtG7dGtOmTXusZSckJKBOnTr45JNPMG7cOHh6emLUqFH48MMPje4BFRkZiTlz5mDu3LkYO3Ys2rRpg/Xr1+Pf//7346ZHZDdYcx6/5pB8ClEVz/yiR9Lr9ahTpw769u2L//73v9YOx6Jat24NT09PbN261dqhEFUqVbmuEJHlseaQufAcKMKdO3eKnSf01Vdf4erVq+jSpYt1grKSQ4cOITs7G0OGDLF2KER2jXWFiCyJNYcsiXugCBkZGRg3bhxefvll1KpVC7/88gs+//xzNG3aFFlZWUY3mqusjh07hqysLMyZMweXL1/GH3/8UeFd/kTEukJElsWaQ5bEc6AIDRo0gJ+fHxYuXIirV6/C09MTQ4YMwcyZM6tMwfnuu++QlJSExo0b49tvv2XzRPSYWFeIyJJYc8iSuAeKiIiIiIhIJp4DRUREREREJBMbKCIiIiIiIpmq9DlQer0ef//9N2rUqFHhm6wRUXFCCFy/fh2+vr5wcKh6v9OwthCZD+sL6wuRucitL1W6gfr777/h5+dn7TCIKq3//e9/qFevnrXDsDjWFiLzY30hInN5VH2p0g1UjRo1ANzfSGq1usQxOp0O6enpiIiIMLrze2VQWXNjXtZXWFgIPz8/6TNW1cipLYB9vaamxLyrTt7myJn1pWrWl8qUD3OxXXLrS5VuoAy7vtVqdZkNlKurK9RqdaV4YzyosubGvGxHVT28RE5tAezzNTUF5l118jZnzqwvVau+VKZ8mIvte1R9qXoHDxMREREREVUQGygiIiIiIiKZ2EARERERERHJxAaKiIiIiIhIpnI3UDt37kSvXr3g6+sLhUKBtWvXGs0XQmDatGmoW7cuXFxcEB4ejlOnThmNuXr1KgYNGgS1Wg0PDw8MHz4cN27cMBpz5MgRdOrUCc7OzvDz88Ps2bOLxbJ69Wo0adIEzs7OCA4OxsaNG8ubDhERERERkWzlbqBu3ryJli1bYvHixSXOnz17NhYuXIhly5Zh//79cHNzQ2RkJO7cuSONGTRoEHJycqDRaLB+/Xrs3LkTo0aNkuYXFhYiIiIC/v7+yMrKwkcffYSEhAR8+umn0pi9e/diwIABGD58OA4fPow+ffqgT58+OHbsWHlTIiIiIiIikqXclzGPiopCVFRUifOEEJg/fz6mTJmC3r17AwC++uoreHt7Y+3atYiJicGJEyewadMmHDx4EG3atAEALFq0CD179sTHH38MX19fpKam4u7du/jiiy+gVCrRrFkzZGdnY+7cuVKjtWDBAvTo0QMTJkwAAMyYMQMajQaffPIJli1bVqGNQUREREREVBaTngN19uxZ5ObmIjw8XJrm7u6O0NBQZGZmAgAyMzPh4eEhNU8AEB4eDgcHB+zfv18a07lzZyiVSmlMZGQkTp48iWvXrkljHlyPYYxhPURERERERKZm0hvp5ubmAgC8vb2Npnt7e0vzcnNz4eXlZRxEtWrw9PQ0GhMQEFBsGYZ5NWvWRG5ubpnrKYlWq4VWq5UeFxYWArh/EzCdTlficwzTQ5I2Qas3zU37jiVEmmQ5j8uQW2m52yvmZX32ECM9WoN3Nph0eedmRpt0eURkv8pbX1SOArPbAc0TNkNbVPz7GOsLWZJJGyhbl5ycjMTExGLT09PT4erqWuZzZ7TRmywOW7vYhUajsXYIZsG8rOfWrVvWDoGIiIjILEzaQPn4+AAA8vLyULduXWl6Xl4eWrVqJY25dOmS0fPu3buHq1evSs/38fFBXl6e0RjD40eNMcwvyeTJkzF+/HjpcWFhIfz8/BAREQG1Wl3ic3Q6HTQaDaYecqiUe6A0Gg26d+8OJycna4djMszL+gx7d4mIiIgqG5M2UAEBAfDx8cHWrVulhqmwsBD79+/HmDFjAABhYWHIz89HVlYWQkJCAADbtm2DXq9HaGioNOa9996DTqeTvihqNBo0btwYNWvWlMZs3boVY8eOldav0WgQFhZWanwqlQoqlarYdCcnp0d+IdXqFSXuMq4IW/vyKyd/e8S8rMfW4yMiIiKqqHJfROLGjRvIzs5GdnY2gPsXjsjOzsaFCxegUCgwduxYvP/++1i3bh2OHj2KIUOGwNfXF3369AEANG3aFD169MDIkSNx4MAB7NmzB/Hx8YiJiYGvry8AYODAgVAqlRg+fDhycnKwcuVKLFiwwGjv0b/+9S9s2rQJc+bMwW+//YaEhAQcOnQI8fHxj79ViIiIiIiISlDuPVCHDh3Cc889Jz02NDWxsbFISUnBxIkTcfPmTYwaNQr5+fno2LEjNm3aBGdnZ+k5qampiI+PR7du3eDg4IB+/fph4cKF0nx3d3ekp6cjLi4OISEhqF27NqZNm2Z0r6hnnnkGaWlpmDJlCt599108+eSTWLt2LZo3b16hDUFERERERPQo5W6gunTpAiFEqfMVCgWSkpKQlJRU6hhPT0+kpaWVuZ4WLVpg165dZY55+eWX8fLLL5cdMBERERERkYmY9D5QRERERERElRkbKCIiIiIiIpnYQBGR3Vi6dClatGgBtVoNtVqNsLAw/Pzzz9L8O3fuIC4uDrVq1UL16tXRr1+/Yrc7uHDhAqKjo+Hq6govLy9MmDAB9+7dMxqTkZGBp59+GiqVCo0aNUJKSool0iMiK2J9ISK52EARkd2oV68eZs6ciaysLBw6dAhdu3ZF7969kZOTAwAYN24cfvrpJ6xevRo7duzA33//jb59+0rPLyoqQnR0NO7evYu9e/fiyy+/REpKCqZNmyaNOXv2LKKjo/Hcc88hOzsbY8eOxYgRI7B582aL50tElsP6QkRymfQ+UERE5tSrVy+jxx988AGWLl2Kffv2oV69evj888+RlpaGrl27AgCWL1+Opk2bYt++fWjfvj3S09Nx/PhxbNmyBd7e3mjVqhVmzJiBSZMmISEhAUqlEsuWLUNAQADmzJkD4P6tF3bv3o158+YhMtI2boJNRKbH+kJEcrGBIiK7VFRUhNWrV+PmzZsICwtDVlYWdDodwsPDpTFNmjRB/fr1kZmZifbt2yMzMxPBwcHw9vaWxkRGRmLMmDHIyclB69atkZmZabQMw5gHb9r9MK1WC61WKz0uLCwEAOh0Ouh0ulKfZ5hX1hhrUjmWfsXVing4X1vN21yqYt7myNkS24/1xfzKW19UDsLovw+z1TxLYuuvTXlUplwA+XmwgSIiu3L06FGEhYXhzp07qF69On744QcEBQUhOzsbSqUSHh4eRuO9vb2Rm5sLAMjNzTX6cmOYb5hX1pjCwkLcvn0bLi4uxWJKTk5GYmJisenp6elwdXV9ZE4ajeaRY6xhdjvTLm/jxo1Gj201b3OrinmbMudbt26ZbFkPY32xnIrWlxlt9CVOf7i+2ANbfW0qorLkIre+sIEiIrvSuHFjZGdno6CgAN999x1iY2OxY8cOq8Y0efJk6abiwP1fiP38/BAREQG1Wl3q83Q6HTQaDbp37w4nJydLhFouzRNMe17GsYT7hyjZet7mUhXzNkfOhj0w5sD6YjnlrS8qB4EZbfSYesgBWr2i2HxDfbEHtv7alEdlygWQX1/YQBGRXVEqlWjUqBEAICQkBAcPHsSCBQvwyiuv4O7du8jPzzf6lTgvLw8+Pj4AAB8fHxw4cMBoeYaraD045uEra+Xl5UGtVpf46zAAqFQqqFSqYtOdnJxk/UGRO87StEXFv6Q8jodztNW8za0q5m3KnM257VhfLKei9UWrV5T4XFvM8VFs9bWpiMqSi9wceBU+IrJrer0eWq0WISEhcHJywtatW6V5J0+exIULFxAWFgYACAsLw9GjR3Hp0iVpjEajgVqtRlBQkDTmwWUYxhiWQURVB+sLEZWEe6CIyG5MnjwZUVFRqF+/Pq5fv460tDRkZGRg8+bNcHd3x/DhwzF+/Hh4enpCrVbjzTffRFhYGNq3bw8AiIiIQFBQEAYPHozZs2cjNzcXU6ZMQVxcnPQL7+jRo/HJJ59g4sSJGDZsGLZt24ZVq1Zhw4YN1kydiMyM9YWI5GIDRUR249KlSxgyZAguXrwId3d3tGjRAps3b0b37t0BAPPmzYODgwP69esHrVaLyMhILFmyRHq+o6Mj1q9fjzFjxiAsLAxubm6IjY1FUlKSNCYgIAAbNmzAuHHjsGDBAtSrVw+fffYZLzFMVMmxvhCRXGygiMhufP7552XOd3Z2xuLFi7F48eJSx/j7+z/yak1dunTB4cOHKxQjEdkn1hcikovnQBEREREREcnEBoqIiIiIiEgmNlBEREREREQy8RwoIiIra56w2WT3XDo3M9okyyGiyoH1hcj0uAeKiIiIiIhIJjZQREREREREMrGBIiIiIiIikokNFBERERERkUxsoIiIiIiIiGRiA0VERERERCQTGygiIiIiIiKZ2EARERERERHJxAaKiIiIiIhIJjZQREREREREMrGBIiIiIiIikokNFBERERERkUxsoIiIiIiIiGQyeQNVVFSEqVOnIiAgAC4uLggMDMSMGTMghJDGCCEwbdo01K1bFy4uLggPD8epU6eMlnP16lUMGjQIarUaHh4eGD58OG7cuGE05siRI+jUqROcnZ3h5+eH2bNnmzodIiIiIiIiickbqFmzZmHp0qX45JNPcOLECcyaNQuzZ8/GokWLpDGzZ8/GwoULsWzZMuzfvx9ubm6IjIzEnTt3pDGDBg1CTk4ONBoN1q9fj507d2LUqFHS/MLCQkRERMDf3x9ZWVn46KOPkJCQgE8//dTUKREREREREQEAqpl6gXv37kXv3r0RHR0NAGjQoAG+/fZbHDhwAMD9vU/z58/HlClT0Lt3bwDAV199BW9vb6xduxYxMTE4ceIENm3ahIMHD6JNmzYAgEWLFqFnz574+OOP4evri9TUVNy9exdffPEFlEolmjVrhuzsbMydO9eo0SIiIiIiIjIVkzdQzzzzDD799FP8/vvveOqpp/Drr79i9+7dmDt3LgDg7NmzyM3NRXh4uPQcd3d3hIaGIjMzEzExMcjMzISHh4fUPAFAeHg4HBwcsH//frz44ovIzMxE586doVQqpTGRkZGYNWsWrl27hpo1axaLTavVQqvVSo8LCwsBADqdDjqdrsR8DNNVDqLE+RVR2roszRCHrcRjKszL+uwhRiIiIqKKMHkD9c4776CwsBBNmjSBo6MjioqK8MEHH2DQoEEAgNzcXACAt7e30fO8vb2lebm5ufDy8jIOtFo1eHp6Go0JCAgotgzDvJIaqOTkZCQmJhabnp6eDldX1zLzmtFGX+b88ti4caPJlmUKGo3G2iGYBfOynlu3bpllucnJyVizZg1+++03uLi44JlnnsGsWbPQuHFjaUyXLl2wY8cOo+e9/vrrWLZsmfT4woULGDNmDLZv347q1asjNjYWycnJqFbt/0piRkYGxo8fj5ycHPj5+WHKlCkYOnSoWfKqKhq8swEAoHIUmN0OaJ6wGdoiRYWXd25mtKlCI2J9sXOG+mIKrC30KCZvoFatWoXU1FSkpaVJh9WNHTsWvr6+iI2NNfXqymXy5MkYP3689LiwsBB+fn6IiIiAWq0u8Tk6nQ4ajQZTDzlAq6/4H/oHHUuINMlyHpcht+7du8PJycna4ZgM87I+w95dU9uxYwfi4uLQtm1b3Lt3D++++y4iIiJw/PhxuLm5SeNGjhyJpKQk6fGDP5AUFRUhOjoaPj4+2Lt3Ly5evIghQ4bAyckJH374IYD7e8qjo6MxevRopKamYuvWrRgxYgTq1q2LyEjb+PwSkWmxvhCRXCZvoCZMmIB33nkHMTExAIDg4GCcP38eycnJiI2NhY+PDwAgLy8PdevWlZ6Xl5eHVq1aAQB8fHxw6dIlo+Xeu3cPV69elZ7v4+ODvLw8ozGGx4YxD1OpVFCpVMWmOzk5PfILqVaveKxfSh9eny2Rk789Yl7WY674Nm3aZPQ4JSUFXl5eyMrKQufOnaXprq6updaB9PR0HD9+HFu2bIG3tzdatWqFGTNmYNKkSUhISIBSqcSyZcsQEBCAOXPmAACaNm2K3bt3Y968efyCQ1RJsb4QkVwmb6Bu3boFBwfji/s5OjpCr79/CFxAQAB8fHywdetWqWEqLCzE/v37MWbMGABAWFgY8vPzkZWVhZCQEADAtm3boNfrERoaKo157733oNPppC9rGo0GjRs3LvHwPSKqfAoKCgAAnp6eRtNTU1PxzTffwMfHB7169cLUqVOlX4kzMzMRHBxsdBhxZGQkxowZg5ycHLRu3RqZmZlG52kaxowdO7bEOCpyfqVhPmC751iqHE0Xl9Fy/3++j5u3vZ1rZ0/nMZqKOXK21PZjfSl9maZQ3vpiqrohh7nfY5WpFlSmXAD5eZi8gerVqxc++OAD1K9fH82aNcPhw4cxd+5cDBs2DACgUCgwduxYvP/++3jyyScREBCAqVOnwtfXF3369AFw/9eYHj16YOTIkVi2bBl0Oh3i4+MRExMDX19fAMDAgQORmJiI4cOHY9KkSTh27BgWLFiAefPmmTolIrJBer0eY8eORYcOHdC8eXNp+sCBA+Hv7w9fX18cOXIEkyZNwsmTJ7FmzRoA98+RLOkcTMO8ssYUFhbi9u3bcHFxMZr3OOdXArZ7juXsdiZbVIkeN29bO59ULns4j9HUTJmzuc6xfBDrS8lsob6YMp/SWKq2VKZaUFlykVtfTN5ALVq0CFOnTsUbb7yBS5cuwdfXF6+//jqmTZsmjZk4cSJu3ryJUaNGIT8/Hx07dsSmTZvg7OwsjUlNTUV8fDy6desGBwcH9OvXDwsXLpTmu7u7Iz09HXFxcQgJCUHt2rUxbdo0XsKcqIqIi4vDsWPHsHv3bqPpD9aA4OBg1K1bF926dcOZM2cQGBhollgqcn4lYPvnWDZP2GyyZT1I5SAwo43+sfO2lfNJ5bKn8xhNxRw5m+scywexvpTMmvXFVHVDDnPXlspUCypTLoD8+mLyBqpGjRqYP38+5s+fX+oYhUKBpKQko5MwH+bp6Ym0tLQy19WiRQvs2rWroqESkZ2Kj4+XbrBdr169MscaDvs9ffo0AgMD4ePjI92XzuDh8ydLO8dSrVYX+3UYeLzzKwHbPcfSVDGVuvzHzNte/1jbw3mMpmbKnM297VhfSmcL9cWU+ZTGUp/PylQLKksucnNwePQQIiLbIIRAfHw8fvjhB2zbtq3YrQxKkp2dDQDSRWvCwsJw9OhRowvVaDQaqNVqBAUFSWO2bt1qtByNRoOwsDATZUJEtob1hYjkYgNFRHYjLi4O33zzDdLS0lCjRg3k5uYiNzcXt2/fBgCcOXMGM2bMQFZWFs6dO4d169ZhyJAh6Ny5M1q0aAEAiIiIQFBQEAYPHoxff/0VmzdvxpQpUxAXFyf9yjt69Gj88ccfmDhxIn777TcsWbIEq1atwrhx46yWOxGZF+sLEcnFBoqI7MbSpUtRUFCALl26oG7dutK/lStXAgCUSiW2bNmCiIgINGnSBP/+97/Rr18//PTTT9IyHB0dsX79ejg6OiIsLAyvvvoqhgwZYnRIcUBAADZs2ACNRoOWLVtizpw5+Oyzz3iJYaJKjPWFiOQy+TlQRETmIkTZl6/18/PDjh07Hrkcf3//R15lqUuXLjh8+HC54iMi+8X6QkRycQ8UERERERGRTGygiIiIiIiIZGIDRUREREREJBMbKCIiIiIiIpnYQBEREREREcnEBoqIiIiIiEgmNlBEREREREQysYEiIiIiIiKSiQ0UERERERGRTGygiIiIiIiIZGIDRUREREREJBMbKCIiIiIiIpnYQBEREREREcnEBoqIiIiIiEgmNlBEREREREQysYEiIiIiIiKSiQ0UERERERGRTGygiIiIiIiIZGIDRUREREREJBMbKCIiIiIiIpnYQBGR3UhOTkbbtm1Ro0YNeHl5oU+fPjh58qTRmDt37iAuLg61atVC9erV0a9fP+Tl5RmNuXDhAqKjo+Hq6govLy9MmDAB9+7dMxqTkZGBp59+GiqVCo0aNUJKSoq50yMiK2J9ISK52EARkd3YsWMH4uLisG/fPmg0Guh0OkRERODmzZvSmHHjxuGnn37C6tWrsWPHDvz999/o27evNL+oqAjR0dG4e/cu9u7diy+//BIpKSmYNm2aNObs2bOIjo7Gc889h+zsbIwdOxYjRozA5s2bLZovEVkO6wsRyVXN2gEQEcm1adMmo8cpKSnw8vJCVlYWOnfujIKCAnz++edIS0tD165dAQDLly9H06ZNsW/fPrRv3x7p6ek4fvw4tmzZAm9vb7Rq1QozZszApEmTkJCQAKVSiWXLliEgIABz5swBADRt2hS7d+/GvHnzEBkZafG8icj8WF+ISC7ugSIiu1VQUAAA8PT0BABkZWVBp9MhPDxcGtOkSRPUr18fmZmZAIDMzEwEBwfD29tbGhMZGYnCwkLk5ORIYx5chmGMYRlEVPmxvhBRabgHiojskl6vx9ixY9GhQwc0b94cAJCbmwulUgkPDw+jsd7e3sjNzZXGPPjlxjDfMK+sMYWFhbh9+zZcXFyM5mm1Wmi1WulxYWEhAECn00Gn05Wag2GeykHIylmOstZXXipH08VltNz/n+/j5m3KXC3BEK+9xf04zJGzJbYf60vZyzSF8tYXU9UNOcz9HqtMtaAy5QLIz8MsDdRff/2FSZMm4eeff8atW7fQqFEjLF++HG3atAEACCEwffp0/Pe//0V+fj46dOiApUuX4sknn5SWcfXqVbz55pv46aef4ODggH79+mHBggWoXr26NObIkSOIi4vDwYMHUadOHbz55puYOHGiOVIiIhsTFxeHY8eOYffu3dYOBcnJyUhMTCw2PT09Ha6uro98/ow2epPFsnHjRpMta3Y7ky2qRI+btylztSSNRmPtECzOlDnfunXLZMsqDetLyWyhvpgyn9JYqrZUplpQWXKRW19M3kBdu3YNHTp0wHPPPYeff/4ZderUwalTp1CzZk1pzOzZs7Fw4UJ8+eWXCAgIwNSpUxEZGYnjx4/D2dkZADBo0CBcvHhROpHztddew6hRo5CWlgbg/i8wERERCA8Px7Jly3D06FEMGzYMHh4eGDVqlKnTIiIbEh8fj/Xr12Pnzp2oV6+eNN3Hxwd3795Ffn6+0a/EeXl58PHxkcYcOHDAaHmGq2g9OObhK2vl5eVBrVYX+3UYACZPnozx48dLjwsLC+Hn54eIiAio1epS89DpdNBoNJh6yAFavUJm9mU7lmC6cyiaJ5jnpHaVg8CMNvrHztuUuVqC4fXu3r07nJycrB2ORZgjZ8MeGHNhfSmdNeuLqeqGHOauLZWpFlSmXAD59cXkDdSsWbPg5+eH5cuXS9MCAgKk/xdCYP78+ZgyZQp69+4NAPjqq6/g7e2NtWvXIiYmBidOnMCmTZtw8OBBaa/VokWL0LNnT3z88cfw9fVFamoq7t69iy+++AJKpRLNmjVDdnY25s6dywaKqJISQuDNN9/EDz/8gIyMDKPaAgAhISFwcnLC1q1b0a9fPwDAyZMnceHCBYSFhQEAwsLC8MEHH+DSpUvw8vICcP+XM7VajaCgIGnMw79AajQaaRkPU6lUUKlUxaY7OTnJ+oOi1SugLTLNFwJT/gEzVUylLv8x87bXP9Zy3xeViSlzNte2Y315NFuoL6bMpzSW+nxWplpQWXKRm4PJLyKxbt06tGnTBi+//DK8vLzQunVr/Pe//5Xmnz17Frm5uUYnULq7uyM0NNToJEwPDw+peQKA8PBwODg4YP/+/dKYzp07Q6lUSmMiIyNx8uRJXLt2zdRpEZENiIuLwzfffIO0tDTUqFEDubm5yM3Nxe3btwHcryXDhw/H+PHjsX37dmRlZeG1115DWFgY2rdvDwCIiIhAUFAQBg8ejF9//RWbN2/GlClTEBcXJ31JGT16NP744w9MnDgRv/32G5YsWYJVq1Zh3LhxVsudiMyL9YWI5DL5Hqg//vgDS5cuxfjx4/Huu+/i4MGDeOutt6BUKhEbGyudRFnSCZQPnmBp+OVGCrRaNXh6ehqNefjXoQdP1HzwkEGDipyIaesnYT6OynbinwHzsj5zxbh06VIAQJcuXYymL1++HEOHDgUAzJs3TzpvUqvVIjIyEkuWLJHGOjo6Yv369RgzZgzCwsLg5uaG2NhYJCUlSWMCAgKwYcMGjBs3DgsWLEC9evXw2Wef8RLDRJUY6wsRyWXyBkqv16NNmzb48MMPAQCtW7fGsWPHsGzZMsTGxpp6deXyOCdi2upJmKZQWU78exjzsh5zneQtxKN/yHB2dsbixYuxePHiUsf4+/s/8nPYpUsXHD58uNwxEpF9Yn0hIrlM3kDVrVtXOs7XoGnTpvj+++8B/N9JlHl5eahbt640Ji8vD61atZLGXLp0yWgZ9+7dw9WrVx95EuaD63hYRU7EtPWTMB9HZTvxz4B5WZ+5T/ImIiIishaTN1AdOnTAyZMnjab9/vvv8Pf3B3B/17WPjw+2bt0qNUyFhYXYv38/xowZA+D+CZb5+fnIyspCSEgIAGDbtm3Q6/UIDQ2Vxrz33nvQ6XTSl0mNRoPGjRuXePge8HgnYtrqSZimUFlO/HsY87IeW4+PiIiIqKJMfhGJcePGYd++ffjwww9x+vRppKWl4dNPP0VcXBwAQKFQYOzYsXj//fexbt06HD16FEOGDIGvry/69OkD4P4eqx49emDkyJE4cOAA9uzZg/j4eMTExMDX1xcAMHDgQCiVSgwfPhw5OTlYuXIlFixYYLSHiYiIiIiIyJRMvgeqbdu2+OGHHzB58mQkJSUhICAA8+fPx6BBg6QxEydOxM2bNzFq1Cjk5+ejY8eO2LRpk3QPKABITU1FfHw8unXrJp2wuXDhQmm+u7s70tPTERcXh5CQENSuXRvTpk3jJcyJiIiIiMhsTN5AAcDzzz+P559/vtT5CoUCSUlJRleleZinp6d009zStGjRArt27apwnEREREREROVh8kP4iIiIiIiIKis2UERERERERDKxgSIiIiIiIpKJDRQREREREZFMbKCIiIiIiIhkYgNFREREREQkExsoIiIiIiIimdhAERERERERycQGioiIiIiISCY2UERERERERDKxgSIiIiIiIpKJDRQREREREZFM1awdABERmU6DdzZYOwQiqqRYX4ju4x4oIiIiIiIimdhAERERERERycQGioiIiIiISCY2UERkN3bu3IlevXrB19cXCoUCa9euNZo/dOhQKBQKo389evQwGnP16lUMGjQIarUaHh4eGD58OG7cuGE05siRI+jUqROcnZ3h5+eH2bNnmzs1IrIy1hcikosNFBHZjZs3b6Jly5ZYvHhxqWN69OiBixcvSv++/fZbo/mDBg1CTk4ONBoN1q9fj507d2LUqFHS/MLCQkRERMDf3x9ZWVn46KOPkJCQgE8//dRseRGR9bG+EJFcvAofEdmNqKgoREVFlTlGpVLBx8enxHknTpzApk2bcPDgQbRp0wYAsGjRIvTs2RMff/wxfH19kZqairt37+KLL76AUqlEs2bNkJ2djblz5xp9ESLrM+UVwc7NjDbZssg+sb6QgamvNsj6UvmwgSKiSiUjIwNeXl6oWbMmunbtivfffx+1atUCAGRmZsLDw0P6cgMA4eHhcHBwwP79+/Hiiy8iMzMTnTt3hlKplMZERkZi1qxZuHbtGmrWrFlsnVqtFlqtVnpcWFgIANDpdNDpdKXGapinchCPl7SdMeRrS3mX9TqZeh2WWJetMEfO1tx+rC/WY4t1Q66HX6fKVAsqUy6A/DzYQBFRpdGjRw/07dsXAQEBOHPmDN59911ERUUhMzMTjo6OyM3NhZeXl9FzqlWrBk9PT+Tm5gIAcnNzERAQYDTG29tbmlfSF5zk5GQkJiYWm56eng5XV9dHxj2jjV52jpWJLeW9ceNGi61Lo9FYbF22wpQ537p1y2TLKg/WF9tgj/mUVl8qUy2oLLnIrS9soIio0oiJiZH+Pzg4GC1atEBgYCAyMjLQrVs3s6138uTJGD9+vPS4sLAQfn5+iIiIgFqtLvV5Op0OGo0GUw85QKtXmC0+W6NyEJjRRm9TeR9LiDT7Ogyvd/fu3eHk5GT29dkCc+Rs2ANjaawv1mWLdUOuh+tLZaoFlSkXQH59YQNF/6+9e4+Oor7/P/7a3DYESMItCSkBgygX5WaCYbkVJSRgtFJpFaWAluJXGvwWU7XSn+UitlEUUDSKVgVtpaA9gggUEoNcDSCRlIuWguI3UkkQkISAJJtkfn94MnXNhQE2u9nN83FOzmFnPjv7fk+ST/bF7MwAfqtr165q3769Dh8+rBEjRigmJkbHjx93GVNZWalTp06Z5zXExMSouLjYZUzN4/rOfbDb7bLb7bWWBwcHW/qDUl5tU3mVb70hcIem1Lcn//Bb/bnwJ+7suansO+YX7/DFfur7PvnTXOAvvVjtgavwAfBbR48e1cmTJ9WxY0dJksPh0OnTp5Wfn2+O2bhxo6qrq5WUlGSO2bJli8vnoHNyctS9e/c6P14DoHlifgGaLwIUAJ9RVlamgoICFRQUSJKOHDmigoICFRYWqqysTA899JB27NihL774Qrm5ubr11lvVrVs3paZ+9/GJnj17atSoUZoyZYp27dql7du3a9q0aRo3bpxiY2MlSXfddZdCQkI0efJkHThwQCtWrNCzzz7r8hEaAP6H+QWAVQQoAD5j9+7d6t+/v/r37y9JysjIUP/+/TVz5kwFBgZq7969+slPfqKrr75akydPVkJCgrZu3ery8Zc333xTPXr00IgRI3TTTTdpyJAhLvdgiYiIUHZ2to4cOaKEhAT99re/1cyZM7nEMODnmF8AWMU5UAB8xvDhw2UY9V/CdsOGDRfcRtu2bbVs2bIGx/Tp00dbt2696PoA+C7mFwBWcQQKAAAAACwiQAEAAACARQQoAAAAALCo0QPUE088IZvNpunTp5vLzp8/r/T0dLVr106tWrXS2LFja90XobCwUGlpaQoLC1NUVJQeeughVVZWuozZtGmTrrvuOtntdnXr1k1Lly5t7HYAAAAANGONGqA++ugjvfTSS+rTp4/L8gceeEDvvfee3n77bW3evFlfffWVbrvtNnN9VVWV0tLSVFFRoQ8//FCvv/66li5dqpkzZ5pjjhw5orS0NN1www0qKCjQ9OnT9atf/crSSZ4AAAAAcCkaLUCVlZVp/Pjx+vOf/+xyc7iSkhK9+uqrWrBggW688UYlJCRoyZIl+vDDD7Vjxw5JUnZ2tj755BP99a9/Vb9+/TR69GjNnTtXWVlZqqiokCQtXrxY8fHxmj9/vnr27Klp06bpZz/7mRYuXNhYLQEAAABo5hrtMubp6elKS0tTcnKyHn/8cXN5fn6+nE6nkpOTzWU9evRQ586dlZeXp4EDByovL0+9e/dWdHS0OSY1NVVTp07VgQMH1L9/f+Xl5blso2bM9z8q+EPl5eUqLy83H5eWlkqSnE6ny13Bv69muT2g/kubXqz6XsvTaupoKvW4C315ny/UCAAAcCkaJUAtX75cH3/8sT766KNa64qKihQSEqLIyEiX5dHR0SoqKjLHfD881ayvWdfQmNLSUn377bdq0aJFrdfOzMzUnDlzai3Pzs5WWFhYgz3NTaxucP3FWLdundu25Q45OTneLqFR0Jf3nDt3ztslAAAANAq3B6gvv/xSv/nNb5STk6PQ0FB3b/6yzJgxQxkZGebj0tJSxcXFKSUlReHh4XU+x+l0KicnR3/YHaDyaptb6tg/O9Ut27lcNb2NHDlSwcHB3i7HbejL+2qO7gIAAPgbtweo/Px8HT9+XNddd525rKqqSlu2bNHzzz+vDRs2qKKiQqdPn3Y5ClVcXKyYmBhJUkxMjHbt2uWy3Zqr9H1/zA+v3FdcXKzw8PA6jz5Jkt1ul91ur7U8ODj4gm9Iy6ttKq9yT4Bqam9+rfTvi+jLe5p6fQAAAJfK7ReRGDFihPbt26eCggLzKzExUePHjzf/HRwcrNzcXPM5Bw8eVGFhoRwOhyTJ4XBo3759On78uDkmJydH4eHh6tWrlznm+9uoGVOzDQAAAABwN7cfgWrdurWuvfZal2UtW7ZUu3btzOWTJ09WRkaG2rZtq/DwcN1///1yOBwaOHCgJCklJUW9evXShAkTNG/ePBUVFenRRx9Venq6eQTpvvvu0/PPP6+HH35Yv/zlL7Vx40a99dZbWrt2rbtbAgAAAABJjXgVvoYsXLhQAQEBGjt2rMrLy5WamqoXXnjBXB8YGKg1a9Zo6tSpcjgcatmypSZNmqTHHnvMHBMfH6+1a9fqgQce0LPPPqtOnTrplVdeUWpq0zi/CAAAAID/8UiA2rRpk8vj0NBQZWVlKSsrq97ndOnS5YJXqxs+fLj27NnjjhIBAAAA4IIa7Ua6AAAAAOBvCFAAAAAAYBEBCgAAAAAsIkABAAAAgEUEKAAAAACwiAAFAAAAABYRoAAAAADAIgIUAJ+xZcsW3XLLLYqNjZXNZtOqVatc1huGoZkzZ6pjx45q0aKFkpOTdejQIZcxp06d0vjx4xUeHq7IyEhNnjxZZWVlLmP27t2roUOHKjQ0VHFxcZo3b15jtwbAy5hfAFhFgALgM86ePau+ffvWexPuefPmadGiRVq8eLF27typli1bKjU1VefPnzfHjB8/XgcOHFBOTo7WrFmjLVu26N577zXXl5aWKiUlRV26dFF+fr6eeuopzZ49Wy+//HKj9wfAe5hfAFgV5O0CAMCq0aNHa/To0XWuMwxDzzzzjB599FHdeuutkqQ33nhD0dHRWrVqlcaNG6dPP/1U69ev10cffaTExERJ0nPPPaebbrpJTz/9tGJjY/Xmm2+qoqJCr732mkJCQnTNNdeooKBACxYscHkjBMC/ML8AsIoABcAvHDlyREVFRUpOTjaXRUREKCkpSXl5eRo3bpzy8vIUGRlpvrmRpOTkZAUEBGjnzp366U9/qry8PA0bNkwhISHmmNTUVD355JP65ptv1KZNm1qvXV5ervLycvNxaWmpJMnpdMrpdNZbc806e4Bx6Y37oJp+m1LfDX2f3P0annitpqIxevbG/mN+8b6mOG9Y9cPvkz/NBf7Ui2S9DwIUAL9QVFQkSYqOjnZZHh0dba4rKipSVFSUy/qgoCC1bdvWZUx8fHytbdSsq+sNTmZmpubMmVNreXZ2tsLCwi5Y+9zE6guO8UdNqe9169Z57LVycnI89lpNhTt7PnfunNu2ZRXzS9Phi/3UN7/401zgL71YnV8IUABwmWbMmKGMjAzzcWlpqeLi4pSSkqLw8PB6n+d0OpWTk6M/7A5QebXNE6U2CfYAQ3MTq5tU3/tnpzb6a9R8v0eOHKng4OBGf72moDF6rjkC01wwv3ynKc4bVv1wfvGnucCfepGszy8EKAB+ISYmRpJUXFysjh07msuLi4vVr18/c8zx48ddnldZWalTp06Zz4+JiVFxcbHLmJrHNWN+yG63y26311oeHBxs6Q9KebVN5VW+9YbAHZpS3578w2/158KfuLNnb+w75pemwxf7qe/75E9zgb/0YrUHrsIHwC/Ex8crJiZGubm55rLS0lLt3LlTDodDkuRwOHT69Gnl5+ebYzZu3Kjq6molJSWZY7Zs2eLyOeicnBx17969zo/XAPB/zC8Avo8ABcBnlJWVqaCgQAUFBZK+O7G7oKBAhYWFstlsmj59uh5//HGtXr1a+/bt08SJExUbG6sxY8ZIknr27KlRo0ZpypQp2rVrl7Zv365p06Zp3Lhxio2NlSTdddddCgkJ0eTJk3XgwAGtWLFCzz77rMtHaAD4H+YXAFbxET4APmP37t264YYbzMc1bzomTZqkpUuX6uGHH9bZs2d177336vTp0xoyZIjWr1+v0NBQ8zlvvvmmpk2bphEjRiggIEBjx47VokWLzPURERHKzs5Wenq6EhIS1L59e82cOZNLDAN+jvkFgFUEKAA+Y/jw4TKM+i9ha7PZ9Nhjj+mxxx6rd0zbtm21bNmyBl+nT58+2rp16yXXCcD3ML8AsIqP8AEAAACARQQoAAAAALCIAAUAAAAAFhGgAAAAAMAiAhQAAAAAWESAAgAAAACLCFAAAAAAYBEBCgAAAAAsIkABAAAAgEUEKAAAAACwKMjbBQAA4G1XPLLWrdv74ok0t24PgO/64fxiDzQ073rp2tkbVF5lu+jtMb94n9uPQGVmZmrAgAFq3bq1oqKiNGbMGB08eNBlzPnz55Wenq527dqpVatWGjt2rIqLi13GFBYWKi0tTWFhYYqKitJDDz2kyspKlzGbNm3SddddJ7vdrm7dumnp0qXubgcAAAAATG4PUJs3b1Z6erp27NihnJwcOZ1OpaSk6OzZs+aYBx54QO+9957efvttbd68WV999ZVuu+02c31VVZXS0tJUUVGhDz/8UK+//rqWLl2qmTNnmmOOHDmitLQ03XDDDSooKND06dP1q1/9Shs2bHB3SwAAAAAgqRE+wrd+/XqXx0uXLlVUVJTy8/M1bNgwlZSU6NVXX9WyZct04403SpKWLFminj17aseOHRo4cKCys7P1ySef6P3331d0dLT69eunuXPn6ne/+51mz56tkJAQLV68WPHx8Zo/f74kqWfPntq2bZsWLlyo1NRUd7cFAAAAAI1/EYmSkhJJUtu2bSVJ+fn5cjqdSk5ONsf06NFDnTt3Vl5eniQpLy9PvXv3VnR0tDkmNTVVpaWlOnDggDnm+9uoGVOzDQAAAABwt0a9iER1dbWmT5+uwYMH69prr5UkFRUVKSQkRJGRkS5jo6OjVVRUZI75fniqWV+zrqExpaWl+vbbb9WiRYta9ZSXl6u8vNx8XFpaKklyOp1yOp119lCz3B5gWOrZivpey9Nq6mgq9bgLfXmfL9QIAABwKRo1QKWnp2v//v3atm1bY76MZZmZmZozZ06t5dnZ2QoLC2vwuXMTq91Wx7p169y2LXfIycnxdgmNgr6859y5c94uAQAAoFE0WoCaNm2a1qxZoy1btqhTp07m8piYGFVUVOj06dMuR6GKi4sVExNjjtm1a5fL9mqu0vf9MT+8cl9xcbHCw8PrPPokSTNmzFBGRob5uLS0VHFxcUpJSVF4eHidz3E6ncrJydEfdgeovPriLzVZl/2zm8Y5WjW9jRw5UsHBwd4ux23oy/tqju4CAAD4G7cHKMMwdP/992vlypXatGmT4uPjXdYnJCQoODhYubm5Gjt2rCTp4MGDKiwslMPhkCQ5HA798Y9/1PHjxxUVFSXpu/91Dw8PV69evcwxPzySk5OTY26jLna7XXa7vdby4ODgC74hLa+2XdK1+uvS1N78WunfF9GX9zT1+gAAAC6V2wNUenq6li1bpnfffVetW7c2z1mKiIhQixYtFBERocmTJysjI0Nt27ZVeHi47r//fjkcDg0cOFCSlJKSol69emnChAmaN2+eioqK9Oijjyo9Pd0MQPfdd5+ef/55Pfzww/rlL3+pjRs36q233tLate69GSIAAAAA1HD7VfhefPFFlZSUaPjw4erYsaP5tWLFCnPMwoULdfPNN2vs2LEaNmyYYmJi9M4775jrAwMDtWbNGgUGBsrhcOgXv/iFJk6cqMcee8wcEx8fr7Vr1yonJ0d9+/bV/Pnz9corr3AJc6CZmz17tmw2m8tXjx49zPXuupE3gOaFuQVAjUb5CN+FhIaGKisrS1lZWfWO6dKlywUvtjB8+HDt2bPnomsE4N+uueYavf/+++bjoKD/TnUPPPCA1q5dq7ffflsRERGaNm2abrvtNm3fvl3Sf2/kHRMTow8//FDHjh3TxIkTFRwcrD/96U8e7wVA08HcAkBq5KvwAYA3BAUFmRec+T533cgbQPPE3AJA8sCNdAHA0w4dOqTY2Fh17dpV48ePV2FhoST33cgbQPPE3AJA4ggUAD+TlJSkpUuXqnv37jp27JjmzJmjoUOHav/+/W67kfcPXcpNumvWS+69UbcvqOnXn/uu6/vuSzfDdpfG6Nlb+88bc4vE/FLDn+aNy+2lKc0h/javWe2DAAXAr4wePdr8d58+fZSUlKQuXbrorbfeqvcecZfrcm7SLbn3Rt2+xJ/7bugcXl+4Gba7ubNnb92o2xtzi8T88kP+1M+l9nKhawR4g7/Ma1bnFwIUAL8WGRmpq6++WocPH9bIkSPdciPvH7qUm3RLjXOjbl9gDzA0N7Har/uu64bpvnQzbHdpjJ6byo26PTG3SMwvNfxp3rjcXuqaX7zF3+Y1q/MLAQqAXysrK9Nnn32mCRMmuO1G3j90OTfpltx7o25f4s99N/R994WbYbubO3tuKvvOE3OLxPzyQ/7Uz6X20lR+B77PX+Y1qz0QoAD4lQcffFC33HKLunTpoq+++kqzZs1SYGCg7rzzTrfdyBtA88PcAqAGAQqAXzl69KjuvPNOnTx5Uh06dNCQIUO0Y8cOdejQQdJ3N/IOCAjQ2LFjVV5ertTUVL3wwgvm82tu5D116lQ5HA61bNlSkyZNcrmRN4Dmh7kFQA0CFAC/snz58gbXu+tG3gCaF+YWADW4DxQAAAAAWESAAgAAAACLCFAAAAAAYBEBCgAAAAAsIkABAAAAgEUEKAAAAACwiMuYAwDgZlc8srbWMnugoXnXS9fO3qDyKpvlbX3xRJo7SwPg4+qaXy4V88ul4QgUAAAAAFhEgAIAAAAAiwhQAAAAAGARAQoAAAAALCJAAQAAAIBFBCgAAAAAsIgABQAAAAAWEaAAAAAAwCJupAsAQBPmzptmStw4E8B/Xe788sMbhDeX+YUABbgBb3AAAACaBwKUH7jUN+8//F8DqWm/cbfaZ1191aUp9+pu7gx4zWm/AQAA/BDnQAEAAACARRyBQrPl7o/dAQAAwP8RoLygKb9xb8q1NSd1fR+sfjQRAAAAjcfnP8KXlZWlK664QqGhoUpKStKuXbu8XRIAP8H8AqCxML8Avsunj0CtWLFCGRkZWrx4sZKSkvTMM88oNTVVBw8eVFRUlLfLA+DDmF/gr7iojPcxv8BfNZf5xaePQC1YsEBTpkzRPffco169emnx4sUKCwvTa6+95u3SAPg45hcAjYX5BfBtPnsEqqKiQvn5+ZoxY4a5LCAgQMnJycrLy6vzOeXl5SovLzcfl5SUSJJOnTolp9NZ53OcTqfOnTunIGeAqqr967yToGpD585V+11v9NW4Tp48ecExZ86ckSQZhtHY5TSKi51fLmVukfx7fmlIU/lZ9jR/7PtC80HNz/jJkycVHBzsltdkfmme84s//f7QizVW3m+4m9X5xWcD1IkTJ1RVVaXo6GiX5dHR0frXv/5V53MyMzM1Z86cWsvj4+MbpUZfcJe3C2gk9NV42s+3PvbMmTOKiIhovGIaycXOL8wtF68p/Cx7g7/1fTHzgbsxvzS/+cWffn/o5cKa8vziswHqUsyYMUMZGRnm4+rqap06dUrt2rWTzVZ3ai4tLVVcXJy+/PJLhYeHe6pUj/DX3ujL+wzD0JkzZxQbG+vtUjziUuYWybe+p+5E382n78bomfmlec4v/tQPvTRdVucXnw1Q7du3V2BgoIqLi12WFxcXKyYmps7n2O122e12l2WRkZGWXi88PNwvfjDq4q+90Zd3+eL/DNe42PnlcuYWyXe+p+5G382Hu3tmfom0/Hr+9vPmT/3QS9NkZX7x2YtIhISEKCEhQbm5ueay6upq5ebmyuFweLEyAL6O+QVAY2F+AXyfzx6BkqSMjAxNmjRJiYmJuv766/XMM8/o7Nmzuueee7xdGgAfx/wCoLEwvwC+zacD1B133KGvv/5aM2fOVFFRkfr166f169fXOjHzctjtds2aNavW4XN/4K+90Rfcgfml8dB38+m7OfZsBfPLxfOnfujF99kMX70OKAAAAAB4mM+eAwUAAAAAnkaAAgAAAACLCFAAAAAAYBEBCgAAAAAsIkBdQFZWlq644gqFhoYqKSlJu3bt8nZJDdqyZYtuueUWxcbGymazadWqVS7rDcPQzJkz1bFjR7Vo0ULJyck6dOiQy5hTp05p/PjxCg8PV2RkpCZPnqyysjIPdlFbZmamBgwYoNatWysqKkpjxozRwYMHXcacP39e6enpateunVq1aqWxY8fWulFhYWGh0tLSFBYWpqioKD300EOqrKz0ZCsuXnzxRfXp08e8AZ3D4dA//vEPc70v9gTrfG1+uVjumI98jbvmKl/jjrkM7tXU55fZs2fLZrO5fPXo0cNc39T//nnq/dbevXs1dOhQhYaGKi4uTvPmzfN4L3fffXet79WoUaOaZC8eY6Bey5cvN0JCQozXXnvNOHDggDFlyhQjMjLSKC4u9nZp9Vq3bp3x//7f/zPeeecdQ5KxcuVKl/VPPPGEERERYaxatcr45z//afzkJz8x4uPjjW+//dYcM2rUKKNv377Gjh07jK1btxrdunUz7rzzTg934io1NdVYsmSJsX//fqOgoMC46aabjM6dOxtlZWXmmPvuu8+Ii4szcnNzjd27dxsDBw40Bg0aZK6vrKw0rr32WiM5OdnYs2ePsW7dOqN9+/bGjBkzvNGSYRiGsXr1amPt2rXGv//9b+PgwYPG73//eyM4ONjYv3+/YRi+2ROs8cX55WK5Yz7yNe6Yq3zR5c5lcC9fmF9mzZplXHPNNcaxY8fMr6+//tpc39T//nni/VZJSYkRHR1tjB8/3ti/f7/xt7/9zWjRooXx0ksvebSXSZMmGaNGjXL5Xp06dcplTFPpxVMIUA24/vrrjfT0dPNxVVWVERsba2RmZnqxKut++EtQXV1txMTEGE899ZS57PTp04bdbjf+9re/GYZhGJ988okhyfjoo4/MMf/4xz8Mm81m/Oc///FY7Rdy/PhxQ5KxefNmwzC+6yM4ONh4++23zTGffvqpIcnIy8szDOO7CSIgIMAoKioyx7z44otGeHi4UV5e7tkGGtCmTRvjlVde8aueUJuvzy8X61LmI39wKXOVv7iYuQzu5Qvzy6xZs4y+ffvWuc7X/v411vutF154wWjTpo1LP7/73e+M7t27e6wXw/guQN166631Pqep9tKY+AhfPSoqKpSfn6/k5GRzWUBAgJKTk5WXl+fFyi7dkSNHVFRU5NJTRESEkpKSzJ7y8vIUGRmpxMREc0xycrICAgK0c+dOj9dcn5KSEklS27ZtJUn5+flyOp0uvfXo0UOdO3d26a13794uNypMTU1VaWmpDhw44MHq61ZVVaXly5fr7NmzcjgcftET6uaP88vFsjIf+YNLmat83aXMZXAfX5pfDh06pNjYWHXt2lXjx49XYWGhJN//m+6u91t5eXkaNmyYQkJCzDGpqak6ePCgvvnmGw91851NmzYpKipK3bt319SpU3Xy5Elzna/14g4EqHqcOHFCVVVVte4KHh0draKiIi9VdXlq6m6op6KiIkVFRbmsDwoKUtu2bZtM39XV1Zo+fboGDx6sa6+9VtJ3dYeEhCgyMtJl7A97q6v3mnXesm/fPrVq1Up2u1333XefVq5cqV69evl0T2iYP84vF8vKfOTrLnWu8lWXM5fBfXxlfklKStLSpUu1fv16vfjiizpy5IiGDh2qM2fO+PzfP3e932oqPY4aNUpvvPGGcnNz9eSTT2rz5s0aPXq0qqqqzFp8pRd3CfJ2AcDFSk9P1/79+7Vt2zZvl+IW3bt3V0FBgUpKSvT3v/9dkyZN0ubNm71dFoDL5G9z1YUwl+FijB492vx3nz59lJSUpC5duuitt95SixYtvFgZfmjcuHHmv3v37q0+ffroyiuv1KZNmzRixAgvVuY9HIGqR/v27RUYGFjrii/FxcWKiYnxUlWXp6buhnqKiYnR8ePHXdZXVlbq1KlTTaLvadOmac2aNfrggw/UqVMnc3lMTIwqKip0+vRpl/E/7K2u3mvWeUtISIi6deumhIQEZWZmqm/fvnr22Wd9uic0zB/nl4tlZT7yZZczV/mqy5nL4D6+Or9ERkbq6quv1uHDh33+75+73m811R67du2q9u3b6/Dhw2YtvtrLpSJA1SMkJEQJCQnKzc01l1VXVys3N1cOh8OLlV26+Ph4xcTEuPRUWlqqnTt3mj05HA6dPn1a+fn55piNGzequrpaSUlJHq+5hmEYmjZtmlauXKmNGzcqPj7eZX1CQoKCg4Ndejt48KAKCwtdetu3b5/LL3lOTo7Cw8PVq1cvzzRiQXV1tcrLy/2qJ7jyx/nlYlmZj3yRO+Yqf3Excxncx1fnl7KyMn322Wfq2LGjz//9c9f7LYfDoS1btsjpdJpjcnJy1L17d7Vp08ZD3dR29OhRnTx5Uh07dpTk271cMm9fxaIpW758uWG3242lS5can3zyiXHvvfcakZGRLld8aWrOnDlj7Nmzx9izZ48hyViwYIGxZ88e4//+7/8Mw/juspqRkZHGu+++a+zdu9e49dZb67ysZv/+/Y2dO3ca27ZtM6666iqvX8Z86tSpRkREhLFp0yaXy2ieO3fOHHPfffcZnTt3NjZu3Gjs3r3bcDgchsPhMNfXXPI0JSXFKCgoMNavX2906NDBq5f8fuSRR4zNmzcbR44cMfbu3Ws88sgjhs1mM7Kzsw3D8M2eYI0vzi8Xyx3zka9xx1zliy53LoN7+cL88tvf/tbYtGmTceTIEWP79u1GcnKy0b59e+P48eOGYTT9v3+eeL91+vRpIzo62pgwYYKxf/9+Y/ny5UZYWJjbL/3dUC9nzpwxHnzwQSMvL884cuSI8f777xvXXXedcdVVVxnnz59vcr14CgHqAp577jmjc+fORkhIiHH99dcbO3bs8HZJDfrggw8MSbW+Jk2aZBjGd5fW/MMf/mBER0cbdrvdGDFihHHw4EGXbZw8edK48847jVatWhnh4eHGPffcY5w5c8YL3fxXXT1JMpYsWWKO+fbbb41f//rXRps2bYywsDDjpz/9qXHs2DGX7XzxxRfG6NGjjRYtWhjt27c3fvvb3xpOp9PD3fzXL3/5S6NLly5GSEiI0aFDB2PEiBHmGw7D8M2eYJ2vzS8Xyx3zka9x11zla9wxl8G9mvr8cscddxgdO3Y0QkJCjB/96EfGHXfcYRw+fNhc39T//nnq/dY///lPY8iQIYbdbjd+9KMfGU888YRHezl37pyRkpJidOjQwQgODja6dOliTJkypVYYbyq9eIrNMAyjcY9xAQAAAIB/4BwoAAAAALCIAAUAAAAAFhGgAAAAAMAiAhQAAAAAWESAAgAAAACLCFAAAAAAYBEBCgAAAAAsIkABAAAAgEUEKAAAAACwiAAFAAAAABYRoAAAAADAIgIUAAAAAFhEgAIAAAAAiwhQAAAAAGARAQoAAAAALCJAAQAAAIBFBCgAAAAAsIgABQAAAAAWEaAAAAAAwCICFAAAAABYRICCi9mzZ8tms3m7DBeVlZV6+OGHFRcXp4CAAI0ZM8bbJdXyxRdfyGaz6emnn/Z2KQAAAGhEBCh4nNPp1KJFizRgwAC1bt1arVq10oABA7Ro0SI5nc5a41977TU99dRT+tnPfqbXX39dDzzwgMLDw3XrrbfWGrtw4ULZbDZNmjSp1rqZM2fKZrPp3//+d6P0BQAAAP8X5O0C0LycPXtWaWlp2rx5s26++WbdfffdCggI0Pr16/Wb3/xG77zzjtauXauWLVuaz9m4caN+9KMfaeHCheaygQMH6sMPP6y1/e3btysoKEjbt2+vc11UVJSuvvrqxmkOAAAAfo8jUPCojIwMbd68Wc8995zee+89paena+rUqXr33Xf1/PPPa/PmzXrwwQddnnP8+HFFRka6LBsyZIhOnDihTz/91GX59u3bdfvtt+uzzz5TUVGRubyyslI7d+7U4MGDG603AAAA+D8CVDO2bds2DRgwQKGhobryyiv10ksv1RqzZMkS3XjjjYqKipLdblevXr304osvuoyZNGmS2rdvX+fH71JSUtS9e3dJ0tGjR/Xqq6/qxhtv1LRp02qNTU9P1w033KBXXnlFR48eNc8r+uCDD3TgwAHZbDbZbDZt2rRJQ4YMkSSXI02ff/65ioqKNG3aNIWGhrqsKygo0NmzZ83nSdK//vUv/exnP1Pbtm0VGhqqxMRErV69ulZdp0+f1vTp0xUXFye73a5u3brpySefVHV1dYP71zAM3XvvvQoJCdE777zT4FgAAAD4BgJUM7Vv3z6lpKTo+PHjmj17tu655x7NmjVLK1eudBn34osvqkuXLvr973+v+fPnKy4uTr/+9a+VlZVljpkwYYJOnjypDRs2uDy3qKhIGzdu1C9+8QtJ0j/+8Q9VVVVp4sSJ9dY1ceJEVVZWav369erQoYP+8pe/qEePHurUqZP+8pe/6C9/+Yt69uypgQMHKigoSNu2bTOfu337drVs2VIDBgxQYmKiS4Cq+XdNgDpw4IAGDhyoTz/9VI888ojmz5+vli1basyYMS774Ny5c/rxj3+sv/71r5o4caIWLVqkwYMHa8aMGcrIyKi3j6qqKt1999164403tHLlSt122231jgUAAIAPMdAsjRkzxggNDTX+7//+z1z2ySefGIGBgcb3fyzOnTtX67mpqalG165dzcdVVVVGp06djDvuuMNl3IIFCwybzWZ8/vnnhmEYxvTp0w1Jxp49e+qt6+OPPzYkGRkZGeayH//4x8Y111xTa+yAAQOMK6+80nz8P//zP8YNN9xgGIZhPPzww8aAAQPMdT/72c+MsLAww+l0GoZhGCNGjDB69+5tnD9/3hxTXV1tDBo0yLjqqqvMZXPnzjVatmxp/Pvf/3Z57UceecQIDAw0CgsLDcMwjCNHjhiSjKeeespwOp3GHXfcYbRo0cLYsGFDvb0CAADA93AEqhmqqqrShg0bNGbMGHXu3Nlc3rNnT6WmprqMbdGihfnvkpISnThxQj/+8Y/1+eefq6SkRJIUEBCg8ePHa/Xq1Tpz5ow5/s0339SgQYMUHx8vSea61q1b11tbzbrS0tIL9jFkyBCXc522b9+uQYMGSZIGDx6sPXv26Ny5c+a6pKQkBQUF6dSpU9q4caNuv/12nTlzRidOnNCJEyd08uRJpaam6tChQ/rPf/4jSXr77bc1dOhQtWnTxhx34sQJJScnq6qqSlu2bHGpqaKiQj//+c+1Zs0arVu3TikpKRfsAwAAAL6DANUMff311/r222911VVX1VpXc75Sje3btys5OVktW7ZUZGSkOnTooN///veSZAYo6buP3n377bfmx98OHjyo/Px8TZgwwRxTE46+H7J+yErIqvH986BOnz6tAwcOmBeJGDRokCorK7Vr1y4dOXJEx44dM8cfPnxYhmHoD3/4gzp06ODyNWvWLEnfXbhCkg4dOmR+nPD7X8nJyS7jamRmZmrVqlX6+9//ruHDh1+wBwAAAPgWLmOOen322WcaMWKEevTooQULFiguLk4hISFat26dFi5c6HIRhV69eikhIcE8V+ivf/2rQkJCdPvtt5tjevbsKUnau3ev+vXrV+dr7t2719zehdQEom3btiksLEyS5HA4JEnt27fXVVddpW3btunLL790GV9T94MPPljriFuNbt26mWNHjhyphx9+uM5xP7wkempqqtavX6958+Zp+PDhCg0NvWAfAAAA8B0EqGaoQ4cOatGihQ4dOlRr3cGDB81/v/feeyovL9fq1atdPur3wQcf1LndiRMnKiMjQ8eOHdOyZcuUlpamNm3amOtHjx6twMBA/eUvf6n3QhJvvPGGgoKCNGrUqAv2ERUVZYakli1bqlevXi6XOx80aJC2b9+uo0ePKjAw0AxXXbt2lSQFBwebR5Lqc+WVV6qsrOyC42oMHDhQ9913n26++Wb9/Oc/18qVKxUUxK8ZAACAv+AjfM1QYGCgUlNTtWrVKhUWFprLP/30U5cr6QUGBkr67nLcNUpKSrRkyZI6t3vnnXfKZrPpN7/5jT7//HPz6ns14uLidM899+j999+vdSl0SVq8eLE2btyoyZMnq1OnTpZ6GTJkiAoKCpSdnW2e/1Rj0KBBysvL09atW9WnTx/zY4FRUVEaPny4XnrpJR07dqzWNr/++mvz37fffrvy8vJqXWFQ+u7y5pWVlbWWJycna/ny5Vq/fr0mTJhwwcudAwAAwHfwX+PN1Jw5c7R+/XoNHTpUv/71r1VZWannnntO11xzjfkxupSUFIWEhOiWW27R//zP/6isrEx//vOfFRUVVWfw6NChg0aNGqW3335bkZGRSktLqzVm4cKF+te//qVf//rXWr9+vXmkacOGDXr33Xf14x//WPPnz7fcx5AhQ7RkyRJ99NFHSk9Pd1k3aNAglZSUqKSkRPfff7/LuqysLA0ZMkS9e/fWlClT1LVrVxUXFysvL09Hjx7VP//5T0nSQw89pNWrV+vmm2/W3XffrYSEBJ09e1b79u3T3//+d33xxRdq3759rbrGjBmjJUuWaOLEiQoPD6/zHlsAAADwQd6+DCC8Z/PmzUZCQoIREhJidO3a1Vi8eLExa9Ysl8uYr1692ujTp48RGhpqXHHFFcaTTz5pvPbaa4Yk48iRI7W2+dZbbxmSjHvvvbfe1y0vLzcWLlxoJCQkGC1btjTCwsKM6667znjmmWeMioqKWuPru4y5YRjGwYMHDUmGpFqXGq+urjYiIyMNScaKFStqPfezzz4zJk6caMTExBjBwcHGj370I+Pmm282/v73v7uMO3PmjDFjxgyjW7duRkhIiNG+fXtj0KBBxtNPP23W+/3LmH/fCy+8YEgyHnzwwXr3BwAAAHyHzTC+9/ks4DK9++67GjNmjLZs2aKhQ4d6uxwAAADArQhQcKubb75Zn376qQ4fPiybzebtcgAAAAC34hwouMXy5cu1d+9erV27Vs8++yzhCQAAAH6JI1BwC5vNplatWumOO+7Q4sWLuXQ3AAAA/BLvcuEW5HAAAAA0B9wHCgAAAAAsIkABAAAAgEXN+iN81dXV+uqrr9S6dWsuegC4kWEYOnPmjGJjYxUQwP/TAAAA/9GsA9RXX32luLg4b5cB+K0vv/xSnTp18nYZAAAAbtOsA1Tr1q0lffcmLzw8vM4xTqdT2dnZSklJUXBwsCfLa1LYD+wDyfo+KC0tVVxcnPk7BgAA4C+adYCq+dheeHh4gwEqLCxM4eHhzfZNs8R+kNgH0sXvAz4aCwAA/A0nJwAAAACARQQoAAAAALCIAAUAAAAAFhGgAAAAAMAiAhQAAAAAWESAAgAAAACL3B6gMjMzNWDAALVu3VpRUVEaM2aMDh486DLm/PnzSk9PV7t27dSqVSuNHTtWxcXFLmMKCwuVlpamsLAwRUVF6aGHHlJlZaXLmE2bNum6666T3W5Xt27dtHTpUne3AwAAAAAmtweozZs3Kz09XTt27FBOTo6cTqdSUlJ09uxZc8wDDzyg9957T2+//bY2b96sr776Srfddpu5vqqqSmlpaaqoqNCHH36o119/XUuXLtXMmTPNMUeOHFFaWppuuOEGFRQUaPr06frVr36lDRs2uLslAAAAAJDUCDfSXb9+vcvjpUuXKioqSvn5+Ro2bJhKSkr06quvatmyZbrxxhslSUuWLFHPnj21Y8cODRw4UNnZ2frkk0/0/vvvKzo6Wv369dPcuXP1u9/9TrNnz1ZISIgWL16s+Ph4zZ8/X5LUs2dPbdu2TQsXLlRqaqq729K1szeovMo9NwX94ok0t2wHAAAAgGc1+jlQJSUlkqS2bdtKkvLz8+V0OpWcnGyO6dGjhzp37qy8vDxJUl5ennr37q3o6GhzTGpqqkpLS3XgwAFzzPe3UTOmZhsAAAAA4G5uPwL1fdXV1Zo+fboGDx6sa6+9VpJUVFSkkJAQRUZGuoyNjo5WUVGROeb74almfc26hsaUlpbq22+/VYsWLWrVU15ervLycvNxaWmpJMnpdMrpdNbZQ81ye4BhqWcr6nutpqymZl+s3V3YB9b3QXPeRwAAwL81aoBKT0/X/v37tW3btsZ8GcsyMzM1Z86cWsuzs7MVFhbW4HPnJla7rY5169a5bVuelpOT4+0SvI59cOF9cO7cOQ9VAgAA4FmNFqCmTZumNWvWaMuWLerUqZO5PCYmRhUVFTp9+rTLUaji4mLFxMSYY3bt2uWyvZqr9H1/zA+v3FdcXKzw8PA6jz5J0owZM5SRkWE+Li0tVVxcnFJSUhQeHl7nc5xOp3JycvSH3QEqr3bPOVD7Z7v/HK3GVrMfRo4cqeDgYG+X4xbXzr64C47YAwzNTayu82fBF7+nl8Lqz0HN0V0AAAB/4/YAZRiG7r//fq1cuVKbNm1SfHy8y/qEhAQFBwcrNzdXY8eOlSQdPHhQhYWFcjgckiSHw6E//vGPOn78uKKioiR99z/e4eHh6tWrlznmh0dycnJyzG3UxW63y26311oeHBx8wVBQXm1z20UkfDmAWNlXvuJSv591/Sz4yz6x6kI/B81tfwAAgObD7QEqPT1dy5Yt07vvvqvWrVub5yxFRESoRYsWioiI0OTJk5WRkaG2bdsqPDxc999/vxwOhwYOHChJSklJUa9evTRhwgTNmzdPRUVFevTRR5Wenm4GoPvuu0/PP/+8Hn74Yf3yl7/Uxo0b9dZbb2nt2rXubgkAAAAAJDXCVfhefPFFlZSUaPjw4erYsaP5tWLFCnPMwoULdfPNN2vs2LEaNmyYYmJi9M4775jrAwMDtWbNGgUGBsrhcOgXv/iFJk6cqMcee8wcEx8fr7Vr1yonJ0d9+/bV/Pnz9corrzTKJcwBAAAAQGqkj/BdSGhoqLKyspSVlVXvmC5dulzwYgvDhw/Xnj17LrpG1O+KR+o+gmcPNDTv+ou/Hxb3vAIAAIA/adSr8KFu9YWUS0VIAQAAADyj0W+kCwAAAAD+giNQ8BnuPnLXlHGUEgAAoGniCBQAAAAAWESAAgAAAACLCFAAAAAAYBEBCgAAAAAsIkABAAAAgEUEKAAAAACwiAAFAAAAABYRoAAAAADAIgIUAAAAAFhEgAIAAAAAiwhQAAAAAGARAQoAAAAALCJAAQAAAIBFBCgAAAAAsIgABQAAAAAWEaAAAAAAwCICFAAAAABYRIACAAAAAIsIUAAAAABgEQEKAAAAACwiQAEAAACARQQoAAAAALCIAAUAAAAAFhGgAAAAAMAiAhQAAAAAWESAAgAAAACLCFAAAAAAYBEBCgAAAAAsIkABAAAAgEUEKAAAAACwiAAFAAAAABYRoAAAAADAIgIUAAAAAFhEgAIAAAAAiwhQAAAAAGARAQoAAAAALCJAAQAAAIBFbg9QW7Zs0S233KLY2FjZbDatWrXKZf3dd98tm83m8jVq1CiXMadOndL48eMVHh6uyMhITZ48WWVlZS5j9u7dq6FDhyo0NFRxcXGaN2+eu1sBAAAAABduD1Bnz55V3759lZWVVe+YUaNG6dixY+bX3/72N5f148eP14EDB5STk6M1a9Zoy5Ytuvfee831paWlSklJUZcuXZSfn6+nnnpKs2fP1ssvv+zudgAAAADAFOTuDY4ePVqjR49ucIzdbldMTEyd6z799FOtX79eH330kRITEyVJzz33nG666SY9/fTTio2N1ZtvvqmKigq99tprCgkJ0TXXXKOCggItWLDAJWgBAAAAgDu5PUBZsWnTJkVFRalNmza68cYb9fjjj6tdu3aSpLy8PEVGRprhSZKSk5MVEBCgnTt36qc//any8vI0bNgwhYSEmGNSU1P15JNP6ptvvlGbNm3qfN3y8nKVl5ebj0tLSyVJTqdTTqezzufULLcHGJfXdCOqr/ZLYQ+su8+a/i92P3iiNk9paB+4s0/J/b26q76a7Vxoe+7eHwAAAE2FxwPUqFGjdNtttyk+Pl6fffaZfv/732v06NHKy8tTYGCgioqKFBUV5VpkUJDatm2roqIiSVJRUZHi4+NdxkRHR5vr6gtQmZmZmjNnTq3l2dnZCgsLa7DuuYnVlnv0tHXr1rltW/Oub3j9xe4HT9bmKXXtA3f2Kbm/V3fXl5OT0+D6c+fOufX1AAAAmgqPB6hx48aZ/+7du7f69OmjK6+8Ups2bdKIESMa9bVnzJihjIwM83Fpaani4uKUkpKi8PDwOp/jdDqVk5OjP+wOUHm1rVHru1T7Z6e6bVvXzt5Q53J7gKG5idUXvR88UZunNLQP3Nmn5P5e3VVfze/DyJEjFRwcXO+4mqO7AAAA/sYrH+H7vq5du6p9+/Y6fPiwRowYoZiYGB0/ftxlTGVlpU6dOmWeNxUTE6Pi4mKXMTWP6zu3Svru3Cu73V5reXBwcINvBiWpvNqm8qqmGaAuVPvFuFCPF7sfPFmbp9S1D9zZp+T+Xt1d34V+Z9z9egAAAE2F1+8DdfToUZ08eVIdO3aUJDkcDp0+fVr5+fnmmI0bN6q6ulpJSUnmmC1btricZ5GTk6Pu3bvX+/E9AAAAALhcbg9QZWVlKigoUEFBgSTpyJEjKigoUGFhocrKyvTQQw9px44d+uKLL5Sbm6tbb71V3bp1U2rqdx8x6tmzp0aNGqUpU6Zo165d2r59u6ZNm6Zx48YpNjZWknTXXXcpJCREkydP1oEDB7RixQo9++yzLh/PAwAAAAB3c3uA2r17t/r376/+/ftLkjIyMtS/f3/NnDlTgYGB2rt3r37yk5/o6quv1uTJk5WQkKCtW7e6fLTuzTffVI8ePTRixAjddNNNGjJkiMs9niIiIpSdna0jR44oISFBv/3tbzVz5kwuYQ4AAACgUbn9HKjhw4fLMOq/BPOGDRc+Ob5t27ZatmxZg2P69OmjrVu3XnR9AAAAAHCpvH4OFAAAAAD4CgIUAAAAAFhEgAIAAAAAiwhQAAAAAGARAQoAAAAALCJAAQAAAIBFBCgAAAAAsIgABQAAAAAWEaAAAAAAwCICFAAAAABYRIACAAAAAIsIUAAAAABgUZC3CwDQ+K54ZK1btmMPNDTverdsCgAAwCdxBAoAAAAALCJAAQAAAIBFBCgAAAAAsIgABQAAAAAWEaAAAAAAwCICFAAAAABYRIACAAAAAIsIUAAAAABgEQEKAAAAACwiQAEAAACARQQoAAAAALCIAAUAAAAAFhGgAAAAAMAiAhQAAAAAWESAAgAAAACLCFAAAAAAYBEBCgAAAAAsIkABAAAAgEUEKAAAAACwiAAFAAAAABYRoAAAAADAIgIUAAAAAFhEgAIAAAAAiwhQAAAAAGARAQoAAAAALCJAAQAAAIBFbg9QW7Zs0S233KLY2FjZbDatWrXKZb1hGJo5c6Y6duyoFi1aKDk5WYcOHXIZc+rUKY0fP17h4eGKjIzU5MmTVVZW5jJm7969Gjp0qEJDQxUXF6d58+a5uxUAAAAAcOH2AHX27Fn17dtXWVlZda6fN2+eFi1apMWLF2vnzp1q2bKlUlNTdf78eXPM+PHjdeDAAeXk5GjNmjXasmWL7r33XnN9aWmpUlJS1KVLF+Xn5+upp57S7Nmz9fLLL7u7HQAAAAAwBbl7g6NHj9bo0aPrXGcYhp555hk9+uijuvXWWyVJb7zxhqKjo7Vq1SqNGzdOn376qdavX6+PPvpIiYmJkqTnnntON910k55++mnFxsbqzTffVEVFhV577TWFhITommuuUUFBgRYsWOAStAAAAADAndweoBpy5MgRFRUVKTk52VwWERGhpKQk5eXlady4ccrLy1NkZKQZniQpOTlZAQEB2rlzp376058qLy9Pw4YNU0hIiDkmNTVVTz75pL755hu1adOmztcvLy9XeXm5+bi0tFSS5HQ65XQ663xOzXJ7gHHpjTey+mq/FPbAuvus6f9i94MnavOUhvaBO/uUvN9rfWp6v1C/7t4fAAAATYVHA1RRUZEkKTo62mV5dHS0ua6oqEhRUVEu64OCgtS2bVuXMfHx8bW2UbOuvgCVmZmpOXPm1FqenZ2tsLCwBmufm1jd4HpvWrdundu2Ne/6htdf7H7wZG2eUtc+cGefUtPptT45OTkNrj937pyHKgEAAPAsjwYob5sxY4YyMjLMx6WlpYqLi1NKSorCw8PrfI7T6VROTo7+sDtA5dU2T5V6UfbPTnXbtq6dvaHO5fYAQ3MTqy96P3iiNk9paB+4s0/J+73Wp2YfjBw5UsHBwfWOqzm6CwAA4G88GqBiYmIkScXFxerYsaO5vLi4WP369TPHHD9+3OV5lZWVOnXqlPn8mJgYFRcXu4ypeVwzpi52u112u73W8uDg4AbfDEpSebVN5VVNM0BdqPaLcaEeL3Y/eLI2T6lrH7izT6np9FqfC/3OuHt/AAAANBUevQ9UfHy8YmJilJubay4rLS3Vzp075XA4JEkOh0OnT59Wfn6+OWbjxo2qrq5WUlKSOWbLli0u51nk5OSoe/fu9X58DwAAAAAul9sDVFlZmQoKClRQUCDpuwtHFBQUqLCwUDabTdOnT9fjjz+u1atXa9++fZo4caJiY2M1ZswYSVLPnj01atQoTZkyRbt27dL27ds1bdo0jRs3TrGxsZKku+66SyEhIZo8ebIOHDigFStW6Nlnn3X5eB4AAAAAuJvbP8K3e/du3XDDDebjmlAzadIkLV26VA8//LDOnj2re++9V6dPn9aQIUO0fv16hYaGms958803NW3aNI0YMUIBAQEaO3asFi1aZK6PiIhQdna20tPTlZCQoPbt22vmzJlcwhwAAABAo3J7gBo+fLgMo/5LMNtsNj322GN67LHH6h3Ttm1bLVu2rMHX6dOnj7Zu3XrJdQIAAADAxfLoOVAAAAAA4MsIUAAAAABgEQEKAAAAACwiQAEAAACARQQoAAAAALCIAAUAAAAAFhGgAAAAAMAiAhQAAAAAWESAAgAAAACLCFAAAAAAYBEBCgAAAAAsIkABAAAAgEUEKAAAAACwiAAFAAAAABYRoAAAAADAIgIUAAAAAFhEgAIAAAAAiwhQAAAAAGARAQoAAAAALCJAAQAAAIBFBCgAAAAAsIgABQAAAAAWEaAAAAAAwCICFAAAAABYRIACAAAAAIsIUAAAAABgEQEKAAAAACwiQAEAAACARQQoAAAAALCIAAUAAAAAFhGgAAAAAMAiAhQAAAAAWESAAgAAAACLCFAAAAAAYBEBCgAAAAAsIkABAAAAgEUEKAAAAACwiAAFAAAAABYRoAAAAADAIq8EqNmzZ8tms7l89ejRw1x//vx5paenq127dmrVqpXGjh2r4uJil20UFhYqLS1NYWFhioqK0kMPPaTKykpPtwIAAACgGQny1gtfc801ev/99/9bSNB/S3nggQe0du1avf3224qIiNC0adN02223afv27ZKkqqoqpaWlKSYmRh9++KGOHTumiRMnKjg4WH/605883gsAAACA5sFrASooKEgxMTG1lpeUlOjVV1/VsmXLdOONN0qSlixZop49e2rHjh0aOHCgsrOz9cknn+j9999XdHS0+vXrp7lz5+p3v/udZs+erZCQEE+3AwAAAKAZ8FqAOnTokGJjYxUaGiqHw6HMzEx17txZ+fn5cjqdSk5ONsf26NFDnTt3Vl5engYOHKi8vDz17t1b0dHR5pjU1FRNnTpVBw4cUP/+/et8zfLycpWXl5uPS0tLJUlOp1NOp7PO59QstwcYl91zY6mv9kthD6y7z5r+L3Y/eKI2T2loH7izT8n7vdanpvcL9evu/QEAANBUeCVAJSUlaenSperevbuOHTumOXPmaOjQodq/f7+KiooUEhKiyMhIl+dER0erqKhIklRUVOQSnmrW16yrT2ZmpubMmVNreXZ2tsLCwhqseW5itZXWvGLdunVu29a86xtef7H7wZO1eUpd+8CdfUpNp9f65OTkNLj+3LlzHqoEAADAs7wSoEaPHm3+u0+fPkpKSlKXLl301ltvqUWLFo32ujNmzFBGRob5uLS0VHFxcUpJSVF4eHidz3E6ncrJydEfdgeovNrWaLVdjv2zU922rWtnb6hzuT3A0NzE6oveD56ozVMa2gfu7FPyfq/1qdkHI0eOVHBwcL3jao7uAgAA+BuvfYTv+yIjI3X11Vfr8OHDGjlypCoqKnT69GmXo1DFxcXmOVMxMTHatWuXyzZqrtJX13lVNex2u+x2e63lwcHBDb4ZlKTyapvKq5pmgLpQ7RfjQj1e7H7wZG2eUtc+cGefUtPptT4X+p1x9/4AAABoKprEfaDKysr02WefqWPHjkpISFBwcLByc3PN9QcPHlRhYaEcDockyeFwaN++fTp+/Lg5JicnR+Hh4erVq5fH6wcAAADQPHjlCNSDDz6oW265RV26dNFXX32lWbNmKTAwUHfeeaciIiI0efJkZWRkqG3btgoPD9f9998vh8OhgQMHSpJSUlLUq1cvTZgwQfPmzVNRUZEeffRRpaen13mECQAAAADcwSsB6ujRo7rzzjt18uRJdejQQUOGDNGOHTvUoUMHSdLChQsVEBCgsWPHqry8XKmpqXrhhRfM5wcGBmrNmjWaOnWqHA6HWrZsqUmTJumxxx7zRjsAAAAAmgmvBKjly5c3uD40NFRZWVnKysqqd0yXLl3cfuUzAAAAAGhIkzgHCgAAAAB8AQEKAAAAACwiQAEAAACARQQoAAAAALCIAAUAAAAAFhGgAAAAAMAiAhQAAAAAWESAAgAAAACLCFAAAAAAYBEBCgAAAAAsIkABAAAAgEUEKAAAAACwiAAFAAAAABYRoAAAAADAIgIUAAAAAFhEgAIAAAAAiwhQAAAAAGARAQoAAAAALCJAAQAAAIBFBCgAAAAAsIgABQAAAAAWEaAAAAAAwCICFAAAAABYRIACAAAAAIsIUAAAAABgEQEKAAAAACwiQAEAAACARQQoAAAAALCIAAUAAAAAFhGgAAAAAMAiAhQAAAAAWESAAgAAAACLCFAAAAAAYBEBCgAAAAAsIkABAAAAgEUEKAAAAACwiAAFAAAAABYRoAAAAADAIgIUAAAAAFjk8wEqKytLV1xxhUJDQ5WUlKRdu3Z5uyQAAAAAfsqnA9SKFSuUkZGhWbNm6eOPP1bfvn2Vmpqq48ePe7s0AAAAAH7IpwPUggULNGXKFN1zzz3q1auXFi9erLCwML322mveLg0AAACAHwrydgGXqqKiQvn5+ZoxY4a5LCAgQMnJycrLy6vzOeXl5SovLzcfl5SUSJJOnTolp9NZ53OcTqfOnTunIGeAqqptbuzAfU6ePOm2bQVVnq17ebWhc+eqL3o/eKI2T2loH7izT8n7vdanZh+cPHlSwcHB9Y47c+aMJMkwDE+VBgAA4BE+G6BOnDihqqoqRUdHuyyPjo7Wv/71rzqfk5mZqTlz5tRaHh8f3yg1ekr7+Z55nbsu4Tmeqs1T6tsH/tZnQy7m5+DMmTOKiIhotFoAAAA8zWcD1KWYMWOGMjIyzMfV1dU6deqU2rVrJ5ut7qMqpaWliouL05dffqnw8HBPldrksB/YB5L1fWAYhs6cOaPY2FgPVgcAAND4fDZAtW/fXoGBgSouLnZZXlxcrJiYmDqfY7fbZbfbXZZFRkZaer3w8PBm+6b5+9gP7APJ2j7gyBMAAPBHPnsRiZCQECUkJCg3N9dcVl1drdzcXDkcDi9WBgAAAMBf+ewRKEnKyMjQpEmTlJiYqOuvv17PPPOMzp49q3vuucfbpQEAAADwQz4doO644w59/fXXmjlzpoqKitSvXz+tX7++1oUlLofdbtesWbNqffSvuWE/sA8k9gEAAIDN4DrDAAAAAGCJz54DBQAAAACeRoACAAAAAIsIUAAAAABgEQEKAAAAACwiQF1AVlaWrrjiCoWGhiopKUm7du3ydkkek5mZqQEDBqh169aKiorSmDFjdPDgQW+X5VVPPPGEbDabpk+f7u1SPO4///mPfvGLX6hdu3Zq0aKFevfurd27d3u7LAAAAI8iQDVgxYoVysjI0KxZs/Txxx+rb9++Sk1N1fHjx71dmkds3rxZ6enp2rFjh3JycuR0OpWSkqKzZ896uzSv+Oijj/TSSy+pT58+3i7F47755hsNHjxYwcHB+sc//qFPPvlE8+fPV5s2bbxdGgAAgEdxGfMGJCUlacCAAXr++eclSdXV1YqLi9P999+vRx55xMvVed7XX3+tqKgobd68WcOGDfN2OR5VVlam6667Ti+88IIef/xx9evXT88884y3y/KYRx55RNu3b9fWrVu9XQoAAIBXcQSqHhUVFcrPz1dycrK5LCAgQMnJycrLy/NiZd5TUlIiSWrbtq2XK/G89PR0paWlufw8NCerV69WYmKifv7znysqKkr9+/fXn//8Z2+XBQAA4HEEqHqcOHFCVVVVio6OdlkeHR2toqIiL1XlPdXV1Zo+fboGDx6sa6+91tvleNTy5cv18ccfKzMz09uleM3nn3+uF198UVdddZU2bNigqVOn6n//93/1+uuve7s0AAAAjwrydgHwDenp6dq/f7+2bdvm7VI86ssvv9RvfvMb5eTkKDQ01NvleE11dbUSExP1pz/9SZLUv39/7d+/X4sXL9akSZO8XB0AAIDncASqHu3bt1dgYKCKi4tdlhcXFysmJsZLVXnHtGnTtGbNGn3wwQfq1KmTt8vxqPz8fB0/flzXXXedgoKCFBQUpM2bN2vRokUKCgpSVVWVt0v0iI4dO6pXr14uy3r27KnCwkIvVQQAAOAdBKh6hISEKCEhQbm5ueay6upq5ebmyuFweLEyzzEMQ9OmTdPKlSu1ceNGxcfHe7skjxsxYoT27dungoIC8ysxMVHjx49XQUGBAgMDvV2iRwwePLjWJez//e9/q0uXLl6qCAAAwDv4CF8DMjIyNGnSJCUmJur666/XM888o7Nnz+qee+7xdmkekZ6ermXLlundd99V69atzXO/IiIi1KJFCy9X5xmtW7eudc5Xy5Yt1a5du2Z1LtgDDzygQYMG6U9/+pNuv/127dq1Sy+//LJefvllb5cGAADgUVzG/AKef/55PfXUUyoqKlK/fv20aNEiJSUlebssj7DZbHUuX7Jkie6++27PFtOEDB8+vNldxlyS1qxZoxkzZujQoUOKj49XRkaGpkyZ4u2yAAAAPIoABQAAAAAWcQ4UAAAAAFhEgAIAAAAAiwhQAAAAAGARAQoAAAAALCJAAQAAAIBFBCgAAAAAsIgABQAAAAAWEaAAAAAAwCICFAAAAABYRIACAAAAAIsIUAAAAABgEQEKAAAAACz6/3iTn/BEFYojAAAAAElFTkSuQmCC\n"
+          },
+          "metadata": {}
+        }
+      ],
+      "source": [
+        "ed_flights.select_dtypes(include=np.number).hist(figsize=[10,10])\n",
+        "plt.show()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "dCy_h-vONRFq"
+      },
+      "source": [
+        "### Elasticsearch utilities"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 59,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2021-12-15T20:25:02.211768Z",
+          "iopub.status.busy": "2021-12-15T20:25:02.211404Z",
+          "iopub.status.idle": "2021-12-15T20:25:02.297769Z",
+          "shell.execute_reply": "2021-12-15T20:25:02.295526Z"
+        },
+        "pycharm": {
+          "is_executing": false
+        },
+        "id": "IYKn-Uz2NRFr"
+      },
+      "outputs": [],
+      "source": [
+        "ed_flights2 = ed_flights[(ed_flights.OriginAirportID == 'AMS') & (ed_flights.FlightDelayMin > 60)]\n",
+        "ed_flights2 = ed_flights2[['timestamp', 'OriginAirportID', 'DestAirportID', 'FlightDelayMin']]\n",
+        "ed_flights2 = ed_flights2.tail()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 60,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2021-12-15T20:25:02.319861Z",
+          "iopub.status.busy": "2021-12-15T20:25:02.305735Z",
+          "iopub.status.idle": "2021-12-15T20:25:02.325635Z",
+          "shell.execute_reply": "2021-12-15T20:25:02.326869Z"
+        },
+        "pycharm": {
+          "is_executing": false
+        },
+        "id": "hks1CjV0NRFr",
+        "outputId": "523c74c6-334a-4b50-87a2-3060b456c3ef",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "es_index_pattern: flights\n",
+            "Index:\n",
+            " es_index_field: _id\n",
+            " is_source_field: False\n",
+            "Mappings:\n",
+            " capabilities:\n",
+            "                   es_field_name  is_source es_dtype                  es_date_format        pd_dtype  is_searchable  is_aggregatable  is_scripted aggregatable_es_field_name\n",
+            "timestamp              timestamp       True     date  strict_date_hour_minute_second  datetime64[ns]           True             True        False                  timestamp\n",
+            "OriginAirportID  OriginAirportID       True  keyword                            None          object           True             True        False            OriginAirportID\n",
+            "DestAirportID      DestAirportID       True  keyword                            None          object           True             True        False              DestAirportID\n",
+            "FlightDelayMin    FlightDelayMin       True  integer                            None           int64           True             True        False             FlightDelayMin\n",
+            "Operations:\n",
+            " tasks: [('boolean_filter': ('boolean_filter': {'bool': {'must': [{'term': {'OriginAirportID': 'AMS'}}, {'range': {'FlightDelayMin': {'gt': 60}}}]}})), ('tail': ('sort_field': '_doc', 'count': 5))]\n",
+            " size: 5\n",
+            " sort_params: {'_doc': 'desc'}\n",
+            " _source: ['timestamp', 'OriginAirportID', 'DestAirportID', 'FlightDelayMin']\n",
+            " body: {'query': {'bool': {'must': [{'term': {'OriginAirportID': 'AMS'}}, {'range': {'FlightDelayMin': {'gt': 60}}}]}}}\n",
+            " post_processing: [('sort_index')]\n",
+            "\n"
+          ]
+        }
+      ],
+      "source": [
+        "print(ed_flights2.es_info())"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.8.6"
+    },
+    "pycharm": {
+      "stem_cell": {
+        "cell_type": "raw",
+        "metadata": {
+          "collapsed": false
+        },
+        "source": []
+      }
+    },
+    "colab": {
+      "provenance": []
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
 }

--- a/docs/sphinx/examples/demo_notebook.ipynb
+++ b/docs/sphinx/examples/demo_notebook.ipynb
@@ -1,6822 +1,4507 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "GTid11BRNRFA"
-      },
-      "source": [
-        "# Eland Demo Notebook\n",
-        "\n",
-        "<a target=\"_blank\" href=\"https://colab.research.google.com/github/elastic/eland/blob/main/docs/sphinx/examples/demo_notebook.ipynb\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
-        "\n",
-        "In this notebook we'll show you how to explore and analyze data in Elasticsearch using the familiar Pandas-compatible API."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## Requirements 🧰\n",
-        "\n",
-        "For this example, you will need:\n",
-        "\n",
-        "- Python 3.8 or later\n",
-        "- An Elastic deployment\n",
-        "  - We'll be using [Elastic Cloud](https://www.elastic.co/guide/en/cloud/current/ec-getting-started.html) for this example (available with a [free trial](https://cloud.elastic.co/registration))\n",
-        "\n",
-        "### Create Elastic Cloud deployment\n",
-        "\n",
-        "If you don't have an Elastic Cloud deployment, follow these steps to create one.\n",
-        "\n",
-        "1. Go to https://cloud.elastic.co/registration and sign up for a free trial\n",
-        "2. Select **Create Deployment** and follow the instructions\n"
-      ],
-      "metadata": {
-        "id": "Rkdq0gUBOPJn"
-      }
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## Install packages 📦\n",
-        "\n",
-        "First we `pip install` and import the packages we need for this example.\n"
-      ],
-      "metadata": {
-        "id": "8EzcP9SpOYsc"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "!pip install eland\n",
-        "\n",
-        "import eland as ed\n",
-        "import pandas as pd\n",
-        "import numpy as np\n",
-        "import matplotlib.pyplot as plt\n",
-        "\n",
-        "from elasticsearch import Elasticsearch\n",
-        "\n",
-        "# Import standard test settings for consistent results\n",
-        "from eland.conftest import *"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "YTm5ABvjOaSb",
-        "outputId": "a2c127f2-43d7-4103-ac0d-5cdd90ce54c2"
-      },
-      "execution_count": 1,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Requirement already satisfied: eland in /usr/local/lib/python3.10/dist-packages (8.9.0)\n",
-            "Requirement already satisfied: elasticsearch<9,>=8.3 in /usr/local/lib/python3.10/dist-packages (from eland) (8.9.0)\n",
-            "Requirement already satisfied: pandas<2,>=1.5 in /usr/local/lib/python3.10/dist-packages (from eland) (1.5.3)\n",
-            "Requirement already satisfied: matplotlib>=3.6 in /usr/local/lib/python3.10/dist-packages (from eland) (3.7.1)\n",
-            "Requirement already satisfied: numpy<1.24,>=1.2.0 in /usr/local/lib/python3.10/dist-packages (from eland) (1.23.5)\n",
-            "Requirement already satisfied: elastic-transport<9,>=8 in /usr/local/lib/python3.10/dist-packages (from elasticsearch<9,>=8.3->eland) (8.4.0)\n",
-            "Requirement already satisfied: contourpy>=1.0.1 in /usr/local/lib/python3.10/dist-packages (from matplotlib>=3.6->eland) (1.1.0)\n",
-            "Requirement already satisfied: cycler>=0.10 in /usr/local/lib/python3.10/dist-packages (from matplotlib>=3.6->eland) (0.11.0)\n",
-            "Requirement already satisfied: fonttools>=4.22.0 in /usr/local/lib/python3.10/dist-packages (from matplotlib>=3.6->eland) (4.42.1)\n",
-            "Requirement already satisfied: kiwisolver>=1.0.1 in /usr/local/lib/python3.10/dist-packages (from matplotlib>=3.6->eland) (1.4.5)\n",
-            "Requirement already satisfied: packaging>=20.0 in /usr/local/lib/python3.10/dist-packages (from matplotlib>=3.6->eland) (23.1)\n",
-            "Requirement already satisfied: pillow>=6.2.0 in /usr/local/lib/python3.10/dist-packages (from matplotlib>=3.6->eland) (9.4.0)\n",
-            "Requirement already satisfied: pyparsing>=2.3.1 in /usr/local/lib/python3.10/dist-packages (from matplotlib>=3.6->eland) (3.1.1)\n",
-            "Requirement already satisfied: python-dateutil>=2.7 in /usr/local/lib/python3.10/dist-packages (from matplotlib>=3.6->eland) (2.8.2)\n",
-            "Requirement already satisfied: pytz>=2020.1 in /usr/local/lib/python3.10/dist-packages (from pandas<2,>=1.5->eland) (2023.3.post1)\n",
-            "Requirement already satisfied: urllib3<2,>=1.26.2 in /usr/local/lib/python3.10/dist-packages (from elastic-transport<9,>=8->elasticsearch<9,>=8.3->eland) (1.26.16)\n",
-            "Requirement already satisfied: certifi in /usr/local/lib/python3.10/dist-packages (from elastic-transport<9,>=8->elasticsearch<9,>=8.3->eland) (2023.7.22)\n",
-            "Requirement already satisfied: six>=1.5 in /usr/local/lib/python3.10/dist-packages (from python-dateutil>=2.7->matplotlib>=3.6->eland) (1.16.0)\n"
-          ]
-        }
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 1,
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2021-12-15T20:24:28.813370Z",
-          "iopub.status.busy": "2021-12-15T20:24:28.802670Z",
-          "iopub.status.idle": "2021-12-15T20:24:30.192643Z",
-          "shell.execute_reply": "2021-12-15T20:24:30.192931Z"
-        },
-        "pycharm": {
-          "is_executing": false
-        },
-        "id": "64Wm8FvSNRFD"
-      },
-      "outputs": [],
-      "source": []
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## Initialize client 🔌\n",
-        "\n",
-        "Next we input credentials with `getpass`. `getpass` is part of the Python standard library and is used to securely prompt for credentials."
-      ],
-      "metadata": {
-        "id": "J9YR-d7OOk0-"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "from getpass import getpass\n",
-        "\n",
-        "ELASTIC_HOST = getpass(\"Elasticsearch hostname: \")\n",
-        "ELASTIC_PORT = int(input(\"Elasticsearch HTTP port:\"))\n",
-        "ELASTIC_USERNAME = getpass(\"Elasticsearch username: \")\n",
-        "ELASTIC_PASSWORD = getpass(\"Elasticsearch password: \")\n",
-        "\n",
-        "ELASTICSEARCH_URL = f\"https://{ELASTIC_USERNAME}:{ELASTIC_PASSWORD}@{ELASTIC_HOST}:{ELASTIC_PORT}\"\n"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "DARo7JpKOsdW",
-        "outputId": "6497646e-a535-4994-a26a-8aea1caae28c"
-      },
-      "execution_count": 2,
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Elasticsearch host: ··········\n",
-            "Elasticsearch HTTP port:443\n",
-            "Elasticsearch username: ··········\n",
-            "Elasticsearch password: ··········\n"
-          ]
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## Load and process documents 📄\n",
-        "\n",
-        "Time to load some data! We'll be using the Eland test data, which is a fake flights dataset."
-      ],
-      "metadata": {
-        "id": "4m9amNr6OxKr"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "import os\n",
-        "\n",
-        "es = Elasticsearch(ELASTICSEARCH_URL)\n",
-        "print(es.info())\n",
-        "\n",
-        "os.chdir(\"/content/\")\n",
-        "!rm -rf eland/\n",
-        "!git clone https://github.com/elastic/eland.git\n",
-        "\n",
-        "os.chdir(\"eland\")\n",
-        "import sys\n",
-        "sys.path.insert(0, os.getcwd())\n",
-        "os.environ[\"ELASTICSEARCH_URL\"] = ELASTICSEARCH_URL\n",
-        "\n",
-        "from tests import setup_tests\n",
-        "setup_tests._setup_data(es)"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "UXLIpuFTO8pq",
-        "outputId": "647afe26-7852-44fa-eb7f-e4184853aca0"
-      },
-      "execution_count": 3,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "{'name': 'instance-0000000000', 'cluster_name': '9fcead8be8d2469fa096128e20496cee', 'cluster_uuid': 'Vb-ose0ZTJah2ikFeONNIA', 'version': {'number': '8.9.1', 'build_flavor': 'default', 'build_type': 'docker', 'build_hash': 'a813d015ef1826148d9d389bd1c0d781c6e349f0', 'build_date': '2023-08-10T05:02:32.517455352Z', 'build_snapshot': False, 'lucene_version': '9.7.0', 'minimum_wire_compatibility_version': '7.17.0', 'minimum_index_compatibility_version': '7.0.0'}, 'tagline': 'You Know, for Search'}\n",
-            "Cloning into 'eland'...\n",
-            "remote: Enumerating objects: 5073, done.\u001b[K\n",
-            "remote: Counting objects: 100% (1719/1719), done.\u001b[K\n",
-            "remote: Compressing objects: 100% (551/551), done.\u001b[K\n",
-            "remote: Total 5073 (delta 1408), reused 1358 (delta 1167), pack-reused 3354\u001b[K\n",
-            "Receiving objects: 100% (5073/5073), 17.37 MiB | 38.67 MiB/s, done.\n",
-            "Resolving deltas: 100% (3573/3573), done.\n",
-            "Deleting index: flights\n",
-            "Creating index: flights\n",
-            "Adding 13059 items to index: flights\n",
-            "Done flights\n",
-            "Deleting index: flights_small\n",
-            "Creating index: flights_small\n",
-            "Adding 48 items to index: flights_small\n",
-            "Done flights_small\n",
-            "Deleting index: ecommerce\n",
-            "Creating index: ecommerce\n",
-            "Adding 4675 items to index: ecommerce\n",
-            "Done ecommerce\n"
-          ]
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "c3Af_LIiNRFE"
-      },
-      "source": [
-        "## Compare Eland DataFrame vs pandas DataFrame"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "bNs9FbAgNRFE"
-      },
-      "source": [
-        "Create an eland.DataFrame from a `flights` index"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 4,
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2021-12-15T20:24:30.195931Z",
-          "iopub.status.busy": "2021-12-15T20:24:30.195563Z",
-          "iopub.status.idle": "2021-12-15T20:24:30.668077Z",
-          "shell.execute_reply": "2021-12-15T20:24:30.667531Z"
-        },
-        "pycharm": {
-          "is_executing": false
-        },
-        "id": "7_rgLmsLNRFF"
-      },
-      "outputs": [],
-      "source": [
-        "ed_flights = ed.DataFrame(es, 'flights')"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 5,
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2021-12-15T20:24:30.673583Z",
-          "iopub.status.busy": "2021-12-15T20:24:30.673088Z",
-          "iopub.status.idle": "2021-12-15T20:24:30.677254Z",
-          "shell.execute_reply": "2021-12-15T20:24:30.677676Z"
-        },
-        "pycharm": {
-          "is_executing": false
-        },
-        "id": "ickl9aGUNRFH",
-        "outputId": "1039176a-2b64-4a01-ee7f-bacd6ca1a0bf",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        }
-      },
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "eland.dataframe.DataFrame"
-            ]
-          },
-          "metadata": {},
-          "execution_count": 5
-        }
-      ],
-      "source": [
-        "type(ed_flights)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "8Y39fj7rNRFI"
-      },
-      "source": [
-        "Compare to pandas DataFrame (created from the same data)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 6,
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2021-12-15T20:24:30.682438Z",
-          "iopub.status.busy": "2021-12-15T20:24:30.681925Z",
-          "iopub.status.idle": "2021-12-15T20:24:35.046707Z",
-          "shell.execute_reply": "2021-12-15T20:24:35.046060Z"
-        },
-        "pycharm": {
-          "is_executing": false
-        },
-        "id": "Qxz7lZ7zNRFI"
-      },
-      "outputs": [],
-      "source": [
-        "pd_flights = ed.eland_to_pandas(ed_flights)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 7,
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2021-12-15T20:24:35.050698Z",
-          "iopub.status.busy": "2021-12-15T20:24:35.050158Z",
-          "iopub.status.idle": "2021-12-15T20:24:35.053100Z",
-          "shell.execute_reply": "2021-12-15T20:24:35.052560Z"
-        },
-        "pycharm": {
-          "is_executing": false
-        },
-        "id": "0f9qCkT3NRFJ",
-        "outputId": "eb8dd3b7-bc09-45a2-fded-7be827977190",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        }
-      },
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "pandas.core.frame.DataFrame"
-            ]
-          },
-          "metadata": {},
-          "execution_count": 7
-        }
-      ],
-      "source": [
-        "type(pd_flights)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "idu_eqdsNRFK"
-      },
-      "source": [
-        "## Attributes and underlying data"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "bltr_0r-NRFL"
-      },
-      "source": [
-        "### DataFrame.columns"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 8,
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2021-12-15T20:24:35.057245Z",
-          "iopub.status.busy": "2021-12-15T20:24:35.056812Z",
-          "iopub.status.idle": "2021-12-15T20:24:35.059852Z",
-          "shell.execute_reply": "2021-12-15T20:24:35.059182Z"
-        },
-        "pycharm": {
-          "is_executing": false
-        },
-        "id": "ZLVUimn_NRFL",
-        "outputId": "ce814e44-2c16-452d-f9f0-76acaee67940",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        }
-      },
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "Index(['AvgTicketPrice', 'Cancelled', 'Carrier', 'Dest', 'DestAirportID', 'DestCityName',\n",
-              "       'DestCountry', 'DestLocation', 'DestRegion', 'DestWeather', 'DistanceKilometers',\n",
-              "       'DistanceMiles', 'FlightDelay', 'FlightDelayMin', 'FlightDelayType', 'FlightNum',\n",
-              "       'FlightTimeHour', 'FlightTimeMin', 'Origin', 'OriginAirportID', 'OriginCityName',\n",
-              "       'OriginCountry', 'OriginLocation', 'OriginRegion', 'OriginWeather', 'dayOfWeek',\n",
-              "       'timestamp'],\n",
-              "      dtype='object')"
-            ]
-          },
-          "metadata": {},
-          "execution_count": 8
-        }
-      ],
-      "source": [
-        "pd_flights.columns"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 9,
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2021-12-15T20:24:35.063057Z",
-          "iopub.status.busy": "2021-12-15T20:24:35.062660Z",
-          "iopub.status.idle": "2021-12-15T20:24:35.065130Z",
-          "shell.execute_reply": "2021-12-15T20:24:35.064757Z"
-        },
-        "pycharm": {
-          "is_executing": false
-        },
-        "id": "UcFhMhhFNRFM",
-        "outputId": "14e25022-c0dd-4856-e586-9060ed775744",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        }
-      },
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "Index(['AvgTicketPrice', 'Cancelled', 'Carrier', 'Dest', 'DestAirportID', 'DestCityName',\n",
-              "       'DestCountry', 'DestLocation', 'DestRegion', 'DestWeather', 'DistanceKilometers',\n",
-              "       'DistanceMiles', 'FlightDelay', 'FlightDelayMin', 'FlightDelayType', 'FlightNum',\n",
-              "       'FlightTimeHour', 'FlightTimeMin', 'Origin', 'OriginAirportID', 'OriginCityName',\n",
-              "       'OriginCountry', 'OriginLocation', 'OriginRegion', 'OriginWeather', 'dayOfWeek',\n",
-              "       'timestamp'],\n",
-              "      dtype='object')"
-            ]
-          },
-          "metadata": {},
-          "execution_count": 9
-        }
-      ],
-      "source": [
-        "ed_flights.columns"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "NPoDKfjYNRFM"
-      },
-      "source": [
-        "### DataFrame.dtypes"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 10,
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2021-12-15T20:24:35.076896Z",
-          "iopub.status.busy": "2021-12-15T20:24:35.076493Z",
-          "iopub.status.idle": "2021-12-15T20:24:35.079007Z",
-          "shell.execute_reply": "2021-12-15T20:24:35.078592Z"
-        },
-        "pycharm": {
-          "is_executing": false
-        },
-        "id": "b0Xh8p_nNRFN",
-        "outputId": "2b12440d-05f4-4e31-ea1b-c09ae4f0f058",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        }
-      },
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "AvgTicketPrice           float64\n",
-              "Cancelled                   bool\n",
-              "Carrier                   object\n",
-              "Dest                      object\n",
-              "DestAirportID             object\n",
-              "                       ...      \n",
-              "OriginLocation            object\n",
-              "OriginRegion              object\n",
-              "OriginWeather             object\n",
-              "dayOfWeek                  int64\n",
-              "timestamp         datetime64[ns]\n",
-              "Length: 27, dtype: object"
-            ]
-          },
-          "metadata": {},
-          "execution_count": 10
-        }
-      ],
-      "source": [
-        "pd_flights.dtypes"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 11,
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2021-12-15T20:24:35.083103Z",
-          "iopub.status.busy": "2021-12-15T20:24:35.082693Z",
-          "iopub.status.idle": "2021-12-15T20:24:35.085336Z",
-          "shell.execute_reply": "2021-12-15T20:24:35.084836Z"
-        },
-        "pycharm": {
-          "is_executing": false
-        },
-        "id": "IrDE-STnNRFN",
-        "outputId": "e6c2861e-ea3d-481c-d771-5e7cb30db622",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        }
-      },
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "AvgTicketPrice           float64\n",
-              "Cancelled                   bool\n",
-              "Carrier                   object\n",
-              "Dest                      object\n",
-              "DestAirportID             object\n",
-              "                       ...      \n",
-              "OriginLocation            object\n",
-              "OriginRegion              object\n",
-              "OriginWeather             object\n",
-              "dayOfWeek                  int64\n",
-              "timestamp         datetime64[ns]\n",
-              "Length: 27, dtype: object"
-            ]
-          },
-          "metadata": {},
-          "execution_count": 11
-        }
-      ],
-      "source": [
-        "ed_flights.dtypes"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "b4KBN1iQNRFN"
-      },
-      "source": [
-        "### DataFrame.select_dtypes"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 12,
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2021-12-15T20:24:35.090387Z",
-          "iopub.status.busy": "2021-12-15T20:24:35.089910Z",
-          "iopub.status.idle": "2021-12-15T20:24:35.113517Z",
-          "shell.execute_reply": "2021-12-15T20:24:35.113801Z"
-        },
-        "pycharm": {
-          "is_executing": false
-        },
-        "id": "MOAMAU4DNRFO",
-        "outputId": "7a3afb74-3259-4e5a-b0d7-af9201348346",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 424
-        }
-      },
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "       AvgTicketPrice  DistanceKilometers  ...  FlightTimeMin  dayOfWeek\n",
-              "0          841.265642        16492.326654  ...    1030.770416          0\n",
-              "1          882.982662         8823.400140  ...     464.389481          0\n",
-              "2          190.636904            0.000000  ...       0.000000          0\n",
-              "3          181.694216          555.737767  ...     222.749059          0\n",
-              "4          730.041778        13358.244200  ...     785.779071          0\n",
-              "...               ...                 ...  ...            ...        ...\n",
-              "13054     1080.446279         8058.581753  ...     402.929088          6\n",
-              "13055      646.612941         7088.598322  ...     644.418029          6\n",
-              "13056      997.751876        10920.652972  ...     937.540811          6\n",
-              "13057     1102.814465        18748.859647  ...    1697.404971          6\n",
-              "13058      858.144337        16809.141923  ...    1610.761827          6\n",
-              "\n",
-              "[13059 rows x 7 columns]"
-            ],
-            "text/html": [
-              "\n",
-              "  <div id=\"df-5769e971-1862-4e81-af6c-1664d699208d\" class=\"colab-df-container\">\n",
-              "    <div>\n",
-              "<style scoped>\n",
-              "    .dataframe tbody tr th:only-of-type {\n",
-              "        vertical-align: middle;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe tbody tr th {\n",
-              "        vertical-align: top;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe thead th {\n",
-              "        text-align: right;\n",
-              "    }\n",
-              "</style>\n",
-              "<table border=\"1\" class=\"dataframe\">\n",
-              "  <thead>\n",
-              "    <tr style=\"text-align: right;\">\n",
-              "      <th></th>\n",
-              "      <th>AvgTicketPrice</th>\n",
-              "      <th>DistanceKilometers</th>\n",
-              "      <th>...</th>\n",
-              "      <th>FlightTimeMin</th>\n",
-              "      <th>dayOfWeek</th>\n",
-              "    </tr>\n",
-              "  </thead>\n",
-              "  <tbody>\n",
-              "    <tr>\n",
-              "      <th>0</th>\n",
-              "      <td>841.265642</td>\n",
-              "      <td>16492.326654</td>\n",
-              "      <td>...</td>\n",
-              "      <td>1030.770416</td>\n",
-              "      <td>0</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>1</th>\n",
-              "      <td>882.982662</td>\n",
-              "      <td>8823.400140</td>\n",
-              "      <td>...</td>\n",
-              "      <td>464.389481</td>\n",
-              "      <td>0</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>2</th>\n",
-              "      <td>190.636904</td>\n",
-              "      <td>0.000000</td>\n",
-              "      <td>...</td>\n",
-              "      <td>0.000000</td>\n",
-              "      <td>0</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>3</th>\n",
-              "      <td>181.694216</td>\n",
-              "      <td>555.737767</td>\n",
-              "      <td>...</td>\n",
-              "      <td>222.749059</td>\n",
-              "      <td>0</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>4</th>\n",
-              "      <td>730.041778</td>\n",
-              "      <td>13358.244200</td>\n",
-              "      <td>...</td>\n",
-              "      <td>785.779071</td>\n",
-              "      <td>0</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>...</th>\n",
-              "      <td>...</td>\n",
-              "      <td>...</td>\n",
-              "      <td>...</td>\n",
-              "      <td>...</td>\n",
-              "      <td>...</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>13054</th>\n",
-              "      <td>1080.446279</td>\n",
-              "      <td>8058.581753</td>\n",
-              "      <td>...</td>\n",
-              "      <td>402.929088</td>\n",
-              "      <td>6</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>13055</th>\n",
-              "      <td>646.612941</td>\n",
-              "      <td>7088.598322</td>\n",
-              "      <td>...</td>\n",
-              "      <td>644.418029</td>\n",
-              "      <td>6</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>13056</th>\n",
-              "      <td>997.751876</td>\n",
-              "      <td>10920.652972</td>\n",
-              "      <td>...</td>\n",
-              "      <td>937.540811</td>\n",
-              "      <td>6</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>13057</th>\n",
-              "      <td>1102.814465</td>\n",
-              "      <td>18748.859647</td>\n",
-              "      <td>...</td>\n",
-              "      <td>1697.404971</td>\n",
-              "      <td>6</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>13058</th>\n",
-              "      <td>858.144337</td>\n",
-              "      <td>16809.141923</td>\n",
-              "      <td>...</td>\n",
-              "      <td>1610.761827</td>\n",
-              "      <td>6</td>\n",
-              "    </tr>\n",
-              "  </tbody>\n",
-              "</table>\n",
-              "<p>13059 rows × 7 columns</p>\n",
-              "</div>\n",
-              "    <div class=\"colab-df-buttons\">\n",
-              "\n",
-              "  <div class=\"colab-df-container\">\n",
-              "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-5769e971-1862-4e81-af6c-1664d699208d')\"\n",
-              "            title=\"Convert this dataframe to an interactive table.\"\n",
-              "            style=\"display:none;\">\n",
-              "\n",
-              "  <svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\" viewBox=\"0 -960 960 960\">\n",
-              "    <path d=\"M120-120v-720h720v720H120Zm60-500h600v-160H180v160Zm220 220h160v-160H400v160Zm0 220h160v-160H400v160ZM180-400h160v-160H180v160Zm440 0h160v-160H620v160ZM180-180h160v-160H180v160Zm440 0h160v-160H620v160Z\"/>\n",
-              "  </svg>\n",
-              "    </button>\n",
-              "\n",
-              "  <style>\n",
-              "    .colab-df-container {\n",
-              "      display:flex;\n",
-              "      gap: 12px;\n",
-              "    }\n",
-              "\n",
-              "    .colab-df-convert {\n",
-              "      background-color: #E8F0FE;\n",
-              "      border: none;\n",
-              "      border-radius: 50%;\n",
-              "      cursor: pointer;\n",
-              "      display: none;\n",
-              "      fill: #1967D2;\n",
-              "      height: 32px;\n",
-              "      padding: 0 0 0 0;\n",
-              "      width: 32px;\n",
-              "    }\n",
-              "\n",
-              "    .colab-df-convert:hover {\n",
-              "      background-color: #E2EBFA;\n",
-              "      box-shadow: 0px 1px 2px rgba(60, 64, 67, 0.3), 0px 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
-              "      fill: #174EA6;\n",
-              "    }\n",
-              "\n",
-              "    .colab-df-buttons div {\n",
-              "      margin-bottom: 4px;\n",
-              "    }\n",
-              "\n",
-              "    [theme=dark] .colab-df-convert {\n",
-              "      background-color: #3B4455;\n",
-              "      fill: #D2E3FC;\n",
-              "    }\n",
-              "\n",
-              "    [theme=dark] .colab-df-convert:hover {\n",
-              "      background-color: #434B5C;\n",
-              "      box-shadow: 0px 1px 3px 1px rgba(0, 0, 0, 0.15);\n",
-              "      filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.3));\n",
-              "      fill: #FFFFFF;\n",
-              "    }\n",
-              "  </style>\n",
-              "\n",
-              "    <script>\n",
-              "      const buttonEl =\n",
-              "        document.querySelector('#df-5769e971-1862-4e81-af6c-1664d699208d button.colab-df-convert');\n",
-              "      buttonEl.style.display =\n",
-              "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
-              "\n",
-              "      async function convertToInteractive(key) {\n",
-              "        const element = document.querySelector('#df-5769e971-1862-4e81-af6c-1664d699208d');\n",
-              "        const dataTable =\n",
-              "          await google.colab.kernel.invokeFunction('convertToInteractive',\n",
-              "                                                    [key], {});\n",
-              "        if (!dataTable) return;\n",
-              "\n",
-              "        const docLinkHtml = 'Like what you see? Visit the ' +\n",
-              "          '<a target=\"_blank\" href=https://colab.research.google.com/notebooks/data_table.ipynb>data table notebook</a>'\n",
-              "          + ' to learn more about interactive tables.';\n",
-              "        element.innerHTML = '';\n",
-              "        dataTable['output_type'] = 'display_data';\n",
-              "        await google.colab.output.renderOutput(dataTable, element);\n",
-              "        const docLink = document.createElement('div');\n",
-              "        docLink.innerHTML = docLinkHtml;\n",
-              "        element.appendChild(docLink);\n",
-              "      }\n",
-              "    </script>\n",
-              "  </div>\n",
-              "\n",
-              "\n",
-              "<div id=\"df-8c144ffe-aaab-4cdd-8ab4-c7f4562aa310\">\n",
-              "  <button class=\"colab-df-quickchart\" onclick=\"quickchart('df-8c144ffe-aaab-4cdd-8ab4-c7f4562aa310')\"\n",
-              "            title=\"Suggest charts.\"\n",
-              "            style=\"display:none;\">\n",
-              "\n",
-              "<svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\"viewBox=\"0 0 24 24\"\n",
-              "     width=\"24px\">\n",
-              "    <g>\n",
-              "        <path d=\"M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zM9 17H7v-7h2v7zm4 0h-2V7h2v10zm4 0h-2v-4h2v4z\"/>\n",
-              "    </g>\n",
-              "</svg>\n",
-              "  </button>\n",
-              "\n",
-              "<style>\n",
-              "  .colab-df-quickchart {\n",
-              "      --bg-color: #E8F0FE;\n",
-              "      --fill-color: #1967D2;\n",
-              "      --hover-bg-color: #E2EBFA;\n",
-              "      --hover-fill-color: #174EA6;\n",
-              "      --disabled-fill-color: #AAA;\n",
-              "      --disabled-bg-color: #DDD;\n",
-              "  }\n",
-              "\n",
-              "  [theme=dark] .colab-df-quickchart {\n",
-              "      --bg-color: #3B4455;\n",
-              "      --fill-color: #D2E3FC;\n",
-              "      --hover-bg-color: #434B5C;\n",
-              "      --hover-fill-color: #FFFFFF;\n",
-              "      --disabled-bg-color: #3B4455;\n",
-              "      --disabled-fill-color: #666;\n",
-              "  }\n",
-              "\n",
-              "  .colab-df-quickchart {\n",
-              "    background-color: var(--bg-color);\n",
-              "    border: none;\n",
-              "    border-radius: 50%;\n",
-              "    cursor: pointer;\n",
-              "    display: none;\n",
-              "    fill: var(--fill-color);\n",
-              "    height: 32px;\n",
-              "    padding: 0;\n",
-              "    width: 32px;\n",
-              "  }\n",
-              "\n",
-              "  .colab-df-quickchart:hover {\n",
-              "    background-color: var(--hover-bg-color);\n",
-              "    box-shadow: 0 1px 2px rgba(60, 64, 67, 0.3), 0 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
-              "    fill: var(--button-hover-fill-color);\n",
-              "  }\n",
-              "\n",
-              "  .colab-df-quickchart-complete:disabled,\n",
-              "  .colab-df-quickchart-complete:disabled:hover {\n",
-              "    background-color: var(--disabled-bg-color);\n",
-              "    fill: var(--disabled-fill-color);\n",
-              "    box-shadow: none;\n",
-              "  }\n",
-              "\n",
-              "  .colab-df-spinner {\n",
-              "    border: 2px solid var(--fill-color);\n",
-              "    border-color: transparent;\n",
-              "    border-bottom-color: var(--fill-color);\n",
-              "    animation:\n",
-              "      spin 1s steps(1) infinite;\n",
-              "  }\n",
-              "\n",
-              "  @keyframes spin {\n",
-              "    0% {\n",
-              "      border-color: transparent;\n",
-              "      border-bottom-color: var(--fill-color);\n",
-              "      border-left-color: var(--fill-color);\n",
-              "    }\n",
-              "    20% {\n",
-              "      border-color: transparent;\n",
-              "      border-left-color: var(--fill-color);\n",
-              "      border-top-color: var(--fill-color);\n",
-              "    }\n",
-              "    30% {\n",
-              "      border-color: transparent;\n",
-              "      border-left-color: var(--fill-color);\n",
-              "      border-top-color: var(--fill-color);\n",
-              "      border-right-color: var(--fill-color);\n",
-              "    }\n",
-              "    40% {\n",
-              "      border-color: transparent;\n",
-              "      border-right-color: var(--fill-color);\n",
-              "      border-top-color: var(--fill-color);\n",
-              "    }\n",
-              "    60% {\n",
-              "      border-color: transparent;\n",
-              "      border-right-color: var(--fill-color);\n",
-              "    }\n",
-              "    80% {\n",
-              "      border-color: transparent;\n",
-              "      border-right-color: var(--fill-color);\n",
-              "      border-bottom-color: var(--fill-color);\n",
-              "    }\n",
-              "    90% {\n",
-              "      border-color: transparent;\n",
-              "      border-bottom-color: var(--fill-color);\n",
-              "    }\n",
-              "  }\n",
-              "</style>\n",
-              "\n",
-              "  <script>\n",
-              "    async function quickchart(key) {\n",
-              "      const quickchartButtonEl =\n",
-              "        document.querySelector('#' + key + ' button');\n",
-              "      quickchartButtonEl.disabled = true;  // To prevent multiple clicks.\n",
-              "      quickchartButtonEl.classList.add('colab-df-spinner');\n",
-              "      try {\n",
-              "        const charts = await google.colab.kernel.invokeFunction(\n",
-              "            'suggestCharts', [key], {});\n",
-              "      } catch (error) {\n",
-              "        console.error('Error during call to suggestCharts:', error);\n",
-              "      }\n",
-              "      quickchartButtonEl.classList.remove('colab-df-spinner');\n",
-              "      quickchartButtonEl.classList.add('colab-df-quickchart-complete');\n",
-              "    }\n",
-              "    (() => {\n",
-              "      let quickchartButtonEl =\n",
-              "        document.querySelector('#df-8c144ffe-aaab-4cdd-8ab4-c7f4562aa310 button');\n",
-              "      quickchartButtonEl.style.display =\n",
-              "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
-              "    })();\n",
-              "  </script>\n",
-              "</div>\n",
-              "    </div>\n",
-              "  </div>\n"
-            ]
-          },
-          "metadata": {},
-          "execution_count": 12
-        }
-      ],
-      "source": [
-        "pd_flights.select_dtypes(include=np.number)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 13,
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2021-12-15T20:24:35.131083Z",
-          "iopub.status.busy": "2021-12-15T20:24:35.130699Z",
-          "iopub.status.idle": "2021-12-15T20:24:38.362018Z",
-          "shell.execute_reply": "2021-12-15T20:24:38.360520Z"
-        },
-        "pycharm": {
-          "is_executing": false
-        },
-        "id": "QyaBzEf-NRFO",
-        "outputId": "c71e7496-7564-4881-c272-3eede3536d34",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 424
-        }
-      },
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "       AvgTicketPrice  DistanceKilometers  ...  FlightTimeMin  dayOfWeek\n",
-              "0          841.265642        16492.326654  ...    1030.770416          0\n",
-              "1          882.982662         8823.400140  ...     464.389481          0\n",
-              "2          190.636904            0.000000  ...       0.000000          0\n",
-              "3          181.694216          555.737767  ...     222.749059          0\n",
-              "4          730.041778        13358.244200  ...     785.779071          0\n",
-              "...               ...                 ...  ...            ...        ...\n",
-              "13054     1080.446279         8058.581753  ...     402.929088          6\n",
-              "13055      646.612941         7088.598322  ...     644.418029          6\n",
-              "13056      997.751876        10920.652972  ...     937.540811          6\n",
-              "13057     1102.814465        18748.859647  ...    1697.404971          6\n",
-              "13058      858.144337        16809.141923  ...    1610.761827          6\n",
-              "\n",
-              "[13059 rows x 7 columns]"
-            ],
-            "text/html": [
-              "<div>\n",
-              "<style scoped>\n",
-              "    .dataframe tbody tr th:only-of-type {\n",
-              "        vertical-align: middle;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe tbody tr th {\n",
-              "        vertical-align: top;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe thead th {\n",
-              "        text-align: right;\n",
-              "    }\n",
-              "</style>\n",
-              "<table border=\"1\" class=\"dataframe\">\n",
-              "  <thead>\n",
-              "    <tr style=\"text-align: right;\">\n",
-              "      <th></th>\n",
-              "      <th>AvgTicketPrice</th>\n",
-              "      <th>DistanceKilometers</th>\n",
-              "      <th>...</th>\n",
-              "      <th>FlightTimeMin</th>\n",
-              "      <th>dayOfWeek</th>\n",
-              "    </tr>\n",
-              "  </thead>\n",
-              "  <tbody>\n",
-              "    <tr>\n",
-              "      <th>0</th>\n",
-              "      <td>841.265642</td>\n",
-              "      <td>16492.326654</td>\n",
-              "      <td>...</td>\n",
-              "      <td>1030.770416</td>\n",
-              "      <td>0</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>1</th>\n",
-              "      <td>882.982662</td>\n",
-              "      <td>8823.400140</td>\n",
-              "      <td>...</td>\n",
-              "      <td>464.389481</td>\n",
-              "      <td>0</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>2</th>\n",
-              "      <td>190.636904</td>\n",
-              "      <td>0.000000</td>\n",
-              "      <td>...</td>\n",
-              "      <td>0.000000</td>\n",
-              "      <td>0</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>3</th>\n",
-              "      <td>181.694216</td>\n",
-              "      <td>555.737767</td>\n",
-              "      <td>...</td>\n",
-              "      <td>222.749059</td>\n",
-              "      <td>0</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>4</th>\n",
-              "      <td>730.041778</td>\n",
-              "      <td>13358.244200</td>\n",
-              "      <td>...</td>\n",
-              "      <td>785.779071</td>\n",
-              "      <td>0</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>...</th>\n",
-              "      <td>...</td>\n",
-              "      <td>...</td>\n",
-              "      <td>...</td>\n",
-              "      <td>...</td>\n",
-              "      <td>...</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>13054</th>\n",
-              "      <td>1080.446279</td>\n",
-              "      <td>8058.581753</td>\n",
-              "      <td>...</td>\n",
-              "      <td>402.929088</td>\n",
-              "      <td>6</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>13055</th>\n",
-              "      <td>646.612941</td>\n",
-              "      <td>7088.598322</td>\n",
-              "      <td>...</td>\n",
-              "      <td>644.418029</td>\n",
-              "      <td>6</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>13056</th>\n",
-              "      <td>997.751876</td>\n",
-              "      <td>10920.652972</td>\n",
-              "      <td>...</td>\n",
-              "      <td>937.540811</td>\n",
-              "      <td>6</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>13057</th>\n",
-              "      <td>1102.814465</td>\n",
-              "      <td>18748.859647</td>\n",
-              "      <td>...</td>\n",
-              "      <td>1697.404971</td>\n",
-              "      <td>6</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>13058</th>\n",
-              "      <td>858.144337</td>\n",
-              "      <td>16809.141923</td>\n",
-              "      <td>...</td>\n",
-              "      <td>1610.761827</td>\n",
-              "      <td>6</td>\n",
-              "    </tr>\n",
-              "  </tbody>\n",
-              "</table>\n",
-              "</div>\n",
-              "<p>13059 rows × 7 columns</p>"
-            ]
-          },
-          "metadata": {},
-          "execution_count": 13
-        }
-      ],
-      "source": [
-        "ed_flights.select_dtypes(include=np.number)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "E9hPiMkPNRFP"
-      },
-      "source": [
-        "### DataFrame.empty"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 14,
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2021-12-15T20:24:38.376647Z",
-          "iopub.status.busy": "2021-12-15T20:24:38.374422Z",
-          "iopub.status.idle": "2021-12-15T20:24:38.382068Z",
-          "shell.execute_reply": "2021-12-15T20:24:38.383242Z"
-        },
-        "pycharm": {
-          "is_executing": false
-        },
-        "id": "fLMm3FGpNRFP",
-        "outputId": "d4158c9b-6d8f-4b05-bfdd-921832113278",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        }
-      },
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "False"
-            ]
-          },
-          "metadata": {},
-          "execution_count": 14
-        }
-      ],
-      "source": [
-        "pd_flights.empty"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 15,
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2021-12-15T20:24:38.391560Z",
-          "iopub.status.busy": "2021-12-15T20:24:38.390590Z",
-          "iopub.status.idle": "2021-12-15T20:24:38.463948Z",
-          "shell.execute_reply": "2021-12-15T20:24:38.463507Z"
-        },
-        "pycharm": {
-          "is_executing": false
-        },
-        "id": "cdaA4nkdNRFP",
-        "outputId": "248e88d9-92ca-442a-b5b9-e3b8cd0957ec",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        }
-      },
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "False"
-            ]
-          },
-          "metadata": {},
-          "execution_count": 15
-        }
-      ],
-      "source": [
-        "ed_flights.empty"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "oV6j_h4INRFR"
-      },
-      "source": [
-        "### DataFrame.shape"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 16,
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2021-12-15T20:24:38.467067Z",
-          "iopub.status.busy": "2021-12-15T20:24:38.466671Z",
-          "iopub.status.idle": "2021-12-15T20:24:38.469107Z",
-          "shell.execute_reply": "2021-12-15T20:24:38.468710Z"
-        },
-        "pycharm": {
-          "is_executing": false
-        },
-        "id": "HSlyhmmwNRFR",
-        "outputId": "dda9b642-f2a1-4c30-f563-10e3612cacc0",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        }
-      },
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "(13059, 27)"
-            ]
-          },
-          "metadata": {},
-          "execution_count": 16
-        }
-      ],
-      "source": [
-        "pd_flights.shape"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 17,
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2021-12-15T20:24:38.471904Z",
-          "iopub.status.busy": "2021-12-15T20:24:38.471491Z",
-          "iopub.status.idle": "2021-12-15T20:24:38.558583Z",
-          "shell.execute_reply": "2021-12-15T20:24:38.557300Z"
-        },
-        "pycharm": {
-          "is_executing": false
-        },
-        "id": "n7NFeQR6NRFR",
-        "outputId": "11d9ed11-442d-4465-d1f2-42507ac16c9e",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        }
-      },
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "(13059, 27)"
-            ]
-          },
-          "metadata": {},
-          "execution_count": 17
-        }
-      ],
-      "source": [
-        "ed_flights.shape"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "ib-JYdwXNRFS"
-      },
-      "source": [
-        "### DataFrame.index\n",
-        "\n",
-        "Note, `eland.DataFrame.index` does not mirror `pandas.DataFrame.index`."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 18,
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2021-12-15T20:24:38.569600Z",
-          "iopub.status.busy": "2021-12-15T20:24:38.568315Z",
-          "iopub.status.idle": "2021-12-15T20:24:38.575273Z",
-          "shell.execute_reply": "2021-12-15T20:24:38.574007Z"
-        },
-        "pycharm": {
-          "is_executing": false
-        },
-        "id": "mTSyzPSgNRFS",
-        "outputId": "63794e47-2f04-41a1-89ac-3a5d32e8d371",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        }
-      },
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "Index(['0', '1', '2', '3', '4', '5', '6', '7', '8', '9',\n",
-              "       ...\n",
-              "       '13049', '13050', '13051', '13052', '13053', '13054', '13055', '13056', '13057', '13058'],\n",
-              "      dtype='object', length=13059)"
-            ]
-          },
-          "metadata": {},
-          "execution_count": 18
-        }
-      ],
-      "source": [
-        "pd_flights.index"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 19,
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2021-12-15T20:24:38.583800Z",
-          "iopub.status.busy": "2021-12-15T20:24:38.582630Z",
-          "iopub.status.idle": "2021-12-15T20:24:38.588504Z",
-          "shell.execute_reply": "2021-12-15T20:24:38.589469Z"
-        },
-        "pycharm": {
-          "is_executing": false
-        },
-        "id": "puus-Fk7NRFS",
-        "outputId": "4ceebd2a-0009-4532-fabe-4a0d490541ec",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        }
-      },
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "<eland.index.Index at 0x7c7cf5552dd0>"
-            ]
-          },
-          "metadata": {},
-          "execution_count": 19
-        }
-      ],
-      "source": [
-        "# NBVAL_IGNORE_OUTPUT\n",
-        "ed_flights.index"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 20,
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2021-12-15T20:24:38.598654Z",
-          "iopub.status.busy": "2021-12-15T20:24:38.597416Z",
-          "iopub.status.idle": "2021-12-15T20:24:38.604549Z",
-          "shell.execute_reply": "2021-12-15T20:24:38.603361Z"
-        },
-        "pycharm": {
-          "is_executing": false
-        },
-        "id": "rvJ41P0BNRFT",
-        "outputId": "99d0f85c-3337-4bd7-f7d0-70b2a6702c42",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 35
-        }
-      },
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "'_id'"
-            ],
-            "application/vnd.google.colaboratory.intrinsic+json": {
-              "type": "string"
-            }
-          },
-          "metadata": {},
-          "execution_count": 20
-        }
-      ],
-      "source": [
-        "ed_flights.index.es_index_field"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "5JA3HKJgNRFT"
-      },
-      "source": [
-        "### DataFrame.values\n",
-        "\n",
-        "Note, `eland.DataFrame.values` is not supported."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 21,
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2021-12-15T20:24:38.634011Z",
-          "iopub.status.busy": "2021-12-15T20:24:38.629434Z",
-          "iopub.status.idle": "2021-12-15T20:24:38.681698Z",
-          "shell.execute_reply": "2021-12-15T20:24:38.681982Z"
-        },
-        "pycharm": {
-          "is_executing": false
-        },
-        "id": "oZYSyigXNRFU",
-        "outputId": "b781594f-4772-473e-e916-7fafdb8d3e65",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        }
-      },
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "array([[841.2656419677076, False, 'Kibana Airlines', ..., 'Sunny', 0,\n",
-              "        Timestamp('2018-01-01 00:00:00')],\n",
-              "       [882.9826615595518, False, 'Logstash Airways', ..., 'Clear', 0,\n",
-              "        Timestamp('2018-01-01 18:27:00')],\n",
-              "       [190.6369038508356, False, 'Logstash Airways', ..., 'Rain', 0,\n",
-              "        Timestamp('2018-01-01 17:11:14')],\n",
-              "       ...,\n",
-              "       [997.7518761454494, False, 'Logstash Airways', ..., 'Sunny', 6,\n",
-              "        Timestamp('2018-02-11 04:09:27')],\n",
-              "       [1102.8144645388556, False, 'JetBeats', ..., 'Hail', 6,\n",
-              "        Timestamp('2018-02-11 08:28:21')],\n",
-              "       [858.1443369038839, False, 'JetBeats', ..., 'Rain', 6,\n",
-              "        Timestamp('2018-02-11 14:54:34')]], dtype=object)"
-            ]
-          },
-          "metadata": {},
-          "execution_count": 21
-        }
-      ],
-      "source": [
-        "pd_flights.values"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 22,
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2021-12-15T20:24:38.685031Z",
-          "iopub.status.busy": "2021-12-15T20:24:38.684450Z",
-          "iopub.status.idle": "2021-12-15T20:24:38.687106Z",
-          "shell.execute_reply": "2021-12-15T20:24:38.686771Z"
-        },
-        "pycharm": {
-          "is_executing": false
-        },
-        "id": "gQTQLsmWNRFU",
-        "outputId": "761684f1-c8ac-49e8-c220-b7c886cdebba",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        }
-      },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "This method would scan/scroll the entire Elasticsearch index(s) into memory. If this is explicitly required, and there is sufficient memory, call `ed.eland_to_pandas(ed_df).values`\n"
-          ]
-        }
-      ],
-      "source": [
-        "try:\n",
-        "    ed_flights.values\n",
-        "except AttributeError as e:\n",
-        "    print(e)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "lKqYv_fTNRFV"
-      },
-      "source": [
-        "## Indexing, iteration"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "_RlN4vASNRFV"
-      },
-      "source": [
-        "### DataFrame.head"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 23,
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2021-12-15T20:24:38.694742Z",
-          "iopub.status.busy": "2021-12-15T20:24:38.694371Z",
-          "iopub.status.idle": "2021-12-15T20:24:38.696502Z",
-          "shell.execute_reply": "2021-12-15T20:24:38.696207Z"
-        },
-        "pycharm": {
-          "is_executing": false
-        },
-        "id": "PnuvMIlMNRFV",
-        "outputId": "315ae8c2-e827-451b-b886-69eb11a58ada",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 236
-        }
-      },
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "   AvgTicketPrice  Cancelled  ... dayOfWeek           timestamp\n",
-              "0      841.265642      False  ...         0 2018-01-01 00:00:00\n",
-              "1      882.982662      False  ...         0 2018-01-01 18:27:00\n",
-              "2      190.636904      False  ...         0 2018-01-01 17:11:14\n",
-              "3      181.694216       True  ...         0 2018-01-01 10:33:28\n",
-              "4      730.041778      False  ...         0 2018-01-01 05:13:00\n",
-              "\n",
-              "[5 rows x 27 columns]"
-            ],
-            "text/html": [
-              "\n",
-              "  <div id=\"df-448a03d4-dce8-46a9-baa4-4a72b55c4933\" class=\"colab-df-container\">\n",
-              "    <div>\n",
-              "<style scoped>\n",
-              "    .dataframe tbody tr th:only-of-type {\n",
-              "        vertical-align: middle;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe tbody tr th {\n",
-              "        vertical-align: top;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe thead th {\n",
-              "        text-align: right;\n",
-              "    }\n",
-              "</style>\n",
-              "<table border=\"1\" class=\"dataframe\">\n",
-              "  <thead>\n",
-              "    <tr style=\"text-align: right;\">\n",
-              "      <th></th>\n",
-              "      <th>AvgTicketPrice</th>\n",
-              "      <th>Cancelled</th>\n",
-              "      <th>...</th>\n",
-              "      <th>dayOfWeek</th>\n",
-              "      <th>timestamp</th>\n",
-              "    </tr>\n",
-              "  </thead>\n",
-              "  <tbody>\n",
-              "    <tr>\n",
-              "      <th>0</th>\n",
-              "      <td>841.265642</td>\n",
-              "      <td>False</td>\n",
-              "      <td>...</td>\n",
-              "      <td>0</td>\n",
-              "      <td>2018-01-01 00:00:00</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>1</th>\n",
-              "      <td>882.982662</td>\n",
-              "      <td>False</td>\n",
-              "      <td>...</td>\n",
-              "      <td>0</td>\n",
-              "      <td>2018-01-01 18:27:00</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>2</th>\n",
-              "      <td>190.636904</td>\n",
-              "      <td>False</td>\n",
-              "      <td>...</td>\n",
-              "      <td>0</td>\n",
-              "      <td>2018-01-01 17:11:14</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>3</th>\n",
-              "      <td>181.694216</td>\n",
-              "      <td>True</td>\n",
-              "      <td>...</td>\n",
-              "      <td>0</td>\n",
-              "      <td>2018-01-01 10:33:28</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>4</th>\n",
-              "      <td>730.041778</td>\n",
-              "      <td>False</td>\n",
-              "      <td>...</td>\n",
-              "      <td>0</td>\n",
-              "      <td>2018-01-01 05:13:00</td>\n",
-              "    </tr>\n",
-              "  </tbody>\n",
-              "</table>\n",
-              "<p>5 rows × 27 columns</p>\n",
-              "</div>\n",
-              "    <div class=\"colab-df-buttons\">\n",
-              "\n",
-              "  <div class=\"colab-df-container\">\n",
-              "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-448a03d4-dce8-46a9-baa4-4a72b55c4933')\"\n",
-              "            title=\"Convert this dataframe to an interactive table.\"\n",
-              "            style=\"display:none;\">\n",
-              "\n",
-              "  <svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\" viewBox=\"0 -960 960 960\">\n",
-              "    <path d=\"M120-120v-720h720v720H120Zm60-500h600v-160H180v160Zm220 220h160v-160H400v160Zm0 220h160v-160H400v160ZM180-400h160v-160H180v160Zm440 0h160v-160H620v160ZM180-180h160v-160H180v160Zm440 0h160v-160H620v160Z\"/>\n",
-              "  </svg>\n",
-              "    </button>\n",
-              "\n",
-              "  <style>\n",
-              "    .colab-df-container {\n",
-              "      display:flex;\n",
-              "      gap: 12px;\n",
-              "    }\n",
-              "\n",
-              "    .colab-df-convert {\n",
-              "      background-color: #E8F0FE;\n",
-              "      border: none;\n",
-              "      border-radius: 50%;\n",
-              "      cursor: pointer;\n",
-              "      display: none;\n",
-              "      fill: #1967D2;\n",
-              "      height: 32px;\n",
-              "      padding: 0 0 0 0;\n",
-              "      width: 32px;\n",
-              "    }\n",
-              "\n",
-              "    .colab-df-convert:hover {\n",
-              "      background-color: #E2EBFA;\n",
-              "      box-shadow: 0px 1px 2px rgba(60, 64, 67, 0.3), 0px 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
-              "      fill: #174EA6;\n",
-              "    }\n",
-              "\n",
-              "    .colab-df-buttons div {\n",
-              "      margin-bottom: 4px;\n",
-              "    }\n",
-              "\n",
-              "    [theme=dark] .colab-df-convert {\n",
-              "      background-color: #3B4455;\n",
-              "      fill: #D2E3FC;\n",
-              "    }\n",
-              "\n",
-              "    [theme=dark] .colab-df-convert:hover {\n",
-              "      background-color: #434B5C;\n",
-              "      box-shadow: 0px 1px 3px 1px rgba(0, 0, 0, 0.15);\n",
-              "      filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.3));\n",
-              "      fill: #FFFFFF;\n",
-              "    }\n",
-              "  </style>\n",
-              "\n",
-              "    <script>\n",
-              "      const buttonEl =\n",
-              "        document.querySelector('#df-448a03d4-dce8-46a9-baa4-4a72b55c4933 button.colab-df-convert');\n",
-              "      buttonEl.style.display =\n",
-              "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
-              "\n",
-              "      async function convertToInteractive(key) {\n",
-              "        const element = document.querySelector('#df-448a03d4-dce8-46a9-baa4-4a72b55c4933');\n",
-              "        const dataTable =\n",
-              "          await google.colab.kernel.invokeFunction('convertToInteractive',\n",
-              "                                                    [key], {});\n",
-              "        if (!dataTable) return;\n",
-              "\n",
-              "        const docLinkHtml = 'Like what you see? Visit the ' +\n",
-              "          '<a target=\"_blank\" href=https://colab.research.google.com/notebooks/data_table.ipynb>data table notebook</a>'\n",
-              "          + ' to learn more about interactive tables.';\n",
-              "        element.innerHTML = '';\n",
-              "        dataTable['output_type'] = 'display_data';\n",
-              "        await google.colab.output.renderOutput(dataTable, element);\n",
-              "        const docLink = document.createElement('div');\n",
-              "        docLink.innerHTML = docLinkHtml;\n",
-              "        element.appendChild(docLink);\n",
-              "      }\n",
-              "    </script>\n",
-              "  </div>\n",
-              "\n",
-              "\n",
-              "<div id=\"df-a82787a2-8947-4bc3-a3b6-890eb657f7ef\">\n",
-              "  <button class=\"colab-df-quickchart\" onclick=\"quickchart('df-a82787a2-8947-4bc3-a3b6-890eb657f7ef')\"\n",
-              "            title=\"Suggest charts.\"\n",
-              "            style=\"display:none;\">\n",
-              "\n",
-              "<svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\"viewBox=\"0 0 24 24\"\n",
-              "     width=\"24px\">\n",
-              "    <g>\n",
-              "        <path d=\"M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zM9 17H7v-7h2v7zm4 0h-2V7h2v10zm4 0h-2v-4h2v4z\"/>\n",
-              "    </g>\n",
-              "</svg>\n",
-              "  </button>\n",
-              "\n",
-              "<style>\n",
-              "  .colab-df-quickchart {\n",
-              "      --bg-color: #E8F0FE;\n",
-              "      --fill-color: #1967D2;\n",
-              "      --hover-bg-color: #E2EBFA;\n",
-              "      --hover-fill-color: #174EA6;\n",
-              "      --disabled-fill-color: #AAA;\n",
-              "      --disabled-bg-color: #DDD;\n",
-              "  }\n",
-              "\n",
-              "  [theme=dark] .colab-df-quickchart {\n",
-              "      --bg-color: #3B4455;\n",
-              "      --fill-color: #D2E3FC;\n",
-              "      --hover-bg-color: #434B5C;\n",
-              "      --hover-fill-color: #FFFFFF;\n",
-              "      --disabled-bg-color: #3B4455;\n",
-              "      --disabled-fill-color: #666;\n",
-              "  }\n",
-              "\n",
-              "  .colab-df-quickchart {\n",
-              "    background-color: var(--bg-color);\n",
-              "    border: none;\n",
-              "    border-radius: 50%;\n",
-              "    cursor: pointer;\n",
-              "    display: none;\n",
-              "    fill: var(--fill-color);\n",
-              "    height: 32px;\n",
-              "    padding: 0;\n",
-              "    width: 32px;\n",
-              "  }\n",
-              "\n",
-              "  .colab-df-quickchart:hover {\n",
-              "    background-color: var(--hover-bg-color);\n",
-              "    box-shadow: 0 1px 2px rgba(60, 64, 67, 0.3), 0 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
-              "    fill: var(--button-hover-fill-color);\n",
-              "  }\n",
-              "\n",
-              "  .colab-df-quickchart-complete:disabled,\n",
-              "  .colab-df-quickchart-complete:disabled:hover {\n",
-              "    background-color: var(--disabled-bg-color);\n",
-              "    fill: var(--disabled-fill-color);\n",
-              "    box-shadow: none;\n",
-              "  }\n",
-              "\n",
-              "  .colab-df-spinner {\n",
-              "    border: 2px solid var(--fill-color);\n",
-              "    border-color: transparent;\n",
-              "    border-bottom-color: var(--fill-color);\n",
-              "    animation:\n",
-              "      spin 1s steps(1) infinite;\n",
-              "  }\n",
-              "\n",
-              "  @keyframes spin {\n",
-              "    0% {\n",
-              "      border-color: transparent;\n",
-              "      border-bottom-color: var(--fill-color);\n",
-              "      border-left-color: var(--fill-color);\n",
-              "    }\n",
-              "    20% {\n",
-              "      border-color: transparent;\n",
-              "      border-left-color: var(--fill-color);\n",
-              "      border-top-color: var(--fill-color);\n",
-              "    }\n",
-              "    30% {\n",
-              "      border-color: transparent;\n",
-              "      border-left-color: var(--fill-color);\n",
-              "      border-top-color: var(--fill-color);\n",
-              "      border-right-color: var(--fill-color);\n",
-              "    }\n",
-              "    40% {\n",
-              "      border-color: transparent;\n",
-              "      border-right-color: var(--fill-color);\n",
-              "      border-top-color: var(--fill-color);\n",
-              "    }\n",
-              "    60% {\n",
-              "      border-color: transparent;\n",
-              "      border-right-color: var(--fill-color);\n",
-              "    }\n",
-              "    80% {\n",
-              "      border-color: transparent;\n",
-              "      border-right-color: var(--fill-color);\n",
-              "      border-bottom-color: var(--fill-color);\n",
-              "    }\n",
-              "    90% {\n",
-              "      border-color: transparent;\n",
-              "      border-bottom-color: var(--fill-color);\n",
-              "    }\n",
-              "  }\n",
-              "</style>\n",
-              "\n",
-              "  <script>\n",
-              "    async function quickchart(key) {\n",
-              "      const quickchartButtonEl =\n",
-              "        document.querySelector('#' + key + ' button');\n",
-              "      quickchartButtonEl.disabled = true;  // To prevent multiple clicks.\n",
-              "      quickchartButtonEl.classList.add('colab-df-spinner');\n",
-              "      try {\n",
-              "        const charts = await google.colab.kernel.invokeFunction(\n",
-              "            'suggestCharts', [key], {});\n",
-              "      } catch (error) {\n",
-              "        console.error('Error during call to suggestCharts:', error);\n",
-              "      }\n",
-              "      quickchartButtonEl.classList.remove('colab-df-spinner');\n",
-              "      quickchartButtonEl.classList.add('colab-df-quickchart-complete');\n",
-              "    }\n",
-              "    (() => {\n",
-              "      let quickchartButtonEl =\n",
-              "        document.querySelector('#df-a82787a2-8947-4bc3-a3b6-890eb657f7ef button');\n",
-              "      quickchartButtonEl.style.display =\n",
-              "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
-              "    })();\n",
-              "  </script>\n",
-              "</div>\n",
-              "    </div>\n",
-              "  </div>\n"
-            ]
-          },
-          "metadata": {},
-          "execution_count": 23
-        }
-      ],
-      "source": [
-        "pd_flights.head()"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 24,
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2021-12-15T20:24:38.699691Z",
-          "iopub.status.busy": "2021-12-15T20:24:38.699271Z",
-          "iopub.status.idle": "2021-12-15T20:24:40.675206Z",
-          "shell.execute_reply": "2021-12-15T20:24:40.676183Z"
-        },
-        "pycharm": {
-          "is_executing": false
-        },
-        "id": "i1-efE1RNRFW",
-        "outputId": "15bf7cde-edf5-41fc-ef66-7af780d95a99",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 236
-        }
-      },
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "   AvgTicketPrice  Cancelled  ... dayOfWeek           timestamp\n",
-              "0      841.265642      False  ...         0 2018-01-01 00:00:00\n",
-              "1      882.982662      False  ...         0 2018-01-01 18:27:00\n",
-              "2      190.636904      False  ...         0 2018-01-01 17:11:14\n",
-              "3      181.694216       True  ...         0 2018-01-01 10:33:28\n",
-              "4      730.041778      False  ...         0 2018-01-01 05:13:00\n",
-              "\n",
-              "[5 rows x 27 columns]"
-            ],
-            "text/html": [
-              "<div>\n",
-              "<style scoped>\n",
-              "    .dataframe tbody tr th:only-of-type {\n",
-              "        vertical-align: middle;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe tbody tr th {\n",
-              "        vertical-align: top;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe thead th {\n",
-              "        text-align: right;\n",
-              "    }\n",
-              "</style>\n",
-              "<table border=\"1\" class=\"dataframe\">\n",
-              "  <thead>\n",
-              "    <tr style=\"text-align: right;\">\n",
-              "      <th></th>\n",
-              "      <th>AvgTicketPrice</th>\n",
-              "      <th>Cancelled</th>\n",
-              "      <th>...</th>\n",
-              "      <th>dayOfWeek</th>\n",
-              "      <th>timestamp</th>\n",
-              "    </tr>\n",
-              "  </thead>\n",
-              "  <tbody>\n",
-              "    <tr>\n",
-              "      <th>0</th>\n",
-              "      <td>841.265642</td>\n",
-              "      <td>False</td>\n",
-              "      <td>...</td>\n",
-              "      <td>0</td>\n",
-              "      <td>2018-01-01 00:00:00</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>1</th>\n",
-              "      <td>882.982662</td>\n",
-              "      <td>False</td>\n",
-              "      <td>...</td>\n",
-              "      <td>0</td>\n",
-              "      <td>2018-01-01 18:27:00</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>2</th>\n",
-              "      <td>190.636904</td>\n",
-              "      <td>False</td>\n",
-              "      <td>...</td>\n",
-              "      <td>0</td>\n",
-              "      <td>2018-01-01 17:11:14</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>3</th>\n",
-              "      <td>181.694216</td>\n",
-              "      <td>True</td>\n",
-              "      <td>...</td>\n",
-              "      <td>0</td>\n",
-              "      <td>2018-01-01 10:33:28</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>4</th>\n",
-              "      <td>730.041778</td>\n",
-              "      <td>False</td>\n",
-              "      <td>...</td>\n",
-              "      <td>0</td>\n",
-              "      <td>2018-01-01 05:13:00</td>\n",
-              "    </tr>\n",
-              "  </tbody>\n",
-              "</table>\n",
-              "</div>\n",
-              "<p>5 rows × 27 columns</p>"
-            ]
-          },
-          "metadata": {},
-          "execution_count": 24
-        }
-      ],
-      "source": [
-        "ed_flights.head()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "55T-dd4ENRFW"
-      },
-      "source": [
-        "### DataFrame.tail"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 25,
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2021-12-15T20:24:40.695639Z",
-          "iopub.status.busy": "2021-12-15T20:24:40.694910Z",
-          "iopub.status.idle": "2021-12-15T20:24:40.698148Z",
-          "shell.execute_reply": "2021-12-15T20:24:40.698704Z"
-        },
-        "pycharm": {
-          "is_executing": false
-        },
-        "id": "MUKzwkRtNRFW",
-        "outputId": "d24b73d4-a18a-4029-fe89-3b4690ca7cc4",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 236
-        }
-      },
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "       AvgTicketPrice  Cancelled  ... dayOfWeek           timestamp\n",
-              "13054     1080.446279      False  ...         6 2018-02-11 20:42:25\n",
-              "13055      646.612941      False  ...         6 2018-02-11 01:41:57\n",
-              "13056      997.751876      False  ...         6 2018-02-11 04:09:27\n",
-              "13057     1102.814465      False  ...         6 2018-02-11 08:28:21\n",
-              "13058      858.144337      False  ...         6 2018-02-11 14:54:34\n",
-              "\n",
-              "[5 rows x 27 columns]"
-            ],
-            "text/html": [
-              "\n",
-              "  <div id=\"df-fc6a9899-85fb-44ed-a12f-f530428667d6\" class=\"colab-df-container\">\n",
-              "    <div>\n",
-              "<style scoped>\n",
-              "    .dataframe tbody tr th:only-of-type {\n",
-              "        vertical-align: middle;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe tbody tr th {\n",
-              "        vertical-align: top;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe thead th {\n",
-              "        text-align: right;\n",
-              "    }\n",
-              "</style>\n",
-              "<table border=\"1\" class=\"dataframe\">\n",
-              "  <thead>\n",
-              "    <tr style=\"text-align: right;\">\n",
-              "      <th></th>\n",
-              "      <th>AvgTicketPrice</th>\n",
-              "      <th>Cancelled</th>\n",
-              "      <th>...</th>\n",
-              "      <th>dayOfWeek</th>\n",
-              "      <th>timestamp</th>\n",
-              "    </tr>\n",
-              "  </thead>\n",
-              "  <tbody>\n",
-              "    <tr>\n",
-              "      <th>13054</th>\n",
-              "      <td>1080.446279</td>\n",
-              "      <td>False</td>\n",
-              "      <td>...</td>\n",
-              "      <td>6</td>\n",
-              "      <td>2018-02-11 20:42:25</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>13055</th>\n",
-              "      <td>646.612941</td>\n",
-              "      <td>False</td>\n",
-              "      <td>...</td>\n",
-              "      <td>6</td>\n",
-              "      <td>2018-02-11 01:41:57</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>13056</th>\n",
-              "      <td>997.751876</td>\n",
-              "      <td>False</td>\n",
-              "      <td>...</td>\n",
-              "      <td>6</td>\n",
-              "      <td>2018-02-11 04:09:27</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>13057</th>\n",
-              "      <td>1102.814465</td>\n",
-              "      <td>False</td>\n",
-              "      <td>...</td>\n",
-              "      <td>6</td>\n",
-              "      <td>2018-02-11 08:28:21</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>13058</th>\n",
-              "      <td>858.144337</td>\n",
-              "      <td>False</td>\n",
-              "      <td>...</td>\n",
-              "      <td>6</td>\n",
-              "      <td>2018-02-11 14:54:34</td>\n",
-              "    </tr>\n",
-              "  </tbody>\n",
-              "</table>\n",
-              "<p>5 rows × 27 columns</p>\n",
-              "</div>\n",
-              "    <div class=\"colab-df-buttons\">\n",
-              "\n",
-              "  <div class=\"colab-df-container\">\n",
-              "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-fc6a9899-85fb-44ed-a12f-f530428667d6')\"\n",
-              "            title=\"Convert this dataframe to an interactive table.\"\n",
-              "            style=\"display:none;\">\n",
-              "\n",
-              "  <svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\" viewBox=\"0 -960 960 960\">\n",
-              "    <path d=\"M120-120v-720h720v720H120Zm60-500h600v-160H180v160Zm220 220h160v-160H400v160Zm0 220h160v-160H400v160ZM180-400h160v-160H180v160Zm440 0h160v-160H620v160ZM180-180h160v-160H180v160Zm440 0h160v-160H620v160Z\"/>\n",
-              "  </svg>\n",
-              "    </button>\n",
-              "\n",
-              "  <style>\n",
-              "    .colab-df-container {\n",
-              "      display:flex;\n",
-              "      gap: 12px;\n",
-              "    }\n",
-              "\n",
-              "    .colab-df-convert {\n",
-              "      background-color: #E8F0FE;\n",
-              "      border: none;\n",
-              "      border-radius: 50%;\n",
-              "      cursor: pointer;\n",
-              "      display: none;\n",
-              "      fill: #1967D2;\n",
-              "      height: 32px;\n",
-              "      padding: 0 0 0 0;\n",
-              "      width: 32px;\n",
-              "    }\n",
-              "\n",
-              "    .colab-df-convert:hover {\n",
-              "      background-color: #E2EBFA;\n",
-              "      box-shadow: 0px 1px 2px rgba(60, 64, 67, 0.3), 0px 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
-              "      fill: #174EA6;\n",
-              "    }\n",
-              "\n",
-              "    .colab-df-buttons div {\n",
-              "      margin-bottom: 4px;\n",
-              "    }\n",
-              "\n",
-              "    [theme=dark] .colab-df-convert {\n",
-              "      background-color: #3B4455;\n",
-              "      fill: #D2E3FC;\n",
-              "    }\n",
-              "\n",
-              "    [theme=dark] .colab-df-convert:hover {\n",
-              "      background-color: #434B5C;\n",
-              "      box-shadow: 0px 1px 3px 1px rgba(0, 0, 0, 0.15);\n",
-              "      filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.3));\n",
-              "      fill: #FFFFFF;\n",
-              "    }\n",
-              "  </style>\n",
-              "\n",
-              "    <script>\n",
-              "      const buttonEl =\n",
-              "        document.querySelector('#df-fc6a9899-85fb-44ed-a12f-f530428667d6 button.colab-df-convert');\n",
-              "      buttonEl.style.display =\n",
-              "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
-              "\n",
-              "      async function convertToInteractive(key) {\n",
-              "        const element = document.querySelector('#df-fc6a9899-85fb-44ed-a12f-f530428667d6');\n",
-              "        const dataTable =\n",
-              "          await google.colab.kernel.invokeFunction('convertToInteractive',\n",
-              "                                                    [key], {});\n",
-              "        if (!dataTable) return;\n",
-              "\n",
-              "        const docLinkHtml = 'Like what you see? Visit the ' +\n",
-              "          '<a target=\"_blank\" href=https://colab.research.google.com/notebooks/data_table.ipynb>data table notebook</a>'\n",
-              "          + ' to learn more about interactive tables.';\n",
-              "        element.innerHTML = '';\n",
-              "        dataTable['output_type'] = 'display_data';\n",
-              "        await google.colab.output.renderOutput(dataTable, element);\n",
-              "        const docLink = document.createElement('div');\n",
-              "        docLink.innerHTML = docLinkHtml;\n",
-              "        element.appendChild(docLink);\n",
-              "      }\n",
-              "    </script>\n",
-              "  </div>\n",
-              "\n",
-              "\n",
-              "<div id=\"df-919a1323-b973-4b60-ae1a-e0b4f41a04e2\">\n",
-              "  <button class=\"colab-df-quickchart\" onclick=\"quickchart('df-919a1323-b973-4b60-ae1a-e0b4f41a04e2')\"\n",
-              "            title=\"Suggest charts.\"\n",
-              "            style=\"display:none;\">\n",
-              "\n",
-              "<svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\"viewBox=\"0 0 24 24\"\n",
-              "     width=\"24px\">\n",
-              "    <g>\n",
-              "        <path d=\"M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zM9 17H7v-7h2v7zm4 0h-2V7h2v10zm4 0h-2v-4h2v4z\"/>\n",
-              "    </g>\n",
-              "</svg>\n",
-              "  </button>\n",
-              "\n",
-              "<style>\n",
-              "  .colab-df-quickchart {\n",
-              "      --bg-color: #E8F0FE;\n",
-              "      --fill-color: #1967D2;\n",
-              "      --hover-bg-color: #E2EBFA;\n",
-              "      --hover-fill-color: #174EA6;\n",
-              "      --disabled-fill-color: #AAA;\n",
-              "      --disabled-bg-color: #DDD;\n",
-              "  }\n",
-              "\n",
-              "  [theme=dark] .colab-df-quickchart {\n",
-              "      --bg-color: #3B4455;\n",
-              "      --fill-color: #D2E3FC;\n",
-              "      --hover-bg-color: #434B5C;\n",
-              "      --hover-fill-color: #FFFFFF;\n",
-              "      --disabled-bg-color: #3B4455;\n",
-              "      --disabled-fill-color: #666;\n",
-              "  }\n",
-              "\n",
-              "  .colab-df-quickchart {\n",
-              "    background-color: var(--bg-color);\n",
-              "    border: none;\n",
-              "    border-radius: 50%;\n",
-              "    cursor: pointer;\n",
-              "    display: none;\n",
-              "    fill: var(--fill-color);\n",
-              "    height: 32px;\n",
-              "    padding: 0;\n",
-              "    width: 32px;\n",
-              "  }\n",
-              "\n",
-              "  .colab-df-quickchart:hover {\n",
-              "    background-color: var(--hover-bg-color);\n",
-              "    box-shadow: 0 1px 2px rgba(60, 64, 67, 0.3), 0 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
-              "    fill: var(--button-hover-fill-color);\n",
-              "  }\n",
-              "\n",
-              "  .colab-df-quickchart-complete:disabled,\n",
-              "  .colab-df-quickchart-complete:disabled:hover {\n",
-              "    background-color: var(--disabled-bg-color);\n",
-              "    fill: var(--disabled-fill-color);\n",
-              "    box-shadow: none;\n",
-              "  }\n",
-              "\n",
-              "  .colab-df-spinner {\n",
-              "    border: 2px solid var(--fill-color);\n",
-              "    border-color: transparent;\n",
-              "    border-bottom-color: var(--fill-color);\n",
-              "    animation:\n",
-              "      spin 1s steps(1) infinite;\n",
-              "  }\n",
-              "\n",
-              "  @keyframes spin {\n",
-              "    0% {\n",
-              "      border-color: transparent;\n",
-              "      border-bottom-color: var(--fill-color);\n",
-              "      border-left-color: var(--fill-color);\n",
-              "    }\n",
-              "    20% {\n",
-              "      border-color: transparent;\n",
-              "      border-left-color: var(--fill-color);\n",
-              "      border-top-color: var(--fill-color);\n",
-              "    }\n",
-              "    30% {\n",
-              "      border-color: transparent;\n",
-              "      border-left-color: var(--fill-color);\n",
-              "      border-top-color: var(--fill-color);\n",
-              "      border-right-color: var(--fill-color);\n",
-              "    }\n",
-              "    40% {\n",
-              "      border-color: transparent;\n",
-              "      border-right-color: var(--fill-color);\n",
-              "      border-top-color: var(--fill-color);\n",
-              "    }\n",
-              "    60% {\n",
-              "      border-color: transparent;\n",
-              "      border-right-color: var(--fill-color);\n",
-              "    }\n",
-              "    80% {\n",
-              "      border-color: transparent;\n",
-              "      border-right-color: var(--fill-color);\n",
-              "      border-bottom-color: var(--fill-color);\n",
-              "    }\n",
-              "    90% {\n",
-              "      border-color: transparent;\n",
-              "      border-bottom-color: var(--fill-color);\n",
-              "    }\n",
-              "  }\n",
-              "</style>\n",
-              "\n",
-              "  <script>\n",
-              "    async function quickchart(key) {\n",
-              "      const quickchartButtonEl =\n",
-              "        document.querySelector('#' + key + ' button');\n",
-              "      quickchartButtonEl.disabled = true;  // To prevent multiple clicks.\n",
-              "      quickchartButtonEl.classList.add('colab-df-spinner');\n",
-              "      try {\n",
-              "        const charts = await google.colab.kernel.invokeFunction(\n",
-              "            'suggestCharts', [key], {});\n",
-              "      } catch (error) {\n",
-              "        console.error('Error during call to suggestCharts:', error);\n",
-              "      }\n",
-              "      quickchartButtonEl.classList.remove('colab-df-spinner');\n",
-              "      quickchartButtonEl.classList.add('colab-df-quickchart-complete');\n",
-              "    }\n",
-              "    (() => {\n",
-              "      let quickchartButtonEl =\n",
-              "        document.querySelector('#df-919a1323-b973-4b60-ae1a-e0b4f41a04e2 button');\n",
-              "      quickchartButtonEl.style.display =\n",
-              "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
-              "    })();\n",
-              "  </script>\n",
-              "</div>\n",
-              "    </div>\n",
-              "  </div>\n"
-            ]
-          },
-          "metadata": {},
-          "execution_count": 25
-        }
-      ],
-      "source": [
-        "pd_flights.tail()"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 26,
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2021-12-15T20:24:40.703670Z",
-          "iopub.status.busy": "2021-12-15T20:24:40.702923Z",
-          "iopub.status.idle": "2021-12-15T20:24:42.789898Z",
-          "shell.execute_reply": "2021-12-15T20:24:42.789460Z"
-        },
-        "pycharm": {
-          "is_executing": false
-        },
-        "id": "wnFnjtDGNRFW",
-        "outputId": "6a2f8812-762a-4a01-ef35-e1cc552f5f2c",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 236
-        }
-      },
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "       AvgTicketPrice  Cancelled  ... dayOfWeek           timestamp\n",
-              "13054     1080.446279      False  ...         6 2018-02-11 20:42:25\n",
-              "13055      646.612941      False  ...         6 2018-02-11 01:41:57\n",
-              "13056      997.751876      False  ...         6 2018-02-11 04:09:27\n",
-              "13057     1102.814465      False  ...         6 2018-02-11 08:28:21\n",
-              "13058      858.144337      False  ...         6 2018-02-11 14:54:34\n",
-              "\n",
-              "[5 rows x 27 columns]"
-            ],
-            "text/html": [
-              "<div>\n",
-              "<style scoped>\n",
-              "    .dataframe tbody tr th:only-of-type {\n",
-              "        vertical-align: middle;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe tbody tr th {\n",
-              "        vertical-align: top;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe thead th {\n",
-              "        text-align: right;\n",
-              "    }\n",
-              "</style>\n",
-              "<table border=\"1\" class=\"dataframe\">\n",
-              "  <thead>\n",
-              "    <tr style=\"text-align: right;\">\n",
-              "      <th></th>\n",
-              "      <th>AvgTicketPrice</th>\n",
-              "      <th>Cancelled</th>\n",
-              "      <th>...</th>\n",
-              "      <th>dayOfWeek</th>\n",
-              "      <th>timestamp</th>\n",
-              "    </tr>\n",
-              "  </thead>\n",
-              "  <tbody>\n",
-              "    <tr>\n",
-              "      <th>13054</th>\n",
-              "      <td>1080.446279</td>\n",
-              "      <td>False</td>\n",
-              "      <td>...</td>\n",
-              "      <td>6</td>\n",
-              "      <td>2018-02-11 20:42:25</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>13055</th>\n",
-              "      <td>646.612941</td>\n",
-              "      <td>False</td>\n",
-              "      <td>...</td>\n",
-              "      <td>6</td>\n",
-              "      <td>2018-02-11 01:41:57</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>13056</th>\n",
-              "      <td>997.751876</td>\n",
-              "      <td>False</td>\n",
-              "      <td>...</td>\n",
-              "      <td>6</td>\n",
-              "      <td>2018-02-11 04:09:27</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>13057</th>\n",
-              "      <td>1102.814465</td>\n",
-              "      <td>False</td>\n",
-              "      <td>...</td>\n",
-              "      <td>6</td>\n",
-              "      <td>2018-02-11 08:28:21</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>13058</th>\n",
-              "      <td>858.144337</td>\n",
-              "      <td>False</td>\n",
-              "      <td>...</td>\n",
-              "      <td>6</td>\n",
-              "      <td>2018-02-11 14:54:34</td>\n",
-              "    </tr>\n",
-              "  </tbody>\n",
-              "</table>\n",
-              "</div>\n",
-              "<p>5 rows × 27 columns</p>"
-            ]
-          },
-          "metadata": {},
-          "execution_count": 26
-        }
-      ],
-      "source": [
-        "ed_flights.tail()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "y8nBZkIPNRFX"
-      },
-      "source": [
-        "### DataFrame.keys"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 27,
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2021-12-15T20:24:42.793363Z",
-          "iopub.status.busy": "2021-12-15T20:24:42.791765Z",
-          "iopub.status.idle": "2021-12-15T20:24:42.796116Z",
-          "shell.execute_reply": "2021-12-15T20:24:42.795742Z"
-        },
-        "pycharm": {
-          "is_executing": false
-        },
-        "id": "NNt89qcvNRFX",
-        "outputId": "23ff7790-c863-48c6-f933-ed240fa4aa9c",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        }
-      },
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "Index(['AvgTicketPrice', 'Cancelled', 'Carrier', 'Dest', 'DestAirportID', 'DestCityName',\n",
-              "       'DestCountry', 'DestLocation', 'DestRegion', 'DestWeather', 'DistanceKilometers',\n",
-              "       'DistanceMiles', 'FlightDelay', 'FlightDelayMin', 'FlightDelayType', 'FlightNum',\n",
-              "       'FlightTimeHour', 'FlightTimeMin', 'Origin', 'OriginAirportID', 'OriginCityName',\n",
-              "       'OriginCountry', 'OriginLocation', 'OriginRegion', 'OriginWeather', 'dayOfWeek',\n",
-              "       'timestamp'],\n",
-              "      dtype='object')"
-            ]
-          },
-          "metadata": {},
-          "execution_count": 27
-        }
-      ],
-      "source": [
-        "pd_flights.keys()"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 28,
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2021-12-15T20:24:42.799972Z",
-          "iopub.status.busy": "2021-12-15T20:24:42.799336Z",
-          "iopub.status.idle": "2021-12-15T20:24:42.802144Z",
-          "shell.execute_reply": "2021-12-15T20:24:42.801772Z"
-        },
-        "pycharm": {
-          "is_executing": false
-        },
-        "id": "zsEuViUSNRFX",
-        "outputId": "b9506acf-62ed-45e9-fec9-ffa1a7e0f392",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        }
-      },
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "Index(['AvgTicketPrice', 'Cancelled', 'Carrier', 'Dest', 'DestAirportID', 'DestCityName',\n",
-              "       'DestCountry', 'DestLocation', 'DestRegion', 'DestWeather', 'DistanceKilometers',\n",
-              "       'DistanceMiles', 'FlightDelay', 'FlightDelayMin', 'FlightDelayType', 'FlightNum',\n",
-              "       'FlightTimeHour', 'FlightTimeMin', 'Origin', 'OriginAirportID', 'OriginCityName',\n",
-              "       'OriginCountry', 'OriginLocation', 'OriginRegion', 'OriginWeather', 'dayOfWeek',\n",
-              "       'timestamp'],\n",
-              "      dtype='object')"
-            ]
-          },
-          "metadata": {},
-          "execution_count": 28
-        }
-      ],
-      "source": [
-        "ed_flights.keys()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "KtypOwLUNRFX"
-      },
-      "source": [
-        "### DataFrame.get"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 29,
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2021-12-15T20:24:42.807664Z",
-          "iopub.status.busy": "2021-12-15T20:24:42.807137Z",
-          "iopub.status.idle": "2021-12-15T20:24:42.809592Z",
-          "shell.execute_reply": "2021-12-15T20:24:42.809225Z"
-        },
-        "pycharm": {
-          "is_executing": false
-        },
-        "id": "kFa9r_yQNRFY",
-        "outputId": "2c193851-2f59-427c-cf63-d420209e086f",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        }
-      },
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "0         Kibana Airlines\n",
-              "1        Logstash Airways\n",
-              "2        Logstash Airways\n",
-              "3         Kibana Airlines\n",
-              "4         Kibana Airlines\n",
-              "               ...       \n",
-              "13054    Logstash Airways\n",
-              "13055    Logstash Airways\n",
-              "13056    Logstash Airways\n",
-              "13057            JetBeats\n",
-              "13058            JetBeats\n",
-              "Name: Carrier, Length: 13059, dtype: object"
-            ]
-          },
-          "metadata": {},
-          "execution_count": 29
-        }
-      ],
-      "source": [
-        "pd_flights.get('Carrier')"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 30,
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2021-12-15T20:24:42.813306Z",
-          "iopub.status.busy": "2021-12-15T20:24:42.812951Z",
-          "iopub.status.idle": "2021-12-15T20:24:44.238665Z",
-          "shell.execute_reply": "2021-12-15T20:24:44.239468Z"
-        },
-        "pycharm": {
-          "is_executing": false
-        },
-        "id": "Fp52TYwGNRFY",
-        "outputId": "f45d1ae9-77b0-4fcc-f9b7-22fa7824f060",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        }
-      },
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "0         Kibana Airlines\n",
-              "1        Logstash Airways\n",
-              "2        Logstash Airways\n",
-              "3         Kibana Airlines\n",
-              "4         Kibana Airlines\n",
-              "               ...       \n",
-              "13054    Logstash Airways\n",
-              "13055    Logstash Airways\n",
-              "13056    Logstash Airways\n",
-              "13057            JetBeats\n",
-              "13058            JetBeats\n",
-              "Name: Carrier, Length: 13059, dtype: object"
-            ]
-          },
-          "metadata": {},
-          "execution_count": 30
-        }
-      ],
-      "source": [
-        "ed_flights.get('Carrier')"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 31,
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2021-12-15T20:24:44.252784Z",
-          "iopub.status.busy": "2021-12-15T20:24:44.244955Z",
-          "iopub.status.idle": "2021-12-15T20:24:44.257030Z",
-          "shell.execute_reply": "2021-12-15T20:24:44.258040Z"
-        },
-        "pycharm": {
-          "is_executing": false
-        },
-        "id": "-1zPSsGHNRFY",
-        "outputId": "2f034c29-21f7-4b98-d17a-3844e20c223b",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 424
-        }
-      },
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "                Carrier                                             Origin\n",
-              "0       Kibana Airlines                          Frankfurt am Main Airport\n",
-              "1      Logstash Airways                    Cape Town International Airport\n",
-              "2      Logstash Airways                          Venice Marco Polo Airport\n",
-              "3       Kibana Airlines                       Naples International Airport\n",
-              "4       Kibana Airlines     Licenciado Benito Juarez International Airport\n",
-              "...                 ...                                                ...\n",
-              "13054  Logstash Airways                         Pisa International Airport\n",
-              "13055  Logstash Airways  Winnipeg / James Armstrong Richardson Internat...\n",
-              "13056  Logstash Airways     Licenciado Benito Juarez International Airport\n",
-              "13057          JetBeats                                      Itami Airport\n",
-              "13058          JetBeats                     Adelaide International Airport\n",
-              "\n",
-              "[13059 rows x 2 columns]"
-            ],
-            "text/html": [
-              "\n",
-              "  <div id=\"df-839ab481-cb93-432b-8e22-3ceed218a732\" class=\"colab-df-container\">\n",
-              "    <div>\n",
-              "<style scoped>\n",
-              "    .dataframe tbody tr th:only-of-type {\n",
-              "        vertical-align: middle;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe tbody tr th {\n",
-              "        vertical-align: top;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe thead th {\n",
-              "        text-align: right;\n",
-              "    }\n",
-              "</style>\n",
-              "<table border=\"1\" class=\"dataframe\">\n",
-              "  <thead>\n",
-              "    <tr style=\"text-align: right;\">\n",
-              "      <th></th>\n",
-              "      <th>Carrier</th>\n",
-              "      <th>Origin</th>\n",
-              "    </tr>\n",
-              "  </thead>\n",
-              "  <tbody>\n",
-              "    <tr>\n",
-              "      <th>0</th>\n",
-              "      <td>Kibana Airlines</td>\n",
-              "      <td>Frankfurt am Main Airport</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>1</th>\n",
-              "      <td>Logstash Airways</td>\n",
-              "      <td>Cape Town International Airport</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>2</th>\n",
-              "      <td>Logstash Airways</td>\n",
-              "      <td>Venice Marco Polo Airport</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>3</th>\n",
-              "      <td>Kibana Airlines</td>\n",
-              "      <td>Naples International Airport</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>4</th>\n",
-              "      <td>Kibana Airlines</td>\n",
-              "      <td>Licenciado Benito Juarez International Airport</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>...</th>\n",
-              "      <td>...</td>\n",
-              "      <td>...</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>13054</th>\n",
-              "      <td>Logstash Airways</td>\n",
-              "      <td>Pisa International Airport</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>13055</th>\n",
-              "      <td>Logstash Airways</td>\n",
-              "      <td>Winnipeg / James Armstrong Richardson Internat...</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>13056</th>\n",
-              "      <td>Logstash Airways</td>\n",
-              "      <td>Licenciado Benito Juarez International Airport</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>13057</th>\n",
-              "      <td>JetBeats</td>\n",
-              "      <td>Itami Airport</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>13058</th>\n",
-              "      <td>JetBeats</td>\n",
-              "      <td>Adelaide International Airport</td>\n",
-              "    </tr>\n",
-              "  </tbody>\n",
-              "</table>\n",
-              "<p>13059 rows × 2 columns</p>\n",
-              "</div>\n",
-              "    <div class=\"colab-df-buttons\">\n",
-              "\n",
-              "  <div class=\"colab-df-container\">\n",
-              "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-839ab481-cb93-432b-8e22-3ceed218a732')\"\n",
-              "            title=\"Convert this dataframe to an interactive table.\"\n",
-              "            style=\"display:none;\">\n",
-              "\n",
-              "  <svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\" viewBox=\"0 -960 960 960\">\n",
-              "    <path d=\"M120-120v-720h720v720H120Zm60-500h600v-160H180v160Zm220 220h160v-160H400v160Zm0 220h160v-160H400v160ZM180-400h160v-160H180v160Zm440 0h160v-160H620v160ZM180-180h160v-160H180v160Zm440 0h160v-160H620v160Z\"/>\n",
-              "  </svg>\n",
-              "    </button>\n",
-              "\n",
-              "  <style>\n",
-              "    .colab-df-container {\n",
-              "      display:flex;\n",
-              "      gap: 12px;\n",
-              "    }\n",
-              "\n",
-              "    .colab-df-convert {\n",
-              "      background-color: #E8F0FE;\n",
-              "      border: none;\n",
-              "      border-radius: 50%;\n",
-              "      cursor: pointer;\n",
-              "      display: none;\n",
-              "      fill: #1967D2;\n",
-              "      height: 32px;\n",
-              "      padding: 0 0 0 0;\n",
-              "      width: 32px;\n",
-              "    }\n",
-              "\n",
-              "    .colab-df-convert:hover {\n",
-              "      background-color: #E2EBFA;\n",
-              "      box-shadow: 0px 1px 2px rgba(60, 64, 67, 0.3), 0px 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
-              "      fill: #174EA6;\n",
-              "    }\n",
-              "\n",
-              "    .colab-df-buttons div {\n",
-              "      margin-bottom: 4px;\n",
-              "    }\n",
-              "\n",
-              "    [theme=dark] .colab-df-convert {\n",
-              "      background-color: #3B4455;\n",
-              "      fill: #D2E3FC;\n",
-              "    }\n",
-              "\n",
-              "    [theme=dark] .colab-df-convert:hover {\n",
-              "      background-color: #434B5C;\n",
-              "      box-shadow: 0px 1px 3px 1px rgba(0, 0, 0, 0.15);\n",
-              "      filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.3));\n",
-              "      fill: #FFFFFF;\n",
-              "    }\n",
-              "  </style>\n",
-              "\n",
-              "    <script>\n",
-              "      const buttonEl =\n",
-              "        document.querySelector('#df-839ab481-cb93-432b-8e22-3ceed218a732 button.colab-df-convert');\n",
-              "      buttonEl.style.display =\n",
-              "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
-              "\n",
-              "      async function convertToInteractive(key) {\n",
-              "        const element = document.querySelector('#df-839ab481-cb93-432b-8e22-3ceed218a732');\n",
-              "        const dataTable =\n",
-              "          await google.colab.kernel.invokeFunction('convertToInteractive',\n",
-              "                                                    [key], {});\n",
-              "        if (!dataTable) return;\n",
-              "\n",
-              "        const docLinkHtml = 'Like what you see? Visit the ' +\n",
-              "          '<a target=\"_blank\" href=https://colab.research.google.com/notebooks/data_table.ipynb>data table notebook</a>'\n",
-              "          + ' to learn more about interactive tables.';\n",
-              "        element.innerHTML = '';\n",
-              "        dataTable['output_type'] = 'display_data';\n",
-              "        await google.colab.output.renderOutput(dataTable, element);\n",
-              "        const docLink = document.createElement('div');\n",
-              "        docLink.innerHTML = docLinkHtml;\n",
-              "        element.appendChild(docLink);\n",
-              "      }\n",
-              "    </script>\n",
-              "  </div>\n",
-              "\n",
-              "\n",
-              "<div id=\"df-9835d2bd-db66-41e3-9844-02f122edecc1\">\n",
-              "  <button class=\"colab-df-quickchart\" onclick=\"quickchart('df-9835d2bd-db66-41e3-9844-02f122edecc1')\"\n",
-              "            title=\"Suggest charts.\"\n",
-              "            style=\"display:none;\">\n",
-              "\n",
-              "<svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\"viewBox=\"0 0 24 24\"\n",
-              "     width=\"24px\">\n",
-              "    <g>\n",
-              "        <path d=\"M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zM9 17H7v-7h2v7zm4 0h-2V7h2v10zm4 0h-2v-4h2v4z\"/>\n",
-              "    </g>\n",
-              "</svg>\n",
-              "  </button>\n",
-              "\n",
-              "<style>\n",
-              "  .colab-df-quickchart {\n",
-              "      --bg-color: #E8F0FE;\n",
-              "      --fill-color: #1967D2;\n",
-              "      --hover-bg-color: #E2EBFA;\n",
-              "      --hover-fill-color: #174EA6;\n",
-              "      --disabled-fill-color: #AAA;\n",
-              "      --disabled-bg-color: #DDD;\n",
-              "  }\n",
-              "\n",
-              "  [theme=dark] .colab-df-quickchart {\n",
-              "      --bg-color: #3B4455;\n",
-              "      --fill-color: #D2E3FC;\n",
-              "      --hover-bg-color: #434B5C;\n",
-              "      --hover-fill-color: #FFFFFF;\n",
-              "      --disabled-bg-color: #3B4455;\n",
-              "      --disabled-fill-color: #666;\n",
-              "  }\n",
-              "\n",
-              "  .colab-df-quickchart {\n",
-              "    background-color: var(--bg-color);\n",
-              "    border: none;\n",
-              "    border-radius: 50%;\n",
-              "    cursor: pointer;\n",
-              "    display: none;\n",
-              "    fill: var(--fill-color);\n",
-              "    height: 32px;\n",
-              "    padding: 0;\n",
-              "    width: 32px;\n",
-              "  }\n",
-              "\n",
-              "  .colab-df-quickchart:hover {\n",
-              "    background-color: var(--hover-bg-color);\n",
-              "    box-shadow: 0 1px 2px rgba(60, 64, 67, 0.3), 0 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
-              "    fill: var(--button-hover-fill-color);\n",
-              "  }\n",
-              "\n",
-              "  .colab-df-quickchart-complete:disabled,\n",
-              "  .colab-df-quickchart-complete:disabled:hover {\n",
-              "    background-color: var(--disabled-bg-color);\n",
-              "    fill: var(--disabled-fill-color);\n",
-              "    box-shadow: none;\n",
-              "  }\n",
-              "\n",
-              "  .colab-df-spinner {\n",
-              "    border: 2px solid var(--fill-color);\n",
-              "    border-color: transparent;\n",
-              "    border-bottom-color: var(--fill-color);\n",
-              "    animation:\n",
-              "      spin 1s steps(1) infinite;\n",
-              "  }\n",
-              "\n",
-              "  @keyframes spin {\n",
-              "    0% {\n",
-              "      border-color: transparent;\n",
-              "      border-bottom-color: var(--fill-color);\n",
-              "      border-left-color: var(--fill-color);\n",
-              "    }\n",
-              "    20% {\n",
-              "      border-color: transparent;\n",
-              "      border-left-color: var(--fill-color);\n",
-              "      border-top-color: var(--fill-color);\n",
-              "    }\n",
-              "    30% {\n",
-              "      border-color: transparent;\n",
-              "      border-left-color: var(--fill-color);\n",
-              "      border-top-color: var(--fill-color);\n",
-              "      border-right-color: var(--fill-color);\n",
-              "    }\n",
-              "    40% {\n",
-              "      border-color: transparent;\n",
-              "      border-right-color: var(--fill-color);\n",
-              "      border-top-color: var(--fill-color);\n",
-              "    }\n",
-              "    60% {\n",
-              "      border-color: transparent;\n",
-              "      border-right-color: var(--fill-color);\n",
-              "    }\n",
-              "    80% {\n",
-              "      border-color: transparent;\n",
-              "      border-right-color: var(--fill-color);\n",
-              "      border-bottom-color: var(--fill-color);\n",
-              "    }\n",
-              "    90% {\n",
-              "      border-color: transparent;\n",
-              "      border-bottom-color: var(--fill-color);\n",
-              "    }\n",
-              "  }\n",
-              "</style>\n",
-              "\n",
-              "  <script>\n",
-              "    async function quickchart(key) {\n",
-              "      const quickchartButtonEl =\n",
-              "        document.querySelector('#' + key + ' button');\n",
-              "      quickchartButtonEl.disabled = true;  // To prevent multiple clicks.\n",
-              "      quickchartButtonEl.classList.add('colab-df-spinner');\n",
-              "      try {\n",
-              "        const charts = await google.colab.kernel.invokeFunction(\n",
-              "            'suggestCharts', [key], {});\n",
-              "      } catch (error) {\n",
-              "        console.error('Error during call to suggestCharts:', error);\n",
-              "      }\n",
-              "      quickchartButtonEl.classList.remove('colab-df-spinner');\n",
-              "      quickchartButtonEl.classList.add('colab-df-quickchart-complete');\n",
-              "    }\n",
-              "    (() => {\n",
-              "      let quickchartButtonEl =\n",
-              "        document.querySelector('#df-9835d2bd-db66-41e3-9844-02f122edecc1 button');\n",
-              "      quickchartButtonEl.style.display =\n",
-              "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
-              "    })();\n",
-              "  </script>\n",
-              "</div>\n",
-              "    </div>\n",
-              "  </div>\n"
-            ]
-          },
-          "metadata": {},
-          "execution_count": 31
-        }
-      ],
-      "source": [
-        "pd_flights.get(['Carrier', 'Origin'])"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "Fk7pTfyGNRFZ"
-      },
-      "source": [
-        "List input not currently supported by `eland.DataFrame.get`"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 32,
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2021-12-15T20:24:44.263674Z",
-          "iopub.status.busy": "2021-12-15T20:24:44.261671Z",
-          "iopub.status.idle": "2021-12-15T20:24:44.266564Z",
-          "shell.execute_reply": "2021-12-15T20:24:44.267454Z"
-        },
-        "pycharm": {
-          "is_executing": false
-        },
-        "id": "iIGNGv6NNRFZ",
-        "outputId": "dd15cda4-0952-4fc3-f66b-c237eb0e29df",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        }
-      },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "unhashable type: 'list'\n"
-          ]
-        }
-      ],
-      "source": [
-        "try:\n",
-        "    ed_flights.get(['Carrier', 'Origin'])\n",
-        "except TypeError as e:\n",
-        "    print(e)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "jygQjxYRNRFa"
-      },
-      "source": [
-        "### DataFrame.query"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 33,
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2021-12-15T20:24:44.291893Z",
-          "iopub.status.busy": "2021-12-15T20:24:44.279615Z",
-          "iopub.status.idle": "2021-12-15T20:24:44.294715Z",
-          "shell.execute_reply": "2021-12-15T20:24:44.294192Z"
-        },
-        "pycharm": {
-          "is_executing": false
-        },
-        "id": "fpKfuV-uNRFa",
-        "outputId": "5c9ce26c-e631-4d87-b9c9-0f309f3e278b",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 424
-        }
-      },
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "       AvgTicketPrice  Cancelled  ... dayOfWeek           timestamp\n",
-              "8          960.869736       True  ...         0 2018-01-01 12:09:35\n",
-              "26         975.812632       True  ...         0 2018-01-01 15:38:32\n",
-              "311        946.358410       True  ...         0 2018-01-01 11:51:12\n",
-              "651        975.383864       True  ...         2 2018-01-03 21:13:17\n",
-              "950        907.836523       True  ...         2 2018-01-03 05:14:51\n",
-              "...               ...        ...  ...       ...                 ...\n",
-              "12820      909.973606       True  ...         5 2018-02-10 05:11:35\n",
-              "12906      983.429244       True  ...         6 2018-02-11 06:19:58\n",
-              "12918     1136.678150       True  ...         6 2018-02-11 16:03:10\n",
-              "12919     1105.211803       True  ...         6 2018-02-11 05:36:05\n",
-              "13013     1055.350213       True  ...         6 2018-02-11 13:20:16\n",
-              "\n",
-              "[68 rows x 27 columns]"
-            ],
-            "text/html": [
-              "\n",
-              "  <div id=\"df-e2228412-ba39-472a-8ecb-703ccdb66ee0\" class=\"colab-df-container\">\n",
-              "    <div>\n",
-              "<style scoped>\n",
-              "    .dataframe tbody tr th:only-of-type {\n",
-              "        vertical-align: middle;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe tbody tr th {\n",
-              "        vertical-align: top;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe thead th {\n",
-              "        text-align: right;\n",
-              "    }\n",
-              "</style>\n",
-              "<table border=\"1\" class=\"dataframe\">\n",
-              "  <thead>\n",
-              "    <tr style=\"text-align: right;\">\n",
-              "      <th></th>\n",
-              "      <th>AvgTicketPrice</th>\n",
-              "      <th>Cancelled</th>\n",
-              "      <th>...</th>\n",
-              "      <th>dayOfWeek</th>\n",
-              "      <th>timestamp</th>\n",
-              "    </tr>\n",
-              "  </thead>\n",
-              "  <tbody>\n",
-              "    <tr>\n",
-              "      <th>8</th>\n",
-              "      <td>960.869736</td>\n",
-              "      <td>True</td>\n",
-              "      <td>...</td>\n",
-              "      <td>0</td>\n",
-              "      <td>2018-01-01 12:09:35</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>26</th>\n",
-              "      <td>975.812632</td>\n",
-              "      <td>True</td>\n",
-              "      <td>...</td>\n",
-              "      <td>0</td>\n",
-              "      <td>2018-01-01 15:38:32</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>311</th>\n",
-              "      <td>946.358410</td>\n",
-              "      <td>True</td>\n",
-              "      <td>...</td>\n",
-              "      <td>0</td>\n",
-              "      <td>2018-01-01 11:51:12</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>651</th>\n",
-              "      <td>975.383864</td>\n",
-              "      <td>True</td>\n",
-              "      <td>...</td>\n",
-              "      <td>2</td>\n",
-              "      <td>2018-01-03 21:13:17</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>950</th>\n",
-              "      <td>907.836523</td>\n",
-              "      <td>True</td>\n",
-              "      <td>...</td>\n",
-              "      <td>2</td>\n",
-              "      <td>2018-01-03 05:14:51</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>...</th>\n",
-              "      <td>...</td>\n",
-              "      <td>...</td>\n",
-              "      <td>...</td>\n",
-              "      <td>...</td>\n",
-              "      <td>...</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>12820</th>\n",
-              "      <td>909.973606</td>\n",
-              "      <td>True</td>\n",
-              "      <td>...</td>\n",
-              "      <td>5</td>\n",
-              "      <td>2018-02-10 05:11:35</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>12906</th>\n",
-              "      <td>983.429244</td>\n",
-              "      <td>True</td>\n",
-              "      <td>...</td>\n",
-              "      <td>6</td>\n",
-              "      <td>2018-02-11 06:19:58</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>12918</th>\n",
-              "      <td>1136.678150</td>\n",
-              "      <td>True</td>\n",
-              "      <td>...</td>\n",
-              "      <td>6</td>\n",
-              "      <td>2018-02-11 16:03:10</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>12919</th>\n",
-              "      <td>1105.211803</td>\n",
-              "      <td>True</td>\n",
-              "      <td>...</td>\n",
-              "      <td>6</td>\n",
-              "      <td>2018-02-11 05:36:05</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>13013</th>\n",
-              "      <td>1055.350213</td>\n",
-              "      <td>True</td>\n",
-              "      <td>...</td>\n",
-              "      <td>6</td>\n",
-              "      <td>2018-02-11 13:20:16</td>\n",
-              "    </tr>\n",
-              "  </tbody>\n",
-              "</table>\n",
-              "<p>68 rows × 27 columns</p>\n",
-              "</div>\n",
-              "    <div class=\"colab-df-buttons\">\n",
-              "\n",
-              "  <div class=\"colab-df-container\">\n",
-              "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-e2228412-ba39-472a-8ecb-703ccdb66ee0')\"\n",
-              "            title=\"Convert this dataframe to an interactive table.\"\n",
-              "            style=\"display:none;\">\n",
-              "\n",
-              "  <svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\" viewBox=\"0 -960 960 960\">\n",
-              "    <path d=\"M120-120v-720h720v720H120Zm60-500h600v-160H180v160Zm220 220h160v-160H400v160Zm0 220h160v-160H400v160ZM180-400h160v-160H180v160Zm440 0h160v-160H620v160ZM180-180h160v-160H180v160Zm440 0h160v-160H620v160Z\"/>\n",
-              "  </svg>\n",
-              "    </button>\n",
-              "\n",
-              "  <style>\n",
-              "    .colab-df-container {\n",
-              "      display:flex;\n",
-              "      gap: 12px;\n",
-              "    }\n",
-              "\n",
-              "    .colab-df-convert {\n",
-              "      background-color: #E8F0FE;\n",
-              "      border: none;\n",
-              "      border-radius: 50%;\n",
-              "      cursor: pointer;\n",
-              "      display: none;\n",
-              "      fill: #1967D2;\n",
-              "      height: 32px;\n",
-              "      padding: 0 0 0 0;\n",
-              "      width: 32px;\n",
-              "    }\n",
-              "\n",
-              "    .colab-df-convert:hover {\n",
-              "      background-color: #E2EBFA;\n",
-              "      box-shadow: 0px 1px 2px rgba(60, 64, 67, 0.3), 0px 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
-              "      fill: #174EA6;\n",
-              "    }\n",
-              "\n",
-              "    .colab-df-buttons div {\n",
-              "      margin-bottom: 4px;\n",
-              "    }\n",
-              "\n",
-              "    [theme=dark] .colab-df-convert {\n",
-              "      background-color: #3B4455;\n",
-              "      fill: #D2E3FC;\n",
-              "    }\n",
-              "\n",
-              "    [theme=dark] .colab-df-convert:hover {\n",
-              "      background-color: #434B5C;\n",
-              "      box-shadow: 0px 1px 3px 1px rgba(0, 0, 0, 0.15);\n",
-              "      filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.3));\n",
-              "      fill: #FFFFFF;\n",
-              "    }\n",
-              "  </style>\n",
-              "\n",
-              "    <script>\n",
-              "      const buttonEl =\n",
-              "        document.querySelector('#df-e2228412-ba39-472a-8ecb-703ccdb66ee0 button.colab-df-convert');\n",
-              "      buttonEl.style.display =\n",
-              "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
-              "\n",
-              "      async function convertToInteractive(key) {\n",
-              "        const element = document.querySelector('#df-e2228412-ba39-472a-8ecb-703ccdb66ee0');\n",
-              "        const dataTable =\n",
-              "          await google.colab.kernel.invokeFunction('convertToInteractive',\n",
-              "                                                    [key], {});\n",
-              "        if (!dataTable) return;\n",
-              "\n",
-              "        const docLinkHtml = 'Like what you see? Visit the ' +\n",
-              "          '<a target=\"_blank\" href=https://colab.research.google.com/notebooks/data_table.ipynb>data table notebook</a>'\n",
-              "          + ' to learn more about interactive tables.';\n",
-              "        element.innerHTML = '';\n",
-              "        dataTable['output_type'] = 'display_data';\n",
-              "        await google.colab.output.renderOutput(dataTable, element);\n",
-              "        const docLink = document.createElement('div');\n",
-              "        docLink.innerHTML = docLinkHtml;\n",
-              "        element.appendChild(docLink);\n",
-              "      }\n",
-              "    </script>\n",
-              "  </div>\n",
-              "\n",
-              "\n",
-              "<div id=\"df-af7efa3e-1879-4963-a549-be22cdde18ef\">\n",
-              "  <button class=\"colab-df-quickchart\" onclick=\"quickchart('df-af7efa3e-1879-4963-a549-be22cdde18ef')\"\n",
-              "            title=\"Suggest charts.\"\n",
-              "            style=\"display:none;\">\n",
-              "\n",
-              "<svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\"viewBox=\"0 0 24 24\"\n",
-              "     width=\"24px\">\n",
-              "    <g>\n",
-              "        <path d=\"M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zM9 17H7v-7h2v7zm4 0h-2V7h2v10zm4 0h-2v-4h2v4z\"/>\n",
-              "    </g>\n",
-              "</svg>\n",
-              "  </button>\n",
-              "\n",
-              "<style>\n",
-              "  .colab-df-quickchart {\n",
-              "      --bg-color: #E8F0FE;\n",
-              "      --fill-color: #1967D2;\n",
-              "      --hover-bg-color: #E2EBFA;\n",
-              "      --hover-fill-color: #174EA6;\n",
-              "      --disabled-fill-color: #AAA;\n",
-              "      --disabled-bg-color: #DDD;\n",
-              "  }\n",
-              "\n",
-              "  [theme=dark] .colab-df-quickchart {\n",
-              "      --bg-color: #3B4455;\n",
-              "      --fill-color: #D2E3FC;\n",
-              "      --hover-bg-color: #434B5C;\n",
-              "      --hover-fill-color: #FFFFFF;\n",
-              "      --disabled-bg-color: #3B4455;\n",
-              "      --disabled-fill-color: #666;\n",
-              "  }\n",
-              "\n",
-              "  .colab-df-quickchart {\n",
-              "    background-color: var(--bg-color);\n",
-              "    border: none;\n",
-              "    border-radius: 50%;\n",
-              "    cursor: pointer;\n",
-              "    display: none;\n",
-              "    fill: var(--fill-color);\n",
-              "    height: 32px;\n",
-              "    padding: 0;\n",
-              "    width: 32px;\n",
-              "  }\n",
-              "\n",
-              "  .colab-df-quickchart:hover {\n",
-              "    background-color: var(--hover-bg-color);\n",
-              "    box-shadow: 0 1px 2px rgba(60, 64, 67, 0.3), 0 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
-              "    fill: var(--button-hover-fill-color);\n",
-              "  }\n",
-              "\n",
-              "  .colab-df-quickchart-complete:disabled,\n",
-              "  .colab-df-quickchart-complete:disabled:hover {\n",
-              "    background-color: var(--disabled-bg-color);\n",
-              "    fill: var(--disabled-fill-color);\n",
-              "    box-shadow: none;\n",
-              "  }\n",
-              "\n",
-              "  .colab-df-spinner {\n",
-              "    border: 2px solid var(--fill-color);\n",
-              "    border-color: transparent;\n",
-              "    border-bottom-color: var(--fill-color);\n",
-              "    animation:\n",
-              "      spin 1s steps(1) infinite;\n",
-              "  }\n",
-              "\n",
-              "  @keyframes spin {\n",
-              "    0% {\n",
-              "      border-color: transparent;\n",
-              "      border-bottom-color: var(--fill-color);\n",
-              "      border-left-color: var(--fill-color);\n",
-              "    }\n",
-              "    20% {\n",
-              "      border-color: transparent;\n",
-              "      border-left-color: var(--fill-color);\n",
-              "      border-top-color: var(--fill-color);\n",
-              "    }\n",
-              "    30% {\n",
-              "      border-color: transparent;\n",
-              "      border-left-color: var(--fill-color);\n",
-              "      border-top-color: var(--fill-color);\n",
-              "      border-right-color: var(--fill-color);\n",
-              "    }\n",
-              "    40% {\n",
-              "      border-color: transparent;\n",
-              "      border-right-color: var(--fill-color);\n",
-              "      border-top-color: var(--fill-color);\n",
-              "    }\n",
-              "    60% {\n",
-              "      border-color: transparent;\n",
-              "      border-right-color: var(--fill-color);\n",
-              "    }\n",
-              "    80% {\n",
-              "      border-color: transparent;\n",
-              "      border-right-color: var(--fill-color);\n",
-              "      border-bottom-color: var(--fill-color);\n",
-              "    }\n",
-              "    90% {\n",
-              "      border-color: transparent;\n",
-              "      border-bottom-color: var(--fill-color);\n",
-              "    }\n",
-              "  }\n",
-              "</style>\n",
-              "\n",
-              "  <script>\n",
-              "    async function quickchart(key) {\n",
-              "      const quickchartButtonEl =\n",
-              "        document.querySelector('#' + key + ' button');\n",
-              "      quickchartButtonEl.disabled = true;  // To prevent multiple clicks.\n",
-              "      quickchartButtonEl.classList.add('colab-df-spinner');\n",
-              "      try {\n",
-              "        const charts = await google.colab.kernel.invokeFunction(\n",
-              "            'suggestCharts', [key], {});\n",
-              "      } catch (error) {\n",
-              "        console.error('Error during call to suggestCharts:', error);\n",
-              "      }\n",
-              "      quickchartButtonEl.classList.remove('colab-df-spinner');\n",
-              "      quickchartButtonEl.classList.add('colab-df-quickchart-complete');\n",
-              "    }\n",
-              "    (() => {\n",
-              "      let quickchartButtonEl =\n",
-              "        document.querySelector('#df-af7efa3e-1879-4963-a549-be22cdde18ef button');\n",
-              "      quickchartButtonEl.style.display =\n",
-              "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
-              "    })();\n",
-              "  </script>\n",
-              "</div>\n",
-              "    </div>\n",
-              "  </div>\n"
-            ]
-          },
-          "metadata": {},
-          "execution_count": 33
-        }
-      ],
-      "source": [
-        "pd_flights.query('Carrier == \"Kibana Airlines\" & AvgTicketPrice > 900.0 & Cancelled == True')"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "BOtIJQ8iNRFb"
-      },
-      "source": [
-        "`eland.DataFrame.query` requires qualifier on bool i.e.\n",
-        "\n",
-        "`ed_flights.query('Carrier == \"Kibana Airlines\" & AvgTicketPrice > 900.0 & Cancelled')` fails"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 34,
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2021-12-15T20:24:44.317223Z",
-          "iopub.status.busy": "2021-12-15T20:24:44.316680Z",
-          "iopub.status.idle": "2021-12-15T20:24:46.365286Z",
-          "shell.execute_reply": "2021-12-15T20:24:46.366706Z"
-        },
-        "pycharm": {
-          "is_executing": false
-        },
-        "id": "BQY-QkAENRFb",
-        "outputId": "4883043c-d971-472d-b17c-bbbb57f85d4e",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        }
-      },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "query() failed as expected: TypeError(\"Cannot interpret '{'terms': {'Carrier': ['Kibana Airlines']}}' as a data type\").\n"
-          ]
-        }
-      ],
-      "source": [
-        "try:\n",
-        "  ed_flights.query('Carrier == \"Kibana Airlines\" & AvgTicketPrice > 900.0 & Cancelled == True')\n",
-        "except Exception as e:\n",
-        "  print(f\"query() failed as expected: {repr(e)}.\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "u669zWowNRFb"
-      },
-      "source": [
-        "#### Boolean indexing query"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 35,
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2021-12-15T20:24:46.417274Z",
-          "iopub.status.busy": "2021-12-15T20:24:46.416156Z",
-          "iopub.status.idle": "2021-12-15T20:24:46.421120Z",
-          "shell.execute_reply": "2021-12-15T20:24:46.421781Z"
-        },
-        "pycharm": {
-          "is_executing": false
-        },
-        "id": "f59Szl_9NRFc",
-        "outputId": "5d4a9d8c-e384-4b1b-97a9-8be3ec1bc35f",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 424
-        }
-      },
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "       AvgTicketPrice  Cancelled  ... dayOfWeek           timestamp\n",
-              "8          960.869736       True  ...         0 2018-01-01 12:09:35\n",
-              "26         975.812632       True  ...         0 2018-01-01 15:38:32\n",
-              "311        946.358410       True  ...         0 2018-01-01 11:51:12\n",
-              "651        975.383864       True  ...         2 2018-01-03 21:13:17\n",
-              "950        907.836523       True  ...         2 2018-01-03 05:14:51\n",
-              "...               ...        ...  ...       ...                 ...\n",
-              "12820      909.973606       True  ...         5 2018-02-10 05:11:35\n",
-              "12906      983.429244       True  ...         6 2018-02-11 06:19:58\n",
-              "12918     1136.678150       True  ...         6 2018-02-11 16:03:10\n",
-              "12919     1105.211803       True  ...         6 2018-02-11 05:36:05\n",
-              "13013     1055.350213       True  ...         6 2018-02-11 13:20:16\n",
-              "\n",
-              "[68 rows x 27 columns]"
-            ],
-            "text/html": [
-              "\n",
-              "  <div id=\"df-3fe16129-dcce-4cd2-9e51-4677c46f253d\" class=\"colab-df-container\">\n",
-              "    <div>\n",
-              "<style scoped>\n",
-              "    .dataframe tbody tr th:only-of-type {\n",
-              "        vertical-align: middle;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe tbody tr th {\n",
-              "        vertical-align: top;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe thead th {\n",
-              "        text-align: right;\n",
-              "    }\n",
-              "</style>\n",
-              "<table border=\"1\" class=\"dataframe\">\n",
-              "  <thead>\n",
-              "    <tr style=\"text-align: right;\">\n",
-              "      <th></th>\n",
-              "      <th>AvgTicketPrice</th>\n",
-              "      <th>Cancelled</th>\n",
-              "      <th>...</th>\n",
-              "      <th>dayOfWeek</th>\n",
-              "      <th>timestamp</th>\n",
-              "    </tr>\n",
-              "  </thead>\n",
-              "  <tbody>\n",
-              "    <tr>\n",
-              "      <th>8</th>\n",
-              "      <td>960.869736</td>\n",
-              "      <td>True</td>\n",
-              "      <td>...</td>\n",
-              "      <td>0</td>\n",
-              "      <td>2018-01-01 12:09:35</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>26</th>\n",
-              "      <td>975.812632</td>\n",
-              "      <td>True</td>\n",
-              "      <td>...</td>\n",
-              "      <td>0</td>\n",
-              "      <td>2018-01-01 15:38:32</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>311</th>\n",
-              "      <td>946.358410</td>\n",
-              "      <td>True</td>\n",
-              "      <td>...</td>\n",
-              "      <td>0</td>\n",
-              "      <td>2018-01-01 11:51:12</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>651</th>\n",
-              "      <td>975.383864</td>\n",
-              "      <td>True</td>\n",
-              "      <td>...</td>\n",
-              "      <td>2</td>\n",
-              "      <td>2018-01-03 21:13:17</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>950</th>\n",
-              "      <td>907.836523</td>\n",
-              "      <td>True</td>\n",
-              "      <td>...</td>\n",
-              "      <td>2</td>\n",
-              "      <td>2018-01-03 05:14:51</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>...</th>\n",
-              "      <td>...</td>\n",
-              "      <td>...</td>\n",
-              "      <td>...</td>\n",
-              "      <td>...</td>\n",
-              "      <td>...</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>12820</th>\n",
-              "      <td>909.973606</td>\n",
-              "      <td>True</td>\n",
-              "      <td>...</td>\n",
-              "      <td>5</td>\n",
-              "      <td>2018-02-10 05:11:35</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>12906</th>\n",
-              "      <td>983.429244</td>\n",
-              "      <td>True</td>\n",
-              "      <td>...</td>\n",
-              "      <td>6</td>\n",
-              "      <td>2018-02-11 06:19:58</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>12918</th>\n",
-              "      <td>1136.678150</td>\n",
-              "      <td>True</td>\n",
-              "      <td>...</td>\n",
-              "      <td>6</td>\n",
-              "      <td>2018-02-11 16:03:10</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>12919</th>\n",
-              "      <td>1105.211803</td>\n",
-              "      <td>True</td>\n",
-              "      <td>...</td>\n",
-              "      <td>6</td>\n",
-              "      <td>2018-02-11 05:36:05</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>13013</th>\n",
-              "      <td>1055.350213</td>\n",
-              "      <td>True</td>\n",
-              "      <td>...</td>\n",
-              "      <td>6</td>\n",
-              "      <td>2018-02-11 13:20:16</td>\n",
-              "    </tr>\n",
-              "  </tbody>\n",
-              "</table>\n",
-              "<p>68 rows × 27 columns</p>\n",
-              "</div>\n",
-              "    <div class=\"colab-df-buttons\">\n",
-              "\n",
-              "  <div class=\"colab-df-container\">\n",
-              "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-3fe16129-dcce-4cd2-9e51-4677c46f253d')\"\n",
-              "            title=\"Convert this dataframe to an interactive table.\"\n",
-              "            style=\"display:none;\">\n",
-              "\n",
-              "  <svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\" viewBox=\"0 -960 960 960\">\n",
-              "    <path d=\"M120-120v-720h720v720H120Zm60-500h600v-160H180v160Zm220 220h160v-160H400v160Zm0 220h160v-160H400v160ZM180-400h160v-160H180v160Zm440 0h160v-160H620v160ZM180-180h160v-160H180v160Zm440 0h160v-160H620v160Z\"/>\n",
-              "  </svg>\n",
-              "    </button>\n",
-              "\n",
-              "  <style>\n",
-              "    .colab-df-container {\n",
-              "      display:flex;\n",
-              "      gap: 12px;\n",
-              "    }\n",
-              "\n",
-              "    .colab-df-convert {\n",
-              "      background-color: #E8F0FE;\n",
-              "      border: none;\n",
-              "      border-radius: 50%;\n",
-              "      cursor: pointer;\n",
-              "      display: none;\n",
-              "      fill: #1967D2;\n",
-              "      height: 32px;\n",
-              "      padding: 0 0 0 0;\n",
-              "      width: 32px;\n",
-              "    }\n",
-              "\n",
-              "    .colab-df-convert:hover {\n",
-              "      background-color: #E2EBFA;\n",
-              "      box-shadow: 0px 1px 2px rgba(60, 64, 67, 0.3), 0px 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
-              "      fill: #174EA6;\n",
-              "    }\n",
-              "\n",
-              "    .colab-df-buttons div {\n",
-              "      margin-bottom: 4px;\n",
-              "    }\n",
-              "\n",
-              "    [theme=dark] .colab-df-convert {\n",
-              "      background-color: #3B4455;\n",
-              "      fill: #D2E3FC;\n",
-              "    }\n",
-              "\n",
-              "    [theme=dark] .colab-df-convert:hover {\n",
-              "      background-color: #434B5C;\n",
-              "      box-shadow: 0px 1px 3px 1px rgba(0, 0, 0, 0.15);\n",
-              "      filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.3));\n",
-              "      fill: #FFFFFF;\n",
-              "    }\n",
-              "  </style>\n",
-              "\n",
-              "    <script>\n",
-              "      const buttonEl =\n",
-              "        document.querySelector('#df-3fe16129-dcce-4cd2-9e51-4677c46f253d button.colab-df-convert');\n",
-              "      buttonEl.style.display =\n",
-              "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
-              "\n",
-              "      async function convertToInteractive(key) {\n",
-              "        const element = document.querySelector('#df-3fe16129-dcce-4cd2-9e51-4677c46f253d');\n",
-              "        const dataTable =\n",
-              "          await google.colab.kernel.invokeFunction('convertToInteractive',\n",
-              "                                                    [key], {});\n",
-              "        if (!dataTable) return;\n",
-              "\n",
-              "        const docLinkHtml = 'Like what you see? Visit the ' +\n",
-              "          '<a target=\"_blank\" href=https://colab.research.google.com/notebooks/data_table.ipynb>data table notebook</a>'\n",
-              "          + ' to learn more about interactive tables.';\n",
-              "        element.innerHTML = '';\n",
-              "        dataTable['output_type'] = 'display_data';\n",
-              "        await google.colab.output.renderOutput(dataTable, element);\n",
-              "        const docLink = document.createElement('div');\n",
-              "        docLink.innerHTML = docLinkHtml;\n",
-              "        element.appendChild(docLink);\n",
-              "      }\n",
-              "    </script>\n",
-              "  </div>\n",
-              "\n",
-              "\n",
-              "<div id=\"df-8bdd4957-d9f7-4474-bad6-c2951e1ece54\">\n",
-              "  <button class=\"colab-df-quickchart\" onclick=\"quickchart('df-8bdd4957-d9f7-4474-bad6-c2951e1ece54')\"\n",
-              "            title=\"Suggest charts.\"\n",
-              "            style=\"display:none;\">\n",
-              "\n",
-              "<svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\"viewBox=\"0 0 24 24\"\n",
-              "     width=\"24px\">\n",
-              "    <g>\n",
-              "        <path d=\"M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zM9 17H7v-7h2v7zm4 0h-2V7h2v10zm4 0h-2v-4h2v4z\"/>\n",
-              "    </g>\n",
-              "</svg>\n",
-              "  </button>\n",
-              "\n",
-              "<style>\n",
-              "  .colab-df-quickchart {\n",
-              "      --bg-color: #E8F0FE;\n",
-              "      --fill-color: #1967D2;\n",
-              "      --hover-bg-color: #E2EBFA;\n",
-              "      --hover-fill-color: #174EA6;\n",
-              "      --disabled-fill-color: #AAA;\n",
-              "      --disabled-bg-color: #DDD;\n",
-              "  }\n",
-              "\n",
-              "  [theme=dark] .colab-df-quickchart {\n",
-              "      --bg-color: #3B4455;\n",
-              "      --fill-color: #D2E3FC;\n",
-              "      --hover-bg-color: #434B5C;\n",
-              "      --hover-fill-color: #FFFFFF;\n",
-              "      --disabled-bg-color: #3B4455;\n",
-              "      --disabled-fill-color: #666;\n",
-              "  }\n",
-              "\n",
-              "  .colab-df-quickchart {\n",
-              "    background-color: var(--bg-color);\n",
-              "    border: none;\n",
-              "    border-radius: 50%;\n",
-              "    cursor: pointer;\n",
-              "    display: none;\n",
-              "    fill: var(--fill-color);\n",
-              "    height: 32px;\n",
-              "    padding: 0;\n",
-              "    width: 32px;\n",
-              "  }\n",
-              "\n",
-              "  .colab-df-quickchart:hover {\n",
-              "    background-color: var(--hover-bg-color);\n",
-              "    box-shadow: 0 1px 2px rgba(60, 64, 67, 0.3), 0 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
-              "    fill: var(--button-hover-fill-color);\n",
-              "  }\n",
-              "\n",
-              "  .colab-df-quickchart-complete:disabled,\n",
-              "  .colab-df-quickchart-complete:disabled:hover {\n",
-              "    background-color: var(--disabled-bg-color);\n",
-              "    fill: var(--disabled-fill-color);\n",
-              "    box-shadow: none;\n",
-              "  }\n",
-              "\n",
-              "  .colab-df-spinner {\n",
-              "    border: 2px solid var(--fill-color);\n",
-              "    border-color: transparent;\n",
-              "    border-bottom-color: var(--fill-color);\n",
-              "    animation:\n",
-              "      spin 1s steps(1) infinite;\n",
-              "  }\n",
-              "\n",
-              "  @keyframes spin {\n",
-              "    0% {\n",
-              "      border-color: transparent;\n",
-              "      border-bottom-color: var(--fill-color);\n",
-              "      border-left-color: var(--fill-color);\n",
-              "    }\n",
-              "    20% {\n",
-              "      border-color: transparent;\n",
-              "      border-left-color: var(--fill-color);\n",
-              "      border-top-color: var(--fill-color);\n",
-              "    }\n",
-              "    30% {\n",
-              "      border-color: transparent;\n",
-              "      border-left-color: var(--fill-color);\n",
-              "      border-top-color: var(--fill-color);\n",
-              "      border-right-color: var(--fill-color);\n",
-              "    }\n",
-              "    40% {\n",
-              "      border-color: transparent;\n",
-              "      border-right-color: var(--fill-color);\n",
-              "      border-top-color: var(--fill-color);\n",
-              "    }\n",
-              "    60% {\n",
-              "      border-color: transparent;\n",
-              "      border-right-color: var(--fill-color);\n",
-              "    }\n",
-              "    80% {\n",
-              "      border-color: transparent;\n",
-              "      border-right-color: var(--fill-color);\n",
-              "      border-bottom-color: var(--fill-color);\n",
-              "    }\n",
-              "    90% {\n",
-              "      border-color: transparent;\n",
-              "      border-bottom-color: var(--fill-color);\n",
-              "    }\n",
-              "  }\n",
-              "</style>\n",
-              "\n",
-              "  <script>\n",
-              "    async function quickchart(key) {\n",
-              "      const quickchartButtonEl =\n",
-              "        document.querySelector('#' + key + ' button');\n",
-              "      quickchartButtonEl.disabled = true;  // To prevent multiple clicks.\n",
-              "      quickchartButtonEl.classList.add('colab-df-spinner');\n",
-              "      try {\n",
-              "        const charts = await google.colab.kernel.invokeFunction(\n",
-              "            'suggestCharts', [key], {});\n",
-              "      } catch (error) {\n",
-              "        console.error('Error during call to suggestCharts:', error);\n",
-              "      }\n",
-              "      quickchartButtonEl.classList.remove('colab-df-spinner');\n",
-              "      quickchartButtonEl.classList.add('colab-df-quickchart-complete');\n",
-              "    }\n",
-              "    (() => {\n",
-              "      let quickchartButtonEl =\n",
-              "        document.querySelector('#df-8bdd4957-d9f7-4474-bad6-c2951e1ece54 button');\n",
-              "      quickchartButtonEl.style.display =\n",
-              "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
-              "    })();\n",
-              "  </script>\n",
-              "</div>\n",
-              "    </div>\n",
-              "  </div>\n"
-            ]
-          },
-          "metadata": {},
-          "execution_count": 35
-        }
-      ],
-      "source": [
-        "pd_flights[(pd_flights.Carrier==\"Kibana Airlines\") &\n",
-        "           (pd_flights.AvgTicketPrice > 900.0) &\n",
-        "           (pd_flights.Cancelled == True)]"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 36,
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2021-12-15T20:24:46.431697Z",
-          "iopub.status.busy": "2021-12-15T20:24:46.431114Z",
-          "iopub.status.idle": "2021-12-15T20:24:48.414684Z",
-          "shell.execute_reply": "2021-12-15T20:24:48.415148Z"
-        },
-        "pycharm": {
-          "is_executing": false
-        },
-        "id": "ZiewRsffNRFc",
-        "outputId": "1df6d2d6-2164-4e06-abf4-4922aac5e42a",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 424
-        }
-      },
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "       AvgTicketPrice  Cancelled  ... dayOfWeek           timestamp\n",
-              "8          960.869736       True  ...         0 2018-01-01 12:09:35\n",
-              "26         975.812632       True  ...         0 2018-01-01 15:38:32\n",
-              "311        946.358410       True  ...         0 2018-01-01 11:51:12\n",
-              "651        975.383864       True  ...         2 2018-01-03 21:13:17\n",
-              "950        907.836523       True  ...         2 2018-01-03 05:14:51\n",
-              "...               ...        ...  ...       ...                 ...\n",
-              "12820      909.973606       True  ...         5 2018-02-10 05:11:35\n",
-              "12906      983.429244       True  ...         6 2018-02-11 06:19:58\n",
-              "12918     1136.678150       True  ...         6 2018-02-11 16:03:10\n",
-              "12919     1105.211803       True  ...         6 2018-02-11 05:36:05\n",
-              "13013     1055.350213       True  ...         6 2018-02-11 13:20:16\n",
-              "\n",
-              "[68 rows x 27 columns]"
-            ],
-            "text/html": [
-              "<div>\n",
-              "<style scoped>\n",
-              "    .dataframe tbody tr th:only-of-type {\n",
-              "        vertical-align: middle;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe tbody tr th {\n",
-              "        vertical-align: top;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe thead th {\n",
-              "        text-align: right;\n",
-              "    }\n",
-              "</style>\n",
-              "<table border=\"1\" class=\"dataframe\">\n",
-              "  <thead>\n",
-              "    <tr style=\"text-align: right;\">\n",
-              "      <th></th>\n",
-              "      <th>AvgTicketPrice</th>\n",
-              "      <th>Cancelled</th>\n",
-              "      <th>...</th>\n",
-              "      <th>dayOfWeek</th>\n",
-              "      <th>timestamp</th>\n",
-              "    </tr>\n",
-              "  </thead>\n",
-              "  <tbody>\n",
-              "    <tr>\n",
-              "      <th>8</th>\n",
-              "      <td>960.869736</td>\n",
-              "      <td>True</td>\n",
-              "      <td>...</td>\n",
-              "      <td>0</td>\n",
-              "      <td>2018-01-01 12:09:35</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>26</th>\n",
-              "      <td>975.812632</td>\n",
-              "      <td>True</td>\n",
-              "      <td>...</td>\n",
-              "      <td>0</td>\n",
-              "      <td>2018-01-01 15:38:32</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>311</th>\n",
-              "      <td>946.358410</td>\n",
-              "      <td>True</td>\n",
-              "      <td>...</td>\n",
-              "      <td>0</td>\n",
-              "      <td>2018-01-01 11:51:12</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>651</th>\n",
-              "      <td>975.383864</td>\n",
-              "      <td>True</td>\n",
-              "      <td>...</td>\n",
-              "      <td>2</td>\n",
-              "      <td>2018-01-03 21:13:17</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>950</th>\n",
-              "      <td>907.836523</td>\n",
-              "      <td>True</td>\n",
-              "      <td>...</td>\n",
-              "      <td>2</td>\n",
-              "      <td>2018-01-03 05:14:51</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>...</th>\n",
-              "      <td>...</td>\n",
-              "      <td>...</td>\n",
-              "      <td>...</td>\n",
-              "      <td>...</td>\n",
-              "      <td>...</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>12820</th>\n",
-              "      <td>909.973606</td>\n",
-              "      <td>True</td>\n",
-              "      <td>...</td>\n",
-              "      <td>5</td>\n",
-              "      <td>2018-02-10 05:11:35</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>12906</th>\n",
-              "      <td>983.429244</td>\n",
-              "      <td>True</td>\n",
-              "      <td>...</td>\n",
-              "      <td>6</td>\n",
-              "      <td>2018-02-11 06:19:58</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>12918</th>\n",
-              "      <td>1136.678150</td>\n",
-              "      <td>True</td>\n",
-              "      <td>...</td>\n",
-              "      <td>6</td>\n",
-              "      <td>2018-02-11 16:03:10</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>12919</th>\n",
-              "      <td>1105.211803</td>\n",
-              "      <td>True</td>\n",
-              "      <td>...</td>\n",
-              "      <td>6</td>\n",
-              "      <td>2018-02-11 05:36:05</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>13013</th>\n",
-              "      <td>1055.350213</td>\n",
-              "      <td>True</td>\n",
-              "      <td>...</td>\n",
-              "      <td>6</td>\n",
-              "      <td>2018-02-11 13:20:16</td>\n",
-              "    </tr>\n",
-              "  </tbody>\n",
-              "</table>\n",
-              "</div>\n",
-              "<p>68 rows × 27 columns</p>"
-            ]
-          },
-          "metadata": {},
-          "execution_count": 36
-        }
-      ],
-      "source": [
-        "ed_flights[(ed_flights.Carrier==\"Kibana Airlines\") &\n",
-        "           (ed_flights.AvgTicketPrice > 900.0) &\n",
-        "           (ed_flights.Cancelled == True)]"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "2aEJXYr3NRFc"
-      },
-      "source": [
-        "## Function application, GroupBy & window"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "PLNjRajUNRFd"
-      },
-      "source": [
-        "### DataFrame.aggs"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 37,
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2021-12-15T20:24:48.421015Z",
-          "iopub.status.busy": "2021-12-15T20:24:48.420431Z",
-          "iopub.status.idle": "2021-12-15T20:24:48.428382Z",
-          "shell.execute_reply": "2021-12-15T20:24:48.428690Z"
-        },
-        "pycharm": {
-          "is_executing": false
-        },
-        "id": "-j7Hwl9FNRFd",
-        "outputId": "3aa241a3-f1b9-4853-f177-4d83eec89f47",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 143
-        }
-      },
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "     DistanceKilometers  AvgTicketPrice\n",
-              "sum        9.261629e+07    8.204365e+06\n",
-              "min        0.000000e+00    1.000205e+02\n",
-              "std        4.578438e+03    2.663969e+02"
-            ],
-            "text/html": [
-              "\n",
-              "  <div id=\"df-ffe34f9c-28c2-4b5d-ab31-094808fa43ac\" class=\"colab-df-container\">\n",
-              "    <div>\n",
-              "<style scoped>\n",
-              "    .dataframe tbody tr th:only-of-type {\n",
-              "        vertical-align: middle;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe tbody tr th {\n",
-              "        vertical-align: top;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe thead th {\n",
-              "        text-align: right;\n",
-              "    }\n",
-              "</style>\n",
-              "<table border=\"1\" class=\"dataframe\">\n",
-              "  <thead>\n",
-              "    <tr style=\"text-align: right;\">\n",
-              "      <th></th>\n",
-              "      <th>DistanceKilometers</th>\n",
-              "      <th>AvgTicketPrice</th>\n",
-              "    </tr>\n",
-              "  </thead>\n",
-              "  <tbody>\n",
-              "    <tr>\n",
-              "      <th>sum</th>\n",
-              "      <td>9.261629e+07</td>\n",
-              "      <td>8.204365e+06</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>min</th>\n",
-              "      <td>0.000000e+00</td>\n",
-              "      <td>1.000205e+02</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>std</th>\n",
-              "      <td>4.578438e+03</td>\n",
-              "      <td>2.663969e+02</td>\n",
-              "    </tr>\n",
-              "  </tbody>\n",
-              "</table>\n",
-              "</div>\n",
-              "    <div class=\"colab-df-buttons\">\n",
-              "\n",
-              "  <div class=\"colab-df-container\">\n",
-              "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-ffe34f9c-28c2-4b5d-ab31-094808fa43ac')\"\n",
-              "            title=\"Convert this dataframe to an interactive table.\"\n",
-              "            style=\"display:none;\">\n",
-              "\n",
-              "  <svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\" viewBox=\"0 -960 960 960\">\n",
-              "    <path d=\"M120-120v-720h720v720H120Zm60-500h600v-160H180v160Zm220 220h160v-160H400v160Zm0 220h160v-160H400v160ZM180-400h160v-160H180v160Zm440 0h160v-160H620v160ZM180-180h160v-160H180v160Zm440 0h160v-160H620v160Z\"/>\n",
-              "  </svg>\n",
-              "    </button>\n",
-              "\n",
-              "  <style>\n",
-              "    .colab-df-container {\n",
-              "      display:flex;\n",
-              "      gap: 12px;\n",
-              "    }\n",
-              "\n",
-              "    .colab-df-convert {\n",
-              "      background-color: #E8F0FE;\n",
-              "      border: none;\n",
-              "      border-radius: 50%;\n",
-              "      cursor: pointer;\n",
-              "      display: none;\n",
-              "      fill: #1967D2;\n",
-              "      height: 32px;\n",
-              "      padding: 0 0 0 0;\n",
-              "      width: 32px;\n",
-              "    }\n",
-              "\n",
-              "    .colab-df-convert:hover {\n",
-              "      background-color: #E2EBFA;\n",
-              "      box-shadow: 0px 1px 2px rgba(60, 64, 67, 0.3), 0px 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
-              "      fill: #174EA6;\n",
-              "    }\n",
-              "\n",
-              "    .colab-df-buttons div {\n",
-              "      margin-bottom: 4px;\n",
-              "    }\n",
-              "\n",
-              "    [theme=dark] .colab-df-convert {\n",
-              "      background-color: #3B4455;\n",
-              "      fill: #D2E3FC;\n",
-              "    }\n",
-              "\n",
-              "    [theme=dark] .colab-df-convert:hover {\n",
-              "      background-color: #434B5C;\n",
-              "      box-shadow: 0px 1px 3px 1px rgba(0, 0, 0, 0.15);\n",
-              "      filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.3));\n",
-              "      fill: #FFFFFF;\n",
-              "    }\n",
-              "  </style>\n",
-              "\n",
-              "    <script>\n",
-              "      const buttonEl =\n",
-              "        document.querySelector('#df-ffe34f9c-28c2-4b5d-ab31-094808fa43ac button.colab-df-convert');\n",
-              "      buttonEl.style.display =\n",
-              "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
-              "\n",
-              "      async function convertToInteractive(key) {\n",
-              "        const element = document.querySelector('#df-ffe34f9c-28c2-4b5d-ab31-094808fa43ac');\n",
-              "        const dataTable =\n",
-              "          await google.colab.kernel.invokeFunction('convertToInteractive',\n",
-              "                                                    [key], {});\n",
-              "        if (!dataTable) return;\n",
-              "\n",
-              "        const docLinkHtml = 'Like what you see? Visit the ' +\n",
-              "          '<a target=\"_blank\" href=https://colab.research.google.com/notebooks/data_table.ipynb>data table notebook</a>'\n",
-              "          + ' to learn more about interactive tables.';\n",
-              "        element.innerHTML = '';\n",
-              "        dataTable['output_type'] = 'display_data';\n",
-              "        await google.colab.output.renderOutput(dataTable, element);\n",
-              "        const docLink = document.createElement('div');\n",
-              "        docLink.innerHTML = docLinkHtml;\n",
-              "        element.appendChild(docLink);\n",
-              "      }\n",
-              "    </script>\n",
-              "  </div>\n",
-              "\n",
-              "\n",
-              "<div id=\"df-9052a490-cc56-456d-ba05-e4dcc27b91ac\">\n",
-              "  <button class=\"colab-df-quickchart\" onclick=\"quickchart('df-9052a490-cc56-456d-ba05-e4dcc27b91ac')\"\n",
-              "            title=\"Suggest charts.\"\n",
-              "            style=\"display:none;\">\n",
-              "\n",
-              "<svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\"viewBox=\"0 0 24 24\"\n",
-              "     width=\"24px\">\n",
-              "    <g>\n",
-              "        <path d=\"M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zM9 17H7v-7h2v7zm4 0h-2V7h2v10zm4 0h-2v-4h2v4z\"/>\n",
-              "    </g>\n",
-              "</svg>\n",
-              "  </button>\n",
-              "\n",
-              "<style>\n",
-              "  .colab-df-quickchart {\n",
-              "      --bg-color: #E8F0FE;\n",
-              "      --fill-color: #1967D2;\n",
-              "      --hover-bg-color: #E2EBFA;\n",
-              "      --hover-fill-color: #174EA6;\n",
-              "      --disabled-fill-color: #AAA;\n",
-              "      --disabled-bg-color: #DDD;\n",
-              "  }\n",
-              "\n",
-              "  [theme=dark] .colab-df-quickchart {\n",
-              "      --bg-color: #3B4455;\n",
-              "      --fill-color: #D2E3FC;\n",
-              "      --hover-bg-color: #434B5C;\n",
-              "      --hover-fill-color: #FFFFFF;\n",
-              "      --disabled-bg-color: #3B4455;\n",
-              "      --disabled-fill-color: #666;\n",
-              "  }\n",
-              "\n",
-              "  .colab-df-quickchart {\n",
-              "    background-color: var(--bg-color);\n",
-              "    border: none;\n",
-              "    border-radius: 50%;\n",
-              "    cursor: pointer;\n",
-              "    display: none;\n",
-              "    fill: var(--fill-color);\n",
-              "    height: 32px;\n",
-              "    padding: 0;\n",
-              "    width: 32px;\n",
-              "  }\n",
-              "\n",
-              "  .colab-df-quickchart:hover {\n",
-              "    background-color: var(--hover-bg-color);\n",
-              "    box-shadow: 0 1px 2px rgba(60, 64, 67, 0.3), 0 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
-              "    fill: var(--button-hover-fill-color);\n",
-              "  }\n",
-              "\n",
-              "  .colab-df-quickchart-complete:disabled,\n",
-              "  .colab-df-quickchart-complete:disabled:hover {\n",
-              "    background-color: var(--disabled-bg-color);\n",
-              "    fill: var(--disabled-fill-color);\n",
-              "    box-shadow: none;\n",
-              "  }\n",
-              "\n",
-              "  .colab-df-spinner {\n",
-              "    border: 2px solid var(--fill-color);\n",
-              "    border-color: transparent;\n",
-              "    border-bottom-color: var(--fill-color);\n",
-              "    animation:\n",
-              "      spin 1s steps(1) infinite;\n",
-              "  }\n",
-              "\n",
-              "  @keyframes spin {\n",
-              "    0% {\n",
-              "      border-color: transparent;\n",
-              "      border-bottom-color: var(--fill-color);\n",
-              "      border-left-color: var(--fill-color);\n",
-              "    }\n",
-              "    20% {\n",
-              "      border-color: transparent;\n",
-              "      border-left-color: var(--fill-color);\n",
-              "      border-top-color: var(--fill-color);\n",
-              "    }\n",
-              "    30% {\n",
-              "      border-color: transparent;\n",
-              "      border-left-color: var(--fill-color);\n",
-              "      border-top-color: var(--fill-color);\n",
-              "      border-right-color: var(--fill-color);\n",
-              "    }\n",
-              "    40% {\n",
-              "      border-color: transparent;\n",
-              "      border-right-color: var(--fill-color);\n",
-              "      border-top-color: var(--fill-color);\n",
-              "    }\n",
-              "    60% {\n",
-              "      border-color: transparent;\n",
-              "      border-right-color: var(--fill-color);\n",
-              "    }\n",
-              "    80% {\n",
-              "      border-color: transparent;\n",
-              "      border-right-color: var(--fill-color);\n",
-              "      border-bottom-color: var(--fill-color);\n",
-              "    }\n",
-              "    90% {\n",
-              "      border-color: transparent;\n",
-              "      border-bottom-color: var(--fill-color);\n",
-              "    }\n",
-              "  }\n",
-              "</style>\n",
-              "\n",
-              "  <script>\n",
-              "    async function quickchart(key) {\n",
-              "      const quickchartButtonEl =\n",
-              "        document.querySelector('#' + key + ' button');\n",
-              "      quickchartButtonEl.disabled = true;  // To prevent multiple clicks.\n",
-              "      quickchartButtonEl.classList.add('colab-df-spinner');\n",
-              "      try {\n",
-              "        const charts = await google.colab.kernel.invokeFunction(\n",
-              "            'suggestCharts', [key], {});\n",
-              "      } catch (error) {\n",
-              "        console.error('Error during call to suggestCharts:', error);\n",
-              "      }\n",
-              "      quickchartButtonEl.classList.remove('colab-df-spinner');\n",
-              "      quickchartButtonEl.classList.add('colab-df-quickchart-complete');\n",
-              "    }\n",
-              "    (() => {\n",
-              "      let quickchartButtonEl =\n",
-              "        document.querySelector('#df-9052a490-cc56-456d-ba05-e4dcc27b91ac button');\n",
-              "      quickchartButtonEl.style.display =\n",
-              "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
-              "    })();\n",
-              "  </script>\n",
-              "</div>\n",
-              "    </div>\n",
-              "  </div>\n"
-            ]
-          },
-          "metadata": {},
-          "execution_count": 37
-        }
-      ],
-      "source": [
-        "pd_flights[['DistanceKilometers', 'AvgTicketPrice']].aggregate(['sum', 'min', 'std'])"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "BL2p1GPLNRFd"
-      },
-      "source": [
-        "`eland.DataFrame.aggregate` currently only supported numeric columns"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 38,
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2021-12-15T20:24:48.433082Z",
-          "iopub.status.busy": "2021-12-15T20:24:48.432716Z",
-          "iopub.status.idle": "2021-12-15T20:24:48.541272Z",
-          "shell.execute_reply": "2021-12-15T20:24:48.542346Z"
-        },
-        "pycharm": {
-          "is_executing": false
-        },
-        "id": "ok4Ui8BhNRFe",
-        "outputId": "6d9ee598-2f23-4a7f-f42e-e181fbdc9426",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 143
-        }
-      },
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "     DistanceKilometers  AvgTicketPrice\n",
-              "sum        9.261629e+07    8.204365e+06\n",
-              "min        0.000000e+00    1.000205e+02\n",
-              "std        4.578614e+03    2.664071e+02"
-            ],
-            "text/html": [
-              "\n",
-              "  <div id=\"df-8bdad06d-4658-48ac-b77f-f54456dea62a\" class=\"colab-df-container\">\n",
-              "    <div>\n",
-              "<style scoped>\n",
-              "    .dataframe tbody tr th:only-of-type {\n",
-              "        vertical-align: middle;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe tbody tr th {\n",
-              "        vertical-align: top;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe thead th {\n",
-              "        text-align: right;\n",
-              "    }\n",
-              "</style>\n",
-              "<table border=\"1\" class=\"dataframe\">\n",
-              "  <thead>\n",
-              "    <tr style=\"text-align: right;\">\n",
-              "      <th></th>\n",
-              "      <th>DistanceKilometers</th>\n",
-              "      <th>AvgTicketPrice</th>\n",
-              "    </tr>\n",
-              "  </thead>\n",
-              "  <tbody>\n",
-              "    <tr>\n",
-              "      <th>sum</th>\n",
-              "      <td>9.261629e+07</td>\n",
-              "      <td>8.204365e+06</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>min</th>\n",
-              "      <td>0.000000e+00</td>\n",
-              "      <td>1.000205e+02</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>std</th>\n",
-              "      <td>4.578614e+03</td>\n",
-              "      <td>2.664071e+02</td>\n",
-              "    </tr>\n",
-              "  </tbody>\n",
-              "</table>\n",
-              "</div>\n",
-              "    <div class=\"colab-df-buttons\">\n",
-              "\n",
-              "  <div class=\"colab-df-container\">\n",
-              "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-8bdad06d-4658-48ac-b77f-f54456dea62a')\"\n",
-              "            title=\"Convert this dataframe to an interactive table.\"\n",
-              "            style=\"display:none;\">\n",
-              "\n",
-              "  <svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\" viewBox=\"0 -960 960 960\">\n",
-              "    <path d=\"M120-120v-720h720v720H120Zm60-500h600v-160H180v160Zm220 220h160v-160H400v160Zm0 220h160v-160H400v160ZM180-400h160v-160H180v160Zm440 0h160v-160H620v160ZM180-180h160v-160H180v160Zm440 0h160v-160H620v160Z\"/>\n",
-              "  </svg>\n",
-              "    </button>\n",
-              "\n",
-              "  <style>\n",
-              "    .colab-df-container {\n",
-              "      display:flex;\n",
-              "      gap: 12px;\n",
-              "    }\n",
-              "\n",
-              "    .colab-df-convert {\n",
-              "      background-color: #E8F0FE;\n",
-              "      border: none;\n",
-              "      border-radius: 50%;\n",
-              "      cursor: pointer;\n",
-              "      display: none;\n",
-              "      fill: #1967D2;\n",
-              "      height: 32px;\n",
-              "      padding: 0 0 0 0;\n",
-              "      width: 32px;\n",
-              "    }\n",
-              "\n",
-              "    .colab-df-convert:hover {\n",
-              "      background-color: #E2EBFA;\n",
-              "      box-shadow: 0px 1px 2px rgba(60, 64, 67, 0.3), 0px 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
-              "      fill: #174EA6;\n",
-              "    }\n",
-              "\n",
-              "    .colab-df-buttons div {\n",
-              "      margin-bottom: 4px;\n",
-              "    }\n",
-              "\n",
-              "    [theme=dark] .colab-df-convert {\n",
-              "      background-color: #3B4455;\n",
-              "      fill: #D2E3FC;\n",
-              "    }\n",
-              "\n",
-              "    [theme=dark] .colab-df-convert:hover {\n",
-              "      background-color: #434B5C;\n",
-              "      box-shadow: 0px 1px 3px 1px rgba(0, 0, 0, 0.15);\n",
-              "      filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.3));\n",
-              "      fill: #FFFFFF;\n",
-              "    }\n",
-              "  </style>\n",
-              "\n",
-              "    <script>\n",
-              "      const buttonEl =\n",
-              "        document.querySelector('#df-8bdad06d-4658-48ac-b77f-f54456dea62a button.colab-df-convert');\n",
-              "      buttonEl.style.display =\n",
-              "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
-              "\n",
-              "      async function convertToInteractive(key) {\n",
-              "        const element = document.querySelector('#df-8bdad06d-4658-48ac-b77f-f54456dea62a');\n",
-              "        const dataTable =\n",
-              "          await google.colab.kernel.invokeFunction('convertToInteractive',\n",
-              "                                                    [key], {});\n",
-              "        if (!dataTable) return;\n",
-              "\n",
-              "        const docLinkHtml = 'Like what you see? Visit the ' +\n",
-              "          '<a target=\"_blank\" href=https://colab.research.google.com/notebooks/data_table.ipynb>data table notebook</a>'\n",
-              "          + ' to learn more about interactive tables.';\n",
-              "        element.innerHTML = '';\n",
-              "        dataTable['output_type'] = 'display_data';\n",
-              "        await google.colab.output.renderOutput(dataTable, element);\n",
-              "        const docLink = document.createElement('div');\n",
-              "        docLink.innerHTML = docLinkHtml;\n",
-              "        element.appendChild(docLink);\n",
-              "      }\n",
-              "    </script>\n",
-              "  </div>\n",
-              "\n",
-              "\n",
-              "<div id=\"df-82508f35-0ec3-402f-98df-b0ab6d857639\">\n",
-              "  <button class=\"colab-df-quickchart\" onclick=\"quickchart('df-82508f35-0ec3-402f-98df-b0ab6d857639')\"\n",
-              "            title=\"Suggest charts.\"\n",
-              "            style=\"display:none;\">\n",
-              "\n",
-              "<svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\"viewBox=\"0 0 24 24\"\n",
-              "     width=\"24px\">\n",
-              "    <g>\n",
-              "        <path d=\"M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zM9 17H7v-7h2v7zm4 0h-2V7h2v10zm4 0h-2v-4h2v4z\"/>\n",
-              "    </g>\n",
-              "</svg>\n",
-              "  </button>\n",
-              "\n",
-              "<style>\n",
-              "  .colab-df-quickchart {\n",
-              "      --bg-color: #E8F0FE;\n",
-              "      --fill-color: #1967D2;\n",
-              "      --hover-bg-color: #E2EBFA;\n",
-              "      --hover-fill-color: #174EA6;\n",
-              "      --disabled-fill-color: #AAA;\n",
-              "      --disabled-bg-color: #DDD;\n",
-              "  }\n",
-              "\n",
-              "  [theme=dark] .colab-df-quickchart {\n",
-              "      --bg-color: #3B4455;\n",
-              "      --fill-color: #D2E3FC;\n",
-              "      --hover-bg-color: #434B5C;\n",
-              "      --hover-fill-color: #FFFFFF;\n",
-              "      --disabled-bg-color: #3B4455;\n",
-              "      --disabled-fill-color: #666;\n",
-              "  }\n",
-              "\n",
-              "  .colab-df-quickchart {\n",
-              "    background-color: var(--bg-color);\n",
-              "    border: none;\n",
-              "    border-radius: 50%;\n",
-              "    cursor: pointer;\n",
-              "    display: none;\n",
-              "    fill: var(--fill-color);\n",
-              "    height: 32px;\n",
-              "    padding: 0;\n",
-              "    width: 32px;\n",
-              "  }\n",
-              "\n",
-              "  .colab-df-quickchart:hover {\n",
-              "    background-color: var(--hover-bg-color);\n",
-              "    box-shadow: 0 1px 2px rgba(60, 64, 67, 0.3), 0 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
-              "    fill: var(--button-hover-fill-color);\n",
-              "  }\n",
-              "\n",
-              "  .colab-df-quickchart-complete:disabled,\n",
-              "  .colab-df-quickchart-complete:disabled:hover {\n",
-              "    background-color: var(--disabled-bg-color);\n",
-              "    fill: var(--disabled-fill-color);\n",
-              "    box-shadow: none;\n",
-              "  }\n",
-              "\n",
-              "  .colab-df-spinner {\n",
-              "    border: 2px solid var(--fill-color);\n",
-              "    border-color: transparent;\n",
-              "    border-bottom-color: var(--fill-color);\n",
-              "    animation:\n",
-              "      spin 1s steps(1) infinite;\n",
-              "  }\n",
-              "\n",
-              "  @keyframes spin {\n",
-              "    0% {\n",
-              "      border-color: transparent;\n",
-              "      border-bottom-color: var(--fill-color);\n",
-              "      border-left-color: var(--fill-color);\n",
-              "    }\n",
-              "    20% {\n",
-              "      border-color: transparent;\n",
-              "      border-left-color: var(--fill-color);\n",
-              "      border-top-color: var(--fill-color);\n",
-              "    }\n",
-              "    30% {\n",
-              "      border-color: transparent;\n",
-              "      border-left-color: var(--fill-color);\n",
-              "      border-top-color: var(--fill-color);\n",
-              "      border-right-color: var(--fill-color);\n",
-              "    }\n",
-              "    40% {\n",
-              "      border-color: transparent;\n",
-              "      border-right-color: var(--fill-color);\n",
-              "      border-top-color: var(--fill-color);\n",
-              "    }\n",
-              "    60% {\n",
-              "      border-color: transparent;\n",
-              "      border-right-color: var(--fill-color);\n",
-              "    }\n",
-              "    80% {\n",
-              "      border-color: transparent;\n",
-              "      border-right-color: var(--fill-color);\n",
-              "      border-bottom-color: var(--fill-color);\n",
-              "    }\n",
-              "    90% {\n",
-              "      border-color: transparent;\n",
-              "      border-bottom-color: var(--fill-color);\n",
-              "    }\n",
-              "  }\n",
-              "</style>\n",
-              "\n",
-              "  <script>\n",
-              "    async function quickchart(key) {\n",
-              "      const quickchartButtonEl =\n",
-              "        document.querySelector('#' + key + ' button');\n",
-              "      quickchartButtonEl.disabled = true;  // To prevent multiple clicks.\n",
-              "      quickchartButtonEl.classList.add('colab-df-spinner');\n",
-              "      try {\n",
-              "        const charts = await google.colab.kernel.invokeFunction(\n",
-              "            'suggestCharts', [key], {});\n",
-              "      } catch (error) {\n",
-              "        console.error('Error during call to suggestCharts:', error);\n",
-              "      }\n",
-              "      quickchartButtonEl.classList.remove('colab-df-spinner');\n",
-              "      quickchartButtonEl.classList.add('colab-df-quickchart-complete');\n",
-              "    }\n",
-              "    (() => {\n",
-              "      let quickchartButtonEl =\n",
-              "        document.querySelector('#df-82508f35-0ec3-402f-98df-b0ab6d857639 button');\n",
-              "      quickchartButtonEl.style.display =\n",
-              "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
-              "    })();\n",
-              "  </script>\n",
-              "</div>\n",
-              "    </div>\n",
-              "  </div>\n"
-            ]
-          },
-          "metadata": {},
-          "execution_count": 38
-        }
-      ],
-      "source": [
-        "ed_flights[['DistanceKilometers', 'AvgTicketPrice']].aggregate(['sum', 'min', 'std'])"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "v-49A_fDNRFe"
-      },
-      "source": [
-        "## Computations / descriptive stats"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "00OupOBTNRFe"
-      },
-      "source": [
-        "### DataFrame.count"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 39,
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2021-12-15T20:24:48.574692Z",
-          "iopub.status.busy": "2021-12-15T20:24:48.574008Z",
-          "iopub.status.idle": "2021-12-15T20:24:48.580240Z",
-          "shell.execute_reply": "2021-12-15T20:24:48.579845Z"
-        },
-        "pycharm": {
-          "is_executing": false
-        },
-        "id": "-1b9NDszNRFe",
-        "outputId": "d788498d-a027-4fcf-b963-e1863cd3ad86",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        }
-      },
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "AvgTicketPrice    13059\n",
-              "Cancelled         13059\n",
-              "Carrier           13059\n",
-              "Dest              13059\n",
-              "DestAirportID     13059\n",
-              "                  ...  \n",
-              "OriginLocation    13059\n",
-              "OriginRegion      13059\n",
-              "OriginWeather     13059\n",
-              "dayOfWeek         13059\n",
-              "timestamp         13059\n",
-              "Length: 27, dtype: int64"
-            ]
-          },
-          "metadata": {},
-          "execution_count": 39
-        }
-      ],
-      "source": [
-        "pd_flights.count()"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 40,
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2021-12-15T20:24:48.583948Z",
-          "iopub.status.busy": "2021-12-15T20:24:48.583565Z",
-          "iopub.status.idle": "2021-12-15T20:24:50.642201Z",
-          "shell.execute_reply": "2021-12-15T20:24:50.643158Z"
-        },
-        "pycharm": {
-          "is_executing": false
-        },
-        "id": "GjHLdmvPNRFf",
-        "outputId": "3cbfb5f9-b75d-4b1e-dcd1-8c735887ca51",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        }
-      },
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "AvgTicketPrice    13059\n",
-              "Cancelled         13059\n",
-              "Carrier           13059\n",
-              "Dest              13059\n",
-              "DestAirportID     13059\n",
-              "                  ...  \n",
-              "OriginLocation    13059\n",
-              "OriginRegion      13059\n",
-              "OriginWeather     13059\n",
-              "dayOfWeek         13059\n",
-              "timestamp         13059\n",
-              "Length: 27, dtype: int64"
-            ]
-          },
-          "metadata": {},
-          "execution_count": 40
-        }
-      ],
-      "source": [
-        "ed_flights.count()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "tF40dPiPNRFf"
-      },
-      "source": [
-        "### DataFrame.describe"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 41,
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2021-12-15T20:24:50.655939Z",
-          "iopub.status.busy": "2021-12-15T20:24:50.654654Z",
-          "iopub.status.idle": "2021-12-15T20:24:50.702251Z",
-          "shell.execute_reply": "2021-12-15T20:24:50.701757Z"
-        },
-        "pycharm": {
-          "is_executing": false
-        },
-        "id": "IKjmnuuBNRFf",
-        "outputId": "8a1418a2-f2e4-408c-8837-ff3626b307b8",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 330
-        }
-      },
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "       AvgTicketPrice  DistanceKilometers  ...  FlightTimeMin     dayOfWeek\n",
-              "count    13059.000000        13059.000000  ...   13059.000000  13059.000000\n",
-              "mean       628.253689         7092.142455  ...     511.127842      2.835975\n",
-              "std        266.396861         4578.438497  ...     334.753952      1.939439\n",
-              "min        100.020528            0.000000  ...       0.000000      0.000000\n",
-              "25%        409.893816         2459.705673  ...     252.333192      1.000000\n",
-              "50%        640.556668         7610.330866  ...     503.045170      3.000000\n",
-              "75%        842.185470         9736.637600  ...     720.416036      4.000000\n",
-              "max       1199.729053        19881.482315  ...    1902.902032      6.000000\n",
-              "\n",
-              "[8 rows x 7 columns]"
-            ],
-            "text/html": [
-              "\n",
-              "  <div id=\"df-ad1dcf82-a33c-4cc9-af15-8f33e0f886ac\" class=\"colab-df-container\">\n",
-              "    <div>\n",
-              "<style scoped>\n",
-              "    .dataframe tbody tr th:only-of-type {\n",
-              "        vertical-align: middle;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe tbody tr th {\n",
-              "        vertical-align: top;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe thead th {\n",
-              "        text-align: right;\n",
-              "    }\n",
-              "</style>\n",
-              "<table border=\"1\" class=\"dataframe\">\n",
-              "  <thead>\n",
-              "    <tr style=\"text-align: right;\">\n",
-              "      <th></th>\n",
-              "      <th>AvgTicketPrice</th>\n",
-              "      <th>DistanceKilometers</th>\n",
-              "      <th>...</th>\n",
-              "      <th>FlightTimeMin</th>\n",
-              "      <th>dayOfWeek</th>\n",
-              "    </tr>\n",
-              "  </thead>\n",
-              "  <tbody>\n",
-              "    <tr>\n",
-              "      <th>count</th>\n",
-              "      <td>13059.000000</td>\n",
-              "      <td>13059.000000</td>\n",
-              "      <td>...</td>\n",
-              "      <td>13059.000000</td>\n",
-              "      <td>13059.000000</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>mean</th>\n",
-              "      <td>628.253689</td>\n",
-              "      <td>7092.142455</td>\n",
-              "      <td>...</td>\n",
-              "      <td>511.127842</td>\n",
-              "      <td>2.835975</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>std</th>\n",
-              "      <td>266.396861</td>\n",
-              "      <td>4578.438497</td>\n",
-              "      <td>...</td>\n",
-              "      <td>334.753952</td>\n",
-              "      <td>1.939439</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>min</th>\n",
-              "      <td>100.020528</td>\n",
-              "      <td>0.000000</td>\n",
-              "      <td>...</td>\n",
-              "      <td>0.000000</td>\n",
-              "      <td>0.000000</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>25%</th>\n",
-              "      <td>409.893816</td>\n",
-              "      <td>2459.705673</td>\n",
-              "      <td>...</td>\n",
-              "      <td>252.333192</td>\n",
-              "      <td>1.000000</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>50%</th>\n",
-              "      <td>640.556668</td>\n",
-              "      <td>7610.330866</td>\n",
-              "      <td>...</td>\n",
-              "      <td>503.045170</td>\n",
-              "      <td>3.000000</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>75%</th>\n",
-              "      <td>842.185470</td>\n",
-              "      <td>9736.637600</td>\n",
-              "      <td>...</td>\n",
-              "      <td>720.416036</td>\n",
-              "      <td>4.000000</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>max</th>\n",
-              "      <td>1199.729053</td>\n",
-              "      <td>19881.482315</td>\n",
-              "      <td>...</td>\n",
-              "      <td>1902.902032</td>\n",
-              "      <td>6.000000</td>\n",
-              "    </tr>\n",
-              "  </tbody>\n",
-              "</table>\n",
-              "<p>8 rows × 7 columns</p>\n",
-              "</div>\n",
-              "    <div class=\"colab-df-buttons\">\n",
-              "\n",
-              "  <div class=\"colab-df-container\">\n",
-              "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-ad1dcf82-a33c-4cc9-af15-8f33e0f886ac')\"\n",
-              "            title=\"Convert this dataframe to an interactive table.\"\n",
-              "            style=\"display:none;\">\n",
-              "\n",
-              "  <svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\" viewBox=\"0 -960 960 960\">\n",
-              "    <path d=\"M120-120v-720h720v720H120Zm60-500h600v-160H180v160Zm220 220h160v-160H400v160Zm0 220h160v-160H400v160ZM180-400h160v-160H180v160Zm440 0h160v-160H620v160ZM180-180h160v-160H180v160Zm440 0h160v-160H620v160Z\"/>\n",
-              "  </svg>\n",
-              "    </button>\n",
-              "\n",
-              "  <style>\n",
-              "    .colab-df-container {\n",
-              "      display:flex;\n",
-              "      gap: 12px;\n",
-              "    }\n",
-              "\n",
-              "    .colab-df-convert {\n",
-              "      background-color: #E8F0FE;\n",
-              "      border: none;\n",
-              "      border-radius: 50%;\n",
-              "      cursor: pointer;\n",
-              "      display: none;\n",
-              "      fill: #1967D2;\n",
-              "      height: 32px;\n",
-              "      padding: 0 0 0 0;\n",
-              "      width: 32px;\n",
-              "    }\n",
-              "\n",
-              "    .colab-df-convert:hover {\n",
-              "      background-color: #E2EBFA;\n",
-              "      box-shadow: 0px 1px 2px rgba(60, 64, 67, 0.3), 0px 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
-              "      fill: #174EA6;\n",
-              "    }\n",
-              "\n",
-              "    .colab-df-buttons div {\n",
-              "      margin-bottom: 4px;\n",
-              "    }\n",
-              "\n",
-              "    [theme=dark] .colab-df-convert {\n",
-              "      background-color: #3B4455;\n",
-              "      fill: #D2E3FC;\n",
-              "    }\n",
-              "\n",
-              "    [theme=dark] .colab-df-convert:hover {\n",
-              "      background-color: #434B5C;\n",
-              "      box-shadow: 0px 1px 3px 1px rgba(0, 0, 0, 0.15);\n",
-              "      filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.3));\n",
-              "      fill: #FFFFFF;\n",
-              "    }\n",
-              "  </style>\n",
-              "\n",
-              "    <script>\n",
-              "      const buttonEl =\n",
-              "        document.querySelector('#df-ad1dcf82-a33c-4cc9-af15-8f33e0f886ac button.colab-df-convert');\n",
-              "      buttonEl.style.display =\n",
-              "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
-              "\n",
-              "      async function convertToInteractive(key) {\n",
-              "        const element = document.querySelector('#df-ad1dcf82-a33c-4cc9-af15-8f33e0f886ac');\n",
-              "        const dataTable =\n",
-              "          await google.colab.kernel.invokeFunction('convertToInteractive',\n",
-              "                                                    [key], {});\n",
-              "        if (!dataTable) return;\n",
-              "\n",
-              "        const docLinkHtml = 'Like what you see? Visit the ' +\n",
-              "          '<a target=\"_blank\" href=https://colab.research.google.com/notebooks/data_table.ipynb>data table notebook</a>'\n",
-              "          + ' to learn more about interactive tables.';\n",
-              "        element.innerHTML = '';\n",
-              "        dataTable['output_type'] = 'display_data';\n",
-              "        await google.colab.output.renderOutput(dataTable, element);\n",
-              "        const docLink = document.createElement('div');\n",
-              "        docLink.innerHTML = docLinkHtml;\n",
-              "        element.appendChild(docLink);\n",
-              "      }\n",
-              "    </script>\n",
-              "  </div>\n",
-              "\n",
-              "\n",
-              "<div id=\"df-ca137ff9-91bd-4b18-a9a6-6d960bc0f917\">\n",
-              "  <button class=\"colab-df-quickchart\" onclick=\"quickchart('df-ca137ff9-91bd-4b18-a9a6-6d960bc0f917')\"\n",
-              "            title=\"Suggest charts.\"\n",
-              "            style=\"display:none;\">\n",
-              "\n",
-              "<svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\"viewBox=\"0 0 24 24\"\n",
-              "     width=\"24px\">\n",
-              "    <g>\n",
-              "        <path d=\"M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zM9 17H7v-7h2v7zm4 0h-2V7h2v10zm4 0h-2v-4h2v4z\"/>\n",
-              "    </g>\n",
-              "</svg>\n",
-              "  </button>\n",
-              "\n",
-              "<style>\n",
-              "  .colab-df-quickchart {\n",
-              "      --bg-color: #E8F0FE;\n",
-              "      --fill-color: #1967D2;\n",
-              "      --hover-bg-color: #E2EBFA;\n",
-              "      --hover-fill-color: #174EA6;\n",
-              "      --disabled-fill-color: #AAA;\n",
-              "      --disabled-bg-color: #DDD;\n",
-              "  }\n",
-              "\n",
-              "  [theme=dark] .colab-df-quickchart {\n",
-              "      --bg-color: #3B4455;\n",
-              "      --fill-color: #D2E3FC;\n",
-              "      --hover-bg-color: #434B5C;\n",
-              "      --hover-fill-color: #FFFFFF;\n",
-              "      --disabled-bg-color: #3B4455;\n",
-              "      --disabled-fill-color: #666;\n",
-              "  }\n",
-              "\n",
-              "  .colab-df-quickchart {\n",
-              "    background-color: var(--bg-color);\n",
-              "    border: none;\n",
-              "    border-radius: 50%;\n",
-              "    cursor: pointer;\n",
-              "    display: none;\n",
-              "    fill: var(--fill-color);\n",
-              "    height: 32px;\n",
-              "    padding: 0;\n",
-              "    width: 32px;\n",
-              "  }\n",
-              "\n",
-              "  .colab-df-quickchart:hover {\n",
-              "    background-color: var(--hover-bg-color);\n",
-              "    box-shadow: 0 1px 2px rgba(60, 64, 67, 0.3), 0 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
-              "    fill: var(--button-hover-fill-color);\n",
-              "  }\n",
-              "\n",
-              "  .colab-df-quickchart-complete:disabled,\n",
-              "  .colab-df-quickchart-complete:disabled:hover {\n",
-              "    background-color: var(--disabled-bg-color);\n",
-              "    fill: var(--disabled-fill-color);\n",
-              "    box-shadow: none;\n",
-              "  }\n",
-              "\n",
-              "  .colab-df-spinner {\n",
-              "    border: 2px solid var(--fill-color);\n",
-              "    border-color: transparent;\n",
-              "    border-bottom-color: var(--fill-color);\n",
-              "    animation:\n",
-              "      spin 1s steps(1) infinite;\n",
-              "  }\n",
-              "\n",
-              "  @keyframes spin {\n",
-              "    0% {\n",
-              "      border-color: transparent;\n",
-              "      border-bottom-color: var(--fill-color);\n",
-              "      border-left-color: var(--fill-color);\n",
-              "    }\n",
-              "    20% {\n",
-              "      border-color: transparent;\n",
-              "      border-left-color: var(--fill-color);\n",
-              "      border-top-color: var(--fill-color);\n",
-              "    }\n",
-              "    30% {\n",
-              "      border-color: transparent;\n",
-              "      border-left-color: var(--fill-color);\n",
-              "      border-top-color: var(--fill-color);\n",
-              "      border-right-color: var(--fill-color);\n",
-              "    }\n",
-              "    40% {\n",
-              "      border-color: transparent;\n",
-              "      border-right-color: var(--fill-color);\n",
-              "      border-top-color: var(--fill-color);\n",
-              "    }\n",
-              "    60% {\n",
-              "      border-color: transparent;\n",
-              "      border-right-color: var(--fill-color);\n",
-              "    }\n",
-              "    80% {\n",
-              "      border-color: transparent;\n",
-              "      border-right-color: var(--fill-color);\n",
-              "      border-bottom-color: var(--fill-color);\n",
-              "    }\n",
-              "    90% {\n",
-              "      border-color: transparent;\n",
-              "      border-bottom-color: var(--fill-color);\n",
-              "    }\n",
-              "  }\n",
-              "</style>\n",
-              "\n",
-              "  <script>\n",
-              "    async function quickchart(key) {\n",
-              "      const quickchartButtonEl =\n",
-              "        document.querySelector('#' + key + ' button');\n",
-              "      quickchartButtonEl.disabled = true;  // To prevent multiple clicks.\n",
-              "      quickchartButtonEl.classList.add('colab-df-spinner');\n",
-              "      try {\n",
-              "        const charts = await google.colab.kernel.invokeFunction(\n",
-              "            'suggestCharts', [key], {});\n",
-              "      } catch (error) {\n",
-              "        console.error('Error during call to suggestCharts:', error);\n",
-              "      }\n",
-              "      quickchartButtonEl.classList.remove('colab-df-spinner');\n",
-              "      quickchartButtonEl.classList.add('colab-df-quickchart-complete');\n",
-              "    }\n",
-              "    (() => {\n",
-              "      let quickchartButtonEl =\n",
-              "        document.querySelector('#df-ca137ff9-91bd-4b18-a9a6-6d960bc0f917 button');\n",
-              "      quickchartButtonEl.style.display =\n",
-              "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
-              "    })();\n",
-              "  </script>\n",
-              "</div>\n",
-              "    </div>\n",
-              "  </div>\n"
-            ]
-          },
-          "metadata": {},
-          "execution_count": 41
-        }
-      ],
-      "source": [
-        "pd_flights.describe()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "O4FVtGT9NRFg"
-      },
-      "source": [
-        "Values returned from `eland.DataFrame.describe` may vary due to results of Elasticsearch aggregations."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 42,
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2021-12-15T20:24:50.710321Z",
-          "iopub.status.busy": "2021-12-15T20:24:50.709905Z",
-          "iopub.status.idle": "2021-12-15T20:24:50.912876Z",
-          "shell.execute_reply": "2021-12-15T20:24:50.913469Z"
-        },
-        "pycharm": {
-          "is_executing": false
-        },
-        "id": "L7eKy3AINRFg",
-        "outputId": "4e191714-77a5-43a2-d364-bfbed1559b98",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 330
-        }
-      },
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "       AvgTicketPrice     Cancelled  ...  FlightTimeMin     dayOfWeek\n",
-              "count    13059.000000  13059.000000  ...   13059.000000  13059.000000\n",
-              "mean       628.253689      0.128494  ...     511.127842      2.835975\n",
-              "std        266.407061      0.334664  ...     334.766770      1.939513\n",
-              "min        100.020531      0.000000  ...       0.000000      0.000000\n",
-              "25%        411.154491      0.000000  ...     250.428538      1.058527\n",
-              "50%        639.433214      0.000000  ...     502.777975      2.935777\n",
-              "75%        842.336195      0.000000  ...     721.351220      4.427843\n",
-              "max       1199.729004      1.000000  ...    1902.901978      6.000000\n",
-              "\n",
-              "[8 rows x 9 columns]"
-            ],
-            "text/html": [
-              "\n",
-              "  <div id=\"df-c245623d-6905-46ff-a248-ff68036187bc\" class=\"colab-df-container\">\n",
-              "    <div>\n",
-              "<style scoped>\n",
-              "    .dataframe tbody tr th:only-of-type {\n",
-              "        vertical-align: middle;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe tbody tr th {\n",
-              "        vertical-align: top;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe thead th {\n",
-              "        text-align: right;\n",
-              "    }\n",
-              "</style>\n",
-              "<table border=\"1\" class=\"dataframe\">\n",
-              "  <thead>\n",
-              "    <tr style=\"text-align: right;\">\n",
-              "      <th></th>\n",
-              "      <th>AvgTicketPrice</th>\n",
-              "      <th>Cancelled</th>\n",
-              "      <th>...</th>\n",
-              "      <th>FlightTimeMin</th>\n",
-              "      <th>dayOfWeek</th>\n",
-              "    </tr>\n",
-              "  </thead>\n",
-              "  <tbody>\n",
-              "    <tr>\n",
-              "      <th>count</th>\n",
-              "      <td>13059.000000</td>\n",
-              "      <td>13059.000000</td>\n",
-              "      <td>...</td>\n",
-              "      <td>13059.000000</td>\n",
-              "      <td>13059.000000</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>mean</th>\n",
-              "      <td>628.253689</td>\n",
-              "      <td>0.128494</td>\n",
-              "      <td>...</td>\n",
-              "      <td>511.127842</td>\n",
-              "      <td>2.835975</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>std</th>\n",
-              "      <td>266.407061</td>\n",
-              "      <td>0.334664</td>\n",
-              "      <td>...</td>\n",
-              "      <td>334.766770</td>\n",
-              "      <td>1.939513</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>min</th>\n",
-              "      <td>100.020531</td>\n",
-              "      <td>0.000000</td>\n",
-              "      <td>...</td>\n",
-              "      <td>0.000000</td>\n",
-              "      <td>0.000000</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>25%</th>\n",
-              "      <td>411.154491</td>\n",
-              "      <td>0.000000</td>\n",
-              "      <td>...</td>\n",
-              "      <td>250.428538</td>\n",
-              "      <td>1.058527</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>50%</th>\n",
-              "      <td>639.433214</td>\n",
-              "      <td>0.000000</td>\n",
-              "      <td>...</td>\n",
-              "      <td>502.777975</td>\n",
-              "      <td>2.935777</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>75%</th>\n",
-              "      <td>842.336195</td>\n",
-              "      <td>0.000000</td>\n",
-              "      <td>...</td>\n",
-              "      <td>721.351220</td>\n",
-              "      <td>4.427843</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>max</th>\n",
-              "      <td>1199.729004</td>\n",
-              "      <td>1.000000</td>\n",
-              "      <td>...</td>\n",
-              "      <td>1902.901978</td>\n",
-              "      <td>6.000000</td>\n",
-              "    </tr>\n",
-              "  </tbody>\n",
-              "</table>\n",
-              "<p>8 rows × 9 columns</p>\n",
-              "</div>\n",
-              "    <div class=\"colab-df-buttons\">\n",
-              "\n",
-              "  <div class=\"colab-df-container\">\n",
-              "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-c245623d-6905-46ff-a248-ff68036187bc')\"\n",
-              "            title=\"Convert this dataframe to an interactive table.\"\n",
-              "            style=\"display:none;\">\n",
-              "\n",
-              "  <svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\" viewBox=\"0 -960 960 960\">\n",
-              "    <path d=\"M120-120v-720h720v720H120Zm60-500h600v-160H180v160Zm220 220h160v-160H400v160Zm0 220h160v-160H400v160ZM180-400h160v-160H180v160Zm440 0h160v-160H620v160ZM180-180h160v-160H180v160Zm440 0h160v-160H620v160Z\"/>\n",
-              "  </svg>\n",
-              "    </button>\n",
-              "\n",
-              "  <style>\n",
-              "    .colab-df-container {\n",
-              "      display:flex;\n",
-              "      gap: 12px;\n",
-              "    }\n",
-              "\n",
-              "    .colab-df-convert {\n",
-              "      background-color: #E8F0FE;\n",
-              "      border: none;\n",
-              "      border-radius: 50%;\n",
-              "      cursor: pointer;\n",
-              "      display: none;\n",
-              "      fill: #1967D2;\n",
-              "      height: 32px;\n",
-              "      padding: 0 0 0 0;\n",
-              "      width: 32px;\n",
-              "    }\n",
-              "\n",
-              "    .colab-df-convert:hover {\n",
-              "      background-color: #E2EBFA;\n",
-              "      box-shadow: 0px 1px 2px rgba(60, 64, 67, 0.3), 0px 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
-              "      fill: #174EA6;\n",
-              "    }\n",
-              "\n",
-              "    .colab-df-buttons div {\n",
-              "      margin-bottom: 4px;\n",
-              "    }\n",
-              "\n",
-              "    [theme=dark] .colab-df-convert {\n",
-              "      background-color: #3B4455;\n",
-              "      fill: #D2E3FC;\n",
-              "    }\n",
-              "\n",
-              "    [theme=dark] .colab-df-convert:hover {\n",
-              "      background-color: #434B5C;\n",
-              "      box-shadow: 0px 1px 3px 1px rgba(0, 0, 0, 0.15);\n",
-              "      filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.3));\n",
-              "      fill: #FFFFFF;\n",
-              "    }\n",
-              "  </style>\n",
-              "\n",
-              "    <script>\n",
-              "      const buttonEl =\n",
-              "        document.querySelector('#df-c245623d-6905-46ff-a248-ff68036187bc button.colab-df-convert');\n",
-              "      buttonEl.style.display =\n",
-              "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
-              "\n",
-              "      async function convertToInteractive(key) {\n",
-              "        const element = document.querySelector('#df-c245623d-6905-46ff-a248-ff68036187bc');\n",
-              "        const dataTable =\n",
-              "          await google.colab.kernel.invokeFunction('convertToInteractive',\n",
-              "                                                    [key], {});\n",
-              "        if (!dataTable) return;\n",
-              "\n",
-              "        const docLinkHtml = 'Like what you see? Visit the ' +\n",
-              "          '<a target=\"_blank\" href=https://colab.research.google.com/notebooks/data_table.ipynb>data table notebook</a>'\n",
-              "          + ' to learn more about interactive tables.';\n",
-              "        element.innerHTML = '';\n",
-              "        dataTable['output_type'] = 'display_data';\n",
-              "        await google.colab.output.renderOutput(dataTable, element);\n",
-              "        const docLink = document.createElement('div');\n",
-              "        docLink.innerHTML = docLinkHtml;\n",
-              "        element.appendChild(docLink);\n",
-              "      }\n",
-              "    </script>\n",
-              "  </div>\n",
-              "\n",
-              "\n",
-              "<div id=\"df-0c99c5fd-4def-4a58-bdfc-0f05b33edd88\">\n",
-              "  <button class=\"colab-df-quickchart\" onclick=\"quickchart('df-0c99c5fd-4def-4a58-bdfc-0f05b33edd88')\"\n",
-              "            title=\"Suggest charts.\"\n",
-              "            style=\"display:none;\">\n",
-              "\n",
-              "<svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\"viewBox=\"0 0 24 24\"\n",
-              "     width=\"24px\">\n",
-              "    <g>\n",
-              "        <path d=\"M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zM9 17H7v-7h2v7zm4 0h-2V7h2v10zm4 0h-2v-4h2v4z\"/>\n",
-              "    </g>\n",
-              "</svg>\n",
-              "  </button>\n",
-              "\n",
-              "<style>\n",
-              "  .colab-df-quickchart {\n",
-              "      --bg-color: #E8F0FE;\n",
-              "      --fill-color: #1967D2;\n",
-              "      --hover-bg-color: #E2EBFA;\n",
-              "      --hover-fill-color: #174EA6;\n",
-              "      --disabled-fill-color: #AAA;\n",
-              "      --disabled-bg-color: #DDD;\n",
-              "  }\n",
-              "\n",
-              "  [theme=dark] .colab-df-quickchart {\n",
-              "      --bg-color: #3B4455;\n",
-              "      --fill-color: #D2E3FC;\n",
-              "      --hover-bg-color: #434B5C;\n",
-              "      --hover-fill-color: #FFFFFF;\n",
-              "      --disabled-bg-color: #3B4455;\n",
-              "      --disabled-fill-color: #666;\n",
-              "  }\n",
-              "\n",
-              "  .colab-df-quickchart {\n",
-              "    background-color: var(--bg-color);\n",
-              "    border: none;\n",
-              "    border-radius: 50%;\n",
-              "    cursor: pointer;\n",
-              "    display: none;\n",
-              "    fill: var(--fill-color);\n",
-              "    height: 32px;\n",
-              "    padding: 0;\n",
-              "    width: 32px;\n",
-              "  }\n",
-              "\n",
-              "  .colab-df-quickchart:hover {\n",
-              "    background-color: var(--hover-bg-color);\n",
-              "    box-shadow: 0 1px 2px rgba(60, 64, 67, 0.3), 0 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
-              "    fill: var(--button-hover-fill-color);\n",
-              "  }\n",
-              "\n",
-              "  .colab-df-quickchart-complete:disabled,\n",
-              "  .colab-df-quickchart-complete:disabled:hover {\n",
-              "    background-color: var(--disabled-bg-color);\n",
-              "    fill: var(--disabled-fill-color);\n",
-              "    box-shadow: none;\n",
-              "  }\n",
-              "\n",
-              "  .colab-df-spinner {\n",
-              "    border: 2px solid var(--fill-color);\n",
-              "    border-color: transparent;\n",
-              "    border-bottom-color: var(--fill-color);\n",
-              "    animation:\n",
-              "      spin 1s steps(1) infinite;\n",
-              "  }\n",
-              "\n",
-              "  @keyframes spin {\n",
-              "    0% {\n",
-              "      border-color: transparent;\n",
-              "      border-bottom-color: var(--fill-color);\n",
-              "      border-left-color: var(--fill-color);\n",
-              "    }\n",
-              "    20% {\n",
-              "      border-color: transparent;\n",
-              "      border-left-color: var(--fill-color);\n",
-              "      border-top-color: var(--fill-color);\n",
-              "    }\n",
-              "    30% {\n",
-              "      border-color: transparent;\n",
-              "      border-left-color: var(--fill-color);\n",
-              "      border-top-color: var(--fill-color);\n",
-              "      border-right-color: var(--fill-color);\n",
-              "    }\n",
-              "    40% {\n",
-              "      border-color: transparent;\n",
-              "      border-right-color: var(--fill-color);\n",
-              "      border-top-color: var(--fill-color);\n",
-              "    }\n",
-              "    60% {\n",
-              "      border-color: transparent;\n",
-              "      border-right-color: var(--fill-color);\n",
-              "    }\n",
-              "    80% {\n",
-              "      border-color: transparent;\n",
-              "      border-right-color: var(--fill-color);\n",
-              "      border-bottom-color: var(--fill-color);\n",
-              "    }\n",
-              "    90% {\n",
-              "      border-color: transparent;\n",
-              "      border-bottom-color: var(--fill-color);\n",
-              "    }\n",
-              "  }\n",
-              "</style>\n",
-              "\n",
-              "  <script>\n",
-              "    async function quickchart(key) {\n",
-              "      const quickchartButtonEl =\n",
-              "        document.querySelector('#' + key + ' button');\n",
-              "      quickchartButtonEl.disabled = true;  // To prevent multiple clicks.\n",
-              "      quickchartButtonEl.classList.add('colab-df-spinner');\n",
-              "      try {\n",
-              "        const charts = await google.colab.kernel.invokeFunction(\n",
-              "            'suggestCharts', [key], {});\n",
-              "      } catch (error) {\n",
-              "        console.error('Error during call to suggestCharts:', error);\n",
-              "      }\n",
-              "      quickchartButtonEl.classList.remove('colab-df-spinner');\n",
-              "      quickchartButtonEl.classList.add('colab-df-quickchart-complete');\n",
-              "    }\n",
-              "    (() => {\n",
-              "      let quickchartButtonEl =\n",
-              "        document.querySelector('#df-0c99c5fd-4def-4a58-bdfc-0f05b33edd88 button');\n",
-              "      quickchartButtonEl.style.display =\n",
-              "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
-              "    })();\n",
-              "  </script>\n",
-              "</div>\n",
-              "    </div>\n",
-              "  </div>\n"
-            ]
-          },
-          "metadata": {},
-          "execution_count": 42
-        }
-      ],
-      "source": [
-        "# NBVAL_IGNORE_OUTPUT\n",
-        "ed_flights.describe()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "qDo76JgKNRFh"
-      },
-      "source": [
-        "### DataFrame.info"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 43,
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2021-12-15T20:24:50.944997Z",
-          "iopub.status.busy": "2021-12-15T20:24:50.918277Z",
-          "iopub.status.idle": "2021-12-15T20:24:50.958394Z",
-          "shell.execute_reply": "2021-12-15T20:24:50.958030Z"
-        },
-        "pycharm": {
-          "is_executing": false
-        },
-        "id": "GvvfPrPdNRFh",
-        "outputId": "f7f62b65-8741-4f93-e037-7743b1e9f6f5",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        }
-      },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "<class 'pandas.core.frame.DataFrame'>\n",
-            "Index: 13059 entries, 0 to 13058\n",
-            "Data columns (total 27 columns):\n",
-            " #   Column              Non-Null Count  Dtype         \n",
-            "---  ------              --------------  -----         \n",
-            " 0   AvgTicketPrice      13059 non-null  float64       \n",
-            " 1   Cancelled           13059 non-null  bool          \n",
-            " 2   Carrier             13059 non-null  object        \n",
-            " 3   Dest                13059 non-null  object        \n",
-            " 4   DestAirportID       13059 non-null  object        \n",
-            " 5   DestCityName        13059 non-null  object        \n",
-            " 6   DestCountry         13059 non-null  object        \n",
-            " 7   DestLocation        13059 non-null  object        \n",
-            " 8   DestRegion          13059 non-null  object        \n",
-            " 9   DestWeather         13059 non-null  object        \n",
-            " 10  DistanceKilometers  13059 non-null  float64       \n",
-            " 11  DistanceMiles       13059 non-null  float64       \n",
-            " 12  FlightDelay         13059 non-null  bool          \n",
-            " 13  FlightDelayMin      13059 non-null  int64         \n",
-            " 14  FlightDelayType     13059 non-null  object        \n",
-            " 15  FlightNum           13059 non-null  object        \n",
-            " 16  FlightTimeHour      13059 non-null  float64       \n",
-            " 17  FlightTimeMin       13059 non-null  float64       \n",
-            " 18  Origin              13059 non-null  object        \n",
-            " 19  OriginAirportID     13059 non-null  object        \n",
-            " 20  OriginCityName      13059 non-null  object        \n",
-            " 21  OriginCountry       13059 non-null  object        \n",
-            " 22  OriginLocation      13059 non-null  object        \n",
-            " 23  OriginRegion        13059 non-null  object        \n",
-            " 24  OriginWeather       13059 non-null  object        \n",
-            " 25  dayOfWeek           13059 non-null  int64         \n",
-            " 26  timestamp           13059 non-null  datetime64[ns]\n",
-            "dtypes: bool(2), datetime64[ns](1), float64(5), int64(2), object(17)\n",
-            "memory usage: 3.1+ MB\n"
-          ]
-        }
-      ],
-      "source": [
-        "pd_flights.info()"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 44,
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2021-12-15T20:24:50.961762Z",
-          "iopub.status.busy": "2021-12-15T20:24:50.961398Z",
-          "iopub.status.idle": "2021-12-15T20:24:55.507758Z",
-          "shell.execute_reply": "2021-12-15T20:24:55.507382Z"
-        },
-        "pycharm": {
-          "is_executing": false
-        },
-        "id": "ByVDPJXkNRFh",
-        "outputId": "98bff4c2-44f3-42d1-b124-8bf8683fc663",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        }
-      },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "<class 'eland.dataframe.DataFrame'>\n",
-            "Index: 13059 entries, 0 to 13058\n",
-            "Data columns (total 27 columns):\n",
-            " #   Column              Non-Null Count  Dtype         \n",
-            "---  ------              --------------  -----         \n",
-            " 0   AvgTicketPrice      13059 non-null  float64       \n",
-            " 1   Cancelled           13059 non-null  bool          \n",
-            " 2   Carrier             13059 non-null  object        \n",
-            " 3   Dest                13059 non-null  object        \n",
-            " 4   DestAirportID       13059 non-null  object        \n",
-            " 5   DestCityName        13059 non-null  object        \n",
-            " 6   DestCountry         13059 non-null  object        \n",
-            " 7   DestLocation        13059 non-null  object        \n",
-            " 8   DestRegion          13059 non-null  object        \n",
-            " 9   DestWeather         13059 non-null  object        \n",
-            " 10  DistanceKilometers  13059 non-null  float64       \n",
-            " 11  DistanceMiles       13059 non-null  float64       \n",
-            " 12  FlightDelay         13059 non-null  bool          \n",
-            " 13  FlightDelayMin      13059 non-null  int64         \n",
-            " 14  FlightDelayType     13059 non-null  object        \n",
-            " 15  FlightNum           13059 non-null  object        \n",
-            " 16  FlightTimeHour      13059 non-null  float64       \n",
-            " 17  FlightTimeMin       13059 non-null  float64       \n",
-            " 18  Origin              13059 non-null  object        \n",
-            " 19  OriginAirportID     13059 non-null  object        \n",
-            " 20  OriginCityName      13059 non-null  object        \n",
-            " 21  OriginCountry       13059 non-null  object        \n",
-            " 22  OriginLocation      13059 non-null  object        \n",
-            " 23  OriginRegion        13059 non-null  object        \n",
-            " 24  OriginWeather       13059 non-null  object        \n",
-            " 25  dayOfWeek           13059 non-null  int64         \n",
-            " 26  timestamp           13059 non-null  datetime64[ns]\n",
-            "dtypes: bool(2), datetime64[ns](1), float64(5), int64(2), object(17)\n",
-            "memory usage: 64.000 bytes\n",
-            "Elasticsearch storage usage: 11.066 MB\n"
-          ]
-        }
-      ],
-      "source": [
-        "ed_flights.info()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "nW0sRoI3NRFi"
-      },
-      "source": [
-        "### DataFrame.max, DataFrame.min, DataFrame.mean, DataFrame.sum"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "iMSuS3Q9NRFi"
-      },
-      "source": [
-        "#### max"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 45,
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2021-12-15T20:24:55.511067Z",
-          "iopub.status.busy": "2021-12-15T20:24:55.510706Z",
-          "iopub.status.idle": "2021-12-15T20:24:55.515166Z",
-          "shell.execute_reply": "2021-12-15T20:24:55.514795Z"
-        },
-        "pycharm": {
-          "is_executing": false
-        },
-        "id": "a06G_BihNRFj",
-        "outputId": "cd85c3d7-985c-4eb3-bf0d-7cb5dfb5f1ac",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        }
-      },
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "AvgTicketPrice         1199.729053\n",
-              "Cancelled                     True\n",
-              "DistanceKilometers    19881.482315\n",
-              "DistanceMiles         12353.780369\n",
-              "FlightDelay                   True\n",
-              "FlightDelayMin                 360\n",
-              "FlightTimeHour           31.715034\n",
-              "FlightTimeMin          1902.902032\n",
-              "dayOfWeek                        6\n",
-              "dtype: object"
-            ]
-          },
-          "metadata": {},
-          "execution_count": 45
-        }
-      ],
-      "source": [
-        "pd_flights.max(numeric_only=True)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "a6F0YCOCNRFj"
-      },
-      "source": [
-        "`eland.DataFrame.max,min,mean,sum` only aggregate numeric columns"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 46,
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2021-12-15T20:24:55.521502Z",
-          "iopub.status.busy": "2021-12-15T20:24:55.521124Z",
-          "iopub.status.idle": "2021-12-15T20:24:55.615898Z",
-          "shell.execute_reply": "2021-12-15T20:24:55.614418Z"
-        },
-        "pycharm": {
-          "is_executing": false
-        },
-        "id": "JG56E5IoNRFj",
-        "outputId": "736b6d37-4021-41f6-92cf-6e6bf0762a44",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        }
-      },
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "AvgTicketPrice         1199.729004\n",
-              "Cancelled                 1.000000\n",
-              "DistanceKilometers    19881.482422\n",
-              "DistanceMiles         12353.780273\n",
-              "FlightDelay               1.000000\n",
-              "FlightDelayMin          360.000000\n",
-              "FlightTimeHour           31.715034\n",
-              "FlightTimeMin          1902.901978\n",
-              "dayOfWeek                 6.000000\n",
-              "dtype: float64"
-            ]
-          },
-          "metadata": {},
-          "execution_count": 46
-        }
-      ],
-      "source": [
-        "ed_flights.max(numeric_only=True)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "cigqPPNZNRFk"
-      },
-      "source": [
-        "#### min"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 47,
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2021-12-15T20:24:55.629444Z",
-          "iopub.status.busy": "2021-12-15T20:24:55.627340Z",
-          "iopub.status.idle": "2021-12-15T20:24:55.638818Z",
-          "shell.execute_reply": "2021-12-15T20:24:55.637856Z"
-        },
-        "pycharm": {
-          "is_executing": false
-        },
-        "id": "jy4YPXvmNRFk",
-        "outputId": "7e546b63-2510-4c5b-dd3d-af2cf8cd13e3",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        }
-      },
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "AvgTicketPrice        100.020528\n",
-              "Cancelled                  False\n",
-              "DistanceKilometers           0.0\n",
-              "DistanceMiles                0.0\n",
-              "FlightDelay                False\n",
-              "FlightDelayMin                 0\n",
-              "FlightTimeHour               0.0\n",
-              "FlightTimeMin                0.0\n",
-              "dayOfWeek                      0\n",
-              "dtype: object"
-            ]
-          },
-          "metadata": {},
-          "execution_count": 47
-        }
-      ],
-      "source": [
-        "pd_flights.min(numeric_only=True)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 48,
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2021-12-15T20:24:55.649953Z",
-          "iopub.status.busy": "2021-12-15T20:24:55.644304Z",
-          "iopub.status.idle": "2021-12-15T20:24:55.731911Z",
-          "shell.execute_reply": "2021-12-15T20:24:55.731393Z"
-        },
-        "pycharm": {
-          "is_executing": false
-        },
-        "id": "1n3xlYOuNRFk",
-        "outputId": "6983566f-92d6-4a34-d645-05c2da0c68cc",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        }
-      },
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "AvgTicketPrice        100.020531\n",
-              "Cancelled               0.000000\n",
-              "DistanceKilometers      0.000000\n",
-              "DistanceMiles           0.000000\n",
-              "FlightDelay             0.000000\n",
-              "FlightDelayMin          0.000000\n",
-              "FlightTimeHour          0.000000\n",
-              "FlightTimeMin           0.000000\n",
-              "dayOfWeek               0.000000\n",
-              "dtype: float64"
-            ]
-          },
-          "metadata": {},
-          "execution_count": 48
-        }
-      ],
-      "source": [
-        "ed_flights.min(numeric_only=True)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "PJuymQk-NRFl"
-      },
-      "source": [
-        "#### mean"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 49,
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2021-12-15T20:24:55.735976Z",
-          "iopub.status.busy": "2021-12-15T20:24:55.735398Z",
-          "iopub.status.idle": "2021-12-15T20:24:55.740446Z",
-          "shell.execute_reply": "2021-12-15T20:24:55.740037Z"
-        },
-        "pycharm": {
-          "is_executing": false
-        },
-        "id": "Rcj9OfiaNRFl",
-        "outputId": "10ce5668-39bc-43db-c959-21c93baf5eef",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        }
-      },
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "AvgTicketPrice         628.253689\n",
-              "Cancelled                0.128494\n",
-              "DistanceKilometers    7092.142455\n",
-              "DistanceMiles         4406.853013\n",
-              "FlightDelay              0.251168\n",
-              "FlightDelayMin          47.335171\n",
-              "FlightTimeHour           8.518797\n",
-              "FlightTimeMin          511.127842\n",
-              "dayOfWeek                2.835975\n",
-              "dtype: float64"
-            ]
-          },
-          "metadata": {},
-          "execution_count": 49
-        }
-      ],
-      "source": [
-        "pd_flights.mean(numeric_only=True)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 50,
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2021-12-15T20:24:55.746976Z",
-          "iopub.status.busy": "2021-12-15T20:24:55.746605Z",
-          "iopub.status.idle": "2021-12-15T20:24:55.852359Z",
-          "shell.execute_reply": "2021-12-15T20:24:55.850558Z"
-        },
-        "pycharm": {
-          "is_executing": false
-        },
-        "id": "mNz42pJQNRFl",
-        "outputId": "b0e528c6-cceb-43d4-f98a-e017f2e0fa4f",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        }
-      },
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "AvgTicketPrice         628.253689\n",
-              "Cancelled                0.128494\n",
-              "DistanceKilometers    7092.142457\n",
-              "DistanceMiles         4406.853010\n",
-              "FlightDelay              0.251168\n",
-              "FlightDelayMin          47.335171\n",
-              "FlightTimeHour           8.518797\n",
-              "FlightTimeMin          511.127842\n",
-              "dayOfWeek                2.835975\n",
-              "dtype: float64"
-            ]
-          },
-          "metadata": {},
-          "execution_count": 50
-        }
-      ],
-      "source": [
-        "ed_flights.mean(numeric_only=True)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "deosSfnLNRFm"
-      },
-      "source": [
-        "#### sum"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 51,
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2021-12-15T20:24:55.867747Z",
-          "iopub.status.busy": "2021-12-15T20:24:55.865996Z",
-          "iopub.status.idle": "2021-12-15T20:24:55.882127Z",
-          "shell.execute_reply": "2021-12-15T20:24:55.883534Z"
-        },
-        "pycharm": {
-          "is_executing": false
-        },
-        "id": "uKXh2waNNRFm",
-        "outputId": "47309bb4-b1e8-4824-e6a4-c5b9b5bf7ce1",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        }
-      },
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "AvgTicketPrice        8.204365e+06\n",
-              "Cancelled             1.678000e+03\n",
-              "DistanceKilometers    9.261629e+07\n",
-              "DistanceMiles         5.754909e+07\n",
-              "FlightDelay           3.280000e+03\n",
-              "FlightDelayMin        6.181500e+05\n",
-              "FlightTimeHour        1.112470e+05\n",
-              "FlightTimeMin         6.674818e+06\n",
-              "dayOfWeek             3.703500e+04\n",
-              "dtype: float64"
-            ]
-          },
-          "metadata": {},
-          "execution_count": 51
-        }
-      ],
-      "source": [
-        "pd_flights.sum(numeric_only=True)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 52,
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2021-12-15T20:24:55.906057Z",
-          "iopub.status.busy": "2021-12-15T20:24:55.904964Z",
-          "iopub.status.idle": "2021-12-15T20:24:55.997011Z",
-          "shell.execute_reply": "2021-12-15T20:24:55.997419Z"
-        },
-        "pycharm": {
-          "is_executing": false
-        },
-        "id": "ecX1LL0KNRFn",
-        "outputId": "c62cf351-aac2-430f-add7-d230063e349b",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        }
-      },
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "AvgTicketPrice        8.204365e+06\n",
-              "Cancelled             1.678000e+03\n",
-              "DistanceKilometers    9.261629e+07\n",
-              "DistanceMiles         5.754909e+07\n",
-              "FlightDelay           3.280000e+03\n",
-              "FlightDelayMin        6.181500e+05\n",
-              "FlightTimeHour        1.112470e+05\n",
-              "FlightTimeMin         6.674818e+06\n",
-              "dayOfWeek             3.703500e+04\n",
-              "dtype: float64"
-            ]
-          },
-          "metadata": {},
-          "execution_count": 52
-        }
-      ],
-      "source": [
-        "ed_flights.sum(numeric_only=True)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "BPd8ae8SNRFn"
-      },
-      "source": [
-        "### DataFrame.nunique"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 53,
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2021-12-15T20:24:56.003863Z",
-          "iopub.status.busy": "2021-12-15T20:24:56.003311Z",
-          "iopub.status.idle": "2021-12-15T20:24:56.012352Z",
-          "shell.execute_reply": "2021-12-15T20:24:56.012798Z"
-        },
-        "pycharm": {
-          "is_executing": false
-        },
-        "id": "H0_EAT-jNRFn",
-        "outputId": "96a51dc9-1fbf-4c42-9370-de2e8c479759",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        }
-      },
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "Carrier      4\n",
-              "Origin     156\n",
-              "Dest       156\n",
-              "dtype: int64"
-            ]
-          },
-          "metadata": {},
-          "execution_count": 53
-        }
-      ],
-      "source": [
-        "pd_flights[['Carrier', 'Origin', 'Dest']].nunique()"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 54,
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2021-12-15T20:24:56.018633Z",
-          "iopub.status.busy": "2021-12-15T20:24:56.018038Z",
-          "iopub.status.idle": "2021-12-15T20:24:56.109194Z",
-          "shell.execute_reply": "2021-12-15T20:24:56.108015Z"
-        },
-        "pycharm": {
-          "is_executing": false
-        },
-        "id": "J7Y3r7BRNRFn",
-        "outputId": "14ebfc9d-d8ff-4eb4-b7af-f860498d112d",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        }
-      },
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "Carrier      4\n",
-              "Origin     156\n",
-              "Dest       156\n",
-              "dtype: int64"
-            ]
-          },
-          "metadata": {},
-          "execution_count": 54
-        }
-      ],
-      "source": [
-        "ed_flights[['Carrier', 'Origin', 'Dest']].nunique()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "OpLeL6gpNRFo"
-      },
-      "source": [
-        "### DataFrame.drop"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 55,
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2021-12-15T20:24:56.124377Z",
-          "iopub.status.busy": "2021-12-15T20:24:56.123206Z",
-          "iopub.status.idle": "2021-12-15T20:24:56.145226Z",
-          "shell.execute_reply": "2021-12-15T20:24:56.145628Z"
-        },
-        "pycharm": {
-          "is_executing": false
-        },
-        "id": "xkGjF6p8NRFo",
-        "outputId": "497cebfc-ee66-47a4-8d68-718f930be023",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 424
-        }
-      },
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "                Carrier DestRegion  ... dayOfWeek           timestamp\n",
-              "0       Kibana Airlines      SE-BD  ...         0 2018-01-01 00:00:00\n",
-              "1      Logstash Airways      IT-34  ...         0 2018-01-01 18:27:00\n",
-              "2      Logstash Airways      IT-34  ...         0 2018-01-01 17:11:14\n",
-              "3       Kibana Airlines      IT-34  ...         0 2018-01-01 10:33:28\n",
-              "4       Kibana Airlines      SE-BD  ...         0 2018-01-01 05:13:00\n",
-              "...                 ...        ...  ...       ...                 ...\n",
-              "13054  Logstash Airways      SE-BD  ...         6 2018-02-11 20:42:25\n",
-              "13055  Logstash Airways      CH-ZH  ...         6 2018-02-11 01:41:57\n",
-              "13056  Logstash Airways     RU-AMU  ...         6 2018-02-11 04:09:27\n",
-              "13057          JetBeats      SE-BD  ...         6 2018-02-11 08:28:21\n",
-              "13058          JetBeats      US-DC  ...         6 2018-02-11 14:54:34\n",
-              "\n",
-              "[13059 rows x 20 columns]"
-            ],
-            "text/html": [
-              "\n",
-              "  <div id=\"df-0a24b0af-65db-4f81-bffa-efebaf3eef89\" class=\"colab-df-container\">\n",
-              "    <div>\n",
-              "<style scoped>\n",
-              "    .dataframe tbody tr th:only-of-type {\n",
-              "        vertical-align: middle;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe tbody tr th {\n",
-              "        vertical-align: top;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe thead th {\n",
-              "        text-align: right;\n",
-              "    }\n",
-              "</style>\n",
-              "<table border=\"1\" class=\"dataframe\">\n",
-              "  <thead>\n",
-              "    <tr style=\"text-align: right;\">\n",
-              "      <th></th>\n",
-              "      <th>Carrier</th>\n",
-              "      <th>DestRegion</th>\n",
-              "      <th>...</th>\n",
-              "      <th>dayOfWeek</th>\n",
-              "      <th>timestamp</th>\n",
-              "    </tr>\n",
-              "  </thead>\n",
-              "  <tbody>\n",
-              "    <tr>\n",
-              "      <th>0</th>\n",
-              "      <td>Kibana Airlines</td>\n",
-              "      <td>SE-BD</td>\n",
-              "      <td>...</td>\n",
-              "      <td>0</td>\n",
-              "      <td>2018-01-01 00:00:00</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>1</th>\n",
-              "      <td>Logstash Airways</td>\n",
-              "      <td>IT-34</td>\n",
-              "      <td>...</td>\n",
-              "      <td>0</td>\n",
-              "      <td>2018-01-01 18:27:00</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>2</th>\n",
-              "      <td>Logstash Airways</td>\n",
-              "      <td>IT-34</td>\n",
-              "      <td>...</td>\n",
-              "      <td>0</td>\n",
-              "      <td>2018-01-01 17:11:14</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>3</th>\n",
-              "      <td>Kibana Airlines</td>\n",
-              "      <td>IT-34</td>\n",
-              "      <td>...</td>\n",
-              "      <td>0</td>\n",
-              "      <td>2018-01-01 10:33:28</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>4</th>\n",
-              "      <td>Kibana Airlines</td>\n",
-              "      <td>SE-BD</td>\n",
-              "      <td>...</td>\n",
-              "      <td>0</td>\n",
-              "      <td>2018-01-01 05:13:00</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>...</th>\n",
-              "      <td>...</td>\n",
-              "      <td>...</td>\n",
-              "      <td>...</td>\n",
-              "      <td>...</td>\n",
-              "      <td>...</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>13054</th>\n",
-              "      <td>Logstash Airways</td>\n",
-              "      <td>SE-BD</td>\n",
-              "      <td>...</td>\n",
-              "      <td>6</td>\n",
-              "      <td>2018-02-11 20:42:25</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>13055</th>\n",
-              "      <td>Logstash Airways</td>\n",
-              "      <td>CH-ZH</td>\n",
-              "      <td>...</td>\n",
-              "      <td>6</td>\n",
-              "      <td>2018-02-11 01:41:57</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>13056</th>\n",
-              "      <td>Logstash Airways</td>\n",
-              "      <td>RU-AMU</td>\n",
-              "      <td>...</td>\n",
-              "      <td>6</td>\n",
-              "      <td>2018-02-11 04:09:27</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>13057</th>\n",
-              "      <td>JetBeats</td>\n",
-              "      <td>SE-BD</td>\n",
-              "      <td>...</td>\n",
-              "      <td>6</td>\n",
-              "      <td>2018-02-11 08:28:21</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>13058</th>\n",
-              "      <td>JetBeats</td>\n",
-              "      <td>US-DC</td>\n",
-              "      <td>...</td>\n",
-              "      <td>6</td>\n",
-              "      <td>2018-02-11 14:54:34</td>\n",
-              "    </tr>\n",
-              "  </tbody>\n",
-              "</table>\n",
-              "<p>13059 rows × 20 columns</p>\n",
-              "</div>\n",
-              "    <div class=\"colab-df-buttons\">\n",
-              "\n",
-              "  <div class=\"colab-df-container\">\n",
-              "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-0a24b0af-65db-4f81-bffa-efebaf3eef89')\"\n",
-              "            title=\"Convert this dataframe to an interactive table.\"\n",
-              "            style=\"display:none;\">\n",
-              "\n",
-              "  <svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\" viewBox=\"0 -960 960 960\">\n",
-              "    <path d=\"M120-120v-720h720v720H120Zm60-500h600v-160H180v160Zm220 220h160v-160H400v160Zm0 220h160v-160H400v160ZM180-400h160v-160H180v160Zm440 0h160v-160H620v160ZM180-180h160v-160H180v160Zm440 0h160v-160H620v160Z\"/>\n",
-              "  </svg>\n",
-              "    </button>\n",
-              "\n",
-              "  <style>\n",
-              "    .colab-df-container {\n",
-              "      display:flex;\n",
-              "      gap: 12px;\n",
-              "    }\n",
-              "\n",
-              "    .colab-df-convert {\n",
-              "      background-color: #E8F0FE;\n",
-              "      border: none;\n",
-              "      border-radius: 50%;\n",
-              "      cursor: pointer;\n",
-              "      display: none;\n",
-              "      fill: #1967D2;\n",
-              "      height: 32px;\n",
-              "      padding: 0 0 0 0;\n",
-              "      width: 32px;\n",
-              "    }\n",
-              "\n",
-              "    .colab-df-convert:hover {\n",
-              "      background-color: #E2EBFA;\n",
-              "      box-shadow: 0px 1px 2px rgba(60, 64, 67, 0.3), 0px 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
-              "      fill: #174EA6;\n",
-              "    }\n",
-              "\n",
-              "    .colab-df-buttons div {\n",
-              "      margin-bottom: 4px;\n",
-              "    }\n",
-              "\n",
-              "    [theme=dark] .colab-df-convert {\n",
-              "      background-color: #3B4455;\n",
-              "      fill: #D2E3FC;\n",
-              "    }\n",
-              "\n",
-              "    [theme=dark] .colab-df-convert:hover {\n",
-              "      background-color: #434B5C;\n",
-              "      box-shadow: 0px 1px 3px 1px rgba(0, 0, 0, 0.15);\n",
-              "      filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.3));\n",
-              "      fill: #FFFFFF;\n",
-              "    }\n",
-              "  </style>\n",
-              "\n",
-              "    <script>\n",
-              "      const buttonEl =\n",
-              "        document.querySelector('#df-0a24b0af-65db-4f81-bffa-efebaf3eef89 button.colab-df-convert');\n",
-              "      buttonEl.style.display =\n",
-              "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
-              "\n",
-              "      async function convertToInteractive(key) {\n",
-              "        const element = document.querySelector('#df-0a24b0af-65db-4f81-bffa-efebaf3eef89');\n",
-              "        const dataTable =\n",
-              "          await google.colab.kernel.invokeFunction('convertToInteractive',\n",
-              "                                                    [key], {});\n",
-              "        if (!dataTable) return;\n",
-              "\n",
-              "        const docLinkHtml = 'Like what you see? Visit the ' +\n",
-              "          '<a target=\"_blank\" href=https://colab.research.google.com/notebooks/data_table.ipynb>data table notebook</a>'\n",
-              "          + ' to learn more about interactive tables.';\n",
-              "        element.innerHTML = '';\n",
-              "        dataTable['output_type'] = 'display_data';\n",
-              "        await google.colab.output.renderOutput(dataTable, element);\n",
-              "        const docLink = document.createElement('div');\n",
-              "        docLink.innerHTML = docLinkHtml;\n",
-              "        element.appendChild(docLink);\n",
-              "      }\n",
-              "    </script>\n",
-              "  </div>\n",
-              "\n",
-              "\n",
-              "<div id=\"df-d8914f66-8357-4e5d-a145-b37879cd1b07\">\n",
-              "  <button class=\"colab-df-quickchart\" onclick=\"quickchart('df-d8914f66-8357-4e5d-a145-b37879cd1b07')\"\n",
-              "            title=\"Suggest charts.\"\n",
-              "            style=\"display:none;\">\n",
-              "\n",
-              "<svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\"viewBox=\"0 0 24 24\"\n",
-              "     width=\"24px\">\n",
-              "    <g>\n",
-              "        <path d=\"M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zM9 17H7v-7h2v7zm4 0h-2V7h2v10zm4 0h-2v-4h2v4z\"/>\n",
-              "    </g>\n",
-              "</svg>\n",
-              "  </button>\n",
-              "\n",
-              "<style>\n",
-              "  .colab-df-quickchart {\n",
-              "      --bg-color: #E8F0FE;\n",
-              "      --fill-color: #1967D2;\n",
-              "      --hover-bg-color: #E2EBFA;\n",
-              "      --hover-fill-color: #174EA6;\n",
-              "      --disabled-fill-color: #AAA;\n",
-              "      --disabled-bg-color: #DDD;\n",
-              "  }\n",
-              "\n",
-              "  [theme=dark] .colab-df-quickchart {\n",
-              "      --bg-color: #3B4455;\n",
-              "      --fill-color: #D2E3FC;\n",
-              "      --hover-bg-color: #434B5C;\n",
-              "      --hover-fill-color: #FFFFFF;\n",
-              "      --disabled-bg-color: #3B4455;\n",
-              "      --disabled-fill-color: #666;\n",
-              "  }\n",
-              "\n",
-              "  .colab-df-quickchart {\n",
-              "    background-color: var(--bg-color);\n",
-              "    border: none;\n",
-              "    border-radius: 50%;\n",
-              "    cursor: pointer;\n",
-              "    display: none;\n",
-              "    fill: var(--fill-color);\n",
-              "    height: 32px;\n",
-              "    padding: 0;\n",
-              "    width: 32px;\n",
-              "  }\n",
-              "\n",
-              "  .colab-df-quickchart:hover {\n",
-              "    background-color: var(--hover-bg-color);\n",
-              "    box-shadow: 0 1px 2px rgba(60, 64, 67, 0.3), 0 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
-              "    fill: var(--button-hover-fill-color);\n",
-              "  }\n",
-              "\n",
-              "  .colab-df-quickchart-complete:disabled,\n",
-              "  .colab-df-quickchart-complete:disabled:hover {\n",
-              "    background-color: var(--disabled-bg-color);\n",
-              "    fill: var(--disabled-fill-color);\n",
-              "    box-shadow: none;\n",
-              "  }\n",
-              "\n",
-              "  .colab-df-spinner {\n",
-              "    border: 2px solid var(--fill-color);\n",
-              "    border-color: transparent;\n",
-              "    border-bottom-color: var(--fill-color);\n",
-              "    animation:\n",
-              "      spin 1s steps(1) infinite;\n",
-              "  }\n",
-              "\n",
-              "  @keyframes spin {\n",
-              "    0% {\n",
-              "      border-color: transparent;\n",
-              "      border-bottom-color: var(--fill-color);\n",
-              "      border-left-color: var(--fill-color);\n",
-              "    }\n",
-              "    20% {\n",
-              "      border-color: transparent;\n",
-              "      border-left-color: var(--fill-color);\n",
-              "      border-top-color: var(--fill-color);\n",
-              "    }\n",
-              "    30% {\n",
-              "      border-color: transparent;\n",
-              "      border-left-color: var(--fill-color);\n",
-              "      border-top-color: var(--fill-color);\n",
-              "      border-right-color: var(--fill-color);\n",
-              "    }\n",
-              "    40% {\n",
-              "      border-color: transparent;\n",
-              "      border-right-color: var(--fill-color);\n",
-              "      border-top-color: var(--fill-color);\n",
-              "    }\n",
-              "    60% {\n",
-              "      border-color: transparent;\n",
-              "      border-right-color: var(--fill-color);\n",
-              "    }\n",
-              "    80% {\n",
-              "      border-color: transparent;\n",
-              "      border-right-color: var(--fill-color);\n",
-              "      border-bottom-color: var(--fill-color);\n",
-              "    }\n",
-              "    90% {\n",
-              "      border-color: transparent;\n",
-              "      border-bottom-color: var(--fill-color);\n",
-              "    }\n",
-              "  }\n",
-              "</style>\n",
-              "\n",
-              "  <script>\n",
-              "    async function quickchart(key) {\n",
-              "      const quickchartButtonEl =\n",
-              "        document.querySelector('#' + key + ' button');\n",
-              "      quickchartButtonEl.disabled = true;  // To prevent multiple clicks.\n",
-              "      quickchartButtonEl.classList.add('colab-df-spinner');\n",
-              "      try {\n",
-              "        const charts = await google.colab.kernel.invokeFunction(\n",
-              "            'suggestCharts', [key], {});\n",
-              "      } catch (error) {\n",
-              "        console.error('Error during call to suggestCharts:', error);\n",
-              "      }\n",
-              "      quickchartButtonEl.classList.remove('colab-df-spinner');\n",
-              "      quickchartButtonEl.classList.add('colab-df-quickchart-complete');\n",
-              "    }\n",
-              "    (() => {\n",
-              "      let quickchartButtonEl =\n",
-              "        document.querySelector('#df-d8914f66-8357-4e5d-a145-b37879cd1b07 button');\n",
-              "      quickchartButtonEl.style.display =\n",
-              "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
-              "    })();\n",
-              "  </script>\n",
-              "</div>\n",
-              "    </div>\n",
-              "  </div>\n"
-            ]
-          },
-          "metadata": {},
-          "execution_count": 55
-        }
-      ],
-      "source": [
-        "pd_flights.drop(columns=['AvgTicketPrice',\n",
-        "                         'Cancelled',\n",
-        "                         'DestLocation',\n",
-        "                         'Dest',\n",
-        "                         'DestAirportID',\n",
-        "                         'DestCityName',\n",
-        "                         'DestCountry'])"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 56,
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2021-12-15T20:24:56.151182Z",
-          "iopub.status.busy": "2021-12-15T20:24:56.150754Z",
-          "iopub.status.idle": "2021-12-15T20:25:00.584497Z",
-          "shell.execute_reply": "2021-12-15T20:25:00.583176Z"
-        },
-        "pycharm": {
-          "is_executing": false
-        },
-        "id": "dXLW2KyXNRFo",
-        "outputId": "ce268419-2c97-47bd-ed02-c1e10f110927",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 424
-        }
-      },
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "                Carrier DestRegion  ... dayOfWeek           timestamp\n",
-              "0       Kibana Airlines      SE-BD  ...         0 2018-01-01 00:00:00\n",
-              "1      Logstash Airways      IT-34  ...         0 2018-01-01 18:27:00\n",
-              "2      Logstash Airways      IT-34  ...         0 2018-01-01 17:11:14\n",
-              "3       Kibana Airlines      IT-34  ...         0 2018-01-01 10:33:28\n",
-              "4       Kibana Airlines      SE-BD  ...         0 2018-01-01 05:13:00\n",
-              "...                 ...        ...  ...       ...                 ...\n",
-              "13054  Logstash Airways      SE-BD  ...         6 2018-02-11 20:42:25\n",
-              "13055  Logstash Airways      CH-ZH  ...         6 2018-02-11 01:41:57\n",
-              "13056  Logstash Airways     RU-AMU  ...         6 2018-02-11 04:09:27\n",
-              "13057          JetBeats      SE-BD  ...         6 2018-02-11 08:28:21\n",
-              "13058          JetBeats      US-DC  ...         6 2018-02-11 14:54:34\n",
-              "\n",
-              "[13059 rows x 20 columns]"
-            ],
-            "text/html": [
-              "<div>\n",
-              "<style scoped>\n",
-              "    .dataframe tbody tr th:only-of-type {\n",
-              "        vertical-align: middle;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe tbody tr th {\n",
-              "        vertical-align: top;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe thead th {\n",
-              "        text-align: right;\n",
-              "    }\n",
-              "</style>\n",
-              "<table border=\"1\" class=\"dataframe\">\n",
-              "  <thead>\n",
-              "    <tr style=\"text-align: right;\">\n",
-              "      <th></th>\n",
-              "      <th>Carrier</th>\n",
-              "      <th>DestRegion</th>\n",
-              "      <th>...</th>\n",
-              "      <th>dayOfWeek</th>\n",
-              "      <th>timestamp</th>\n",
-              "    </tr>\n",
-              "  </thead>\n",
-              "  <tbody>\n",
-              "    <tr>\n",
-              "      <th>0</th>\n",
-              "      <td>Kibana Airlines</td>\n",
-              "      <td>SE-BD</td>\n",
-              "      <td>...</td>\n",
-              "      <td>0</td>\n",
-              "      <td>2018-01-01 00:00:00</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>1</th>\n",
-              "      <td>Logstash Airways</td>\n",
-              "      <td>IT-34</td>\n",
-              "      <td>...</td>\n",
-              "      <td>0</td>\n",
-              "      <td>2018-01-01 18:27:00</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>2</th>\n",
-              "      <td>Logstash Airways</td>\n",
-              "      <td>IT-34</td>\n",
-              "      <td>...</td>\n",
-              "      <td>0</td>\n",
-              "      <td>2018-01-01 17:11:14</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>3</th>\n",
-              "      <td>Kibana Airlines</td>\n",
-              "      <td>IT-34</td>\n",
-              "      <td>...</td>\n",
-              "      <td>0</td>\n",
-              "      <td>2018-01-01 10:33:28</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>4</th>\n",
-              "      <td>Kibana Airlines</td>\n",
-              "      <td>SE-BD</td>\n",
-              "      <td>...</td>\n",
-              "      <td>0</td>\n",
-              "      <td>2018-01-01 05:13:00</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>...</th>\n",
-              "      <td>...</td>\n",
-              "      <td>...</td>\n",
-              "      <td>...</td>\n",
-              "      <td>...</td>\n",
-              "      <td>...</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>13054</th>\n",
-              "      <td>Logstash Airways</td>\n",
-              "      <td>SE-BD</td>\n",
-              "      <td>...</td>\n",
-              "      <td>6</td>\n",
-              "      <td>2018-02-11 20:42:25</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>13055</th>\n",
-              "      <td>Logstash Airways</td>\n",
-              "      <td>CH-ZH</td>\n",
-              "      <td>...</td>\n",
-              "      <td>6</td>\n",
-              "      <td>2018-02-11 01:41:57</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>13056</th>\n",
-              "      <td>Logstash Airways</td>\n",
-              "      <td>RU-AMU</td>\n",
-              "      <td>...</td>\n",
-              "      <td>6</td>\n",
-              "      <td>2018-02-11 04:09:27</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>13057</th>\n",
-              "      <td>JetBeats</td>\n",
-              "      <td>SE-BD</td>\n",
-              "      <td>...</td>\n",
-              "      <td>6</td>\n",
-              "      <td>2018-02-11 08:28:21</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>13058</th>\n",
-              "      <td>JetBeats</td>\n",
-              "      <td>US-DC</td>\n",
-              "      <td>...</td>\n",
-              "      <td>6</td>\n",
-              "      <td>2018-02-11 14:54:34</td>\n",
-              "    </tr>\n",
-              "  </tbody>\n",
-              "</table>\n",
-              "</div>\n",
-              "<p>13059 rows × 20 columns</p>"
-            ]
-          },
-          "metadata": {},
-          "execution_count": 56
-        }
-      ],
-      "source": [
-        "ed_flights.drop(columns=['AvgTicketPrice',\n",
-        "                         'Cancelled',\n",
-        "                         'DestLocation',\n",
-        "                         'Dest',\n",
-        "                         'DestAirportID',\n",
-        "                         'DestCityName',\n",
-        "                         'DestCountry'])"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "g79LTpPBNRFp"
-      },
-      "source": [
-        "### Plotting"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 57,
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2021-12-15T20:25:00.608502Z",
-          "iopub.status.busy": "2021-12-15T20:25:00.607311Z",
-          "iopub.status.idle": "2021-12-15T20:25:01.255494Z",
-          "shell.execute_reply": "2021-12-15T20:25:01.255790Z"
-        },
-        "pycharm": {
-          "is_executing": false
-        },
-        "id": "0NVvSP02NRFp",
-        "outputId": "947711b0-4ed4-41ab-ca40-ca9d92ae703d",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 853
-        }
-      },
-      "outputs": [
-        {
-          "output_type": "display_data",
-          "data": {
-            "text/plain": [
-              "<Figure size 1000x1000 with 9 Axes>"
-            ],
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAA1AAAANECAYAAAC+XM68AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjcuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/bCgiHAAAACXBIWXMAAA9hAAAPYQGoP6dpAADRcElEQVR4nOzdeVhUdfs/8PeAzLDogKiAJCJiqSguoSK5ZIogkmlahppibmlQj/qkZrkAVqjlnsvTU0kL5FJmpqaMC664kaSimZrLUwnmAriOI/P5/eFvzteRxQPOCu/XdXnVnPOZc+77zMzN3HM2hRBCgIiIiIiIiB7JwdoBEBERERER2Qs2UERERERERDKxgSIiIiIiIpKJDRQREREREZFMbKCIiIiIiIhkYgNFREREREQkExsoIiIiIiIimdhAERERERERycQGioiIiIiISCY2UGRWDRo0wNChQ8v1nIyMDCgUCnz33XfmCcqEEhISoFAorB0GUYXw/Vu6Ll26oEuXLtLjc+fOQaFQICUlxWoxEdF9rF3yGL5PZWRkSNOGDh2KBg0aWC2myoINVCWyZMkSKBQKhIaGmm0dhg+jnH+2YsmSJSV+6Xk4FycnJzRs2BBDhgzBH3/8YflAiR5TSkqK0Xva2dkZvr6+iIyMxMKFC3H9+vXHXsfff/+NhIQEZGdnP37AFjZ06FBUr1692PQjR46gdu3aaNCgAc6dO2f5wEzoww8/xNq1a60dBlG5sHaVbejQoVAoFFCr1bh9+3ax+adOnZK23ccff2yFCKueatYOgEwnNTUVDRo0wIEDB3D69Gk0atTI5Oto2rQpvv76a6NpkydPRvXq1fHee+8VG3/y5Ek4OFi3T1+yZAlq165d6p6wt956C23btoVOp8Mvv/yCTz/9FBs2bMDRo0fh6+tb5rKnTJmCd955xwxRE1VcUlISAgICoNPpkJubi4yMDIwdOxZz587FunXr0KJFCwAVe//+/fffSExMRIMGDdCqVSszRG9Zx44dQ7du3eDm5obt27dLv8ymp6dbN7AK+vDDD/HSSy+hT58+1g6FqNxYu0pXrVo13Lp1Cz/99BP69+9vNC81NRXOzs64c+eO0fTOnTvj9u3bUCqVlgy1SmADVUmcPXsWe/fuxZo1a/D6668jNTUV06dPN/l6vL298eqrrxpNmzlzJmrXrl1sOgCoVCqTx2BqnTp1wksvvQQAeO211/DUU0/hrbfewpdffonJkyeX+JybN2/Czc0N1apVQ7Vq/BiRbYmKikKbNm2kx5MnT8a2bdvw/PPP44UXXsCJEyfg4uJS5d+/OTk56Nq1K1xcXLB9+3YEBARI8/iF4//cuXMHSqXS6j+GUeXH2lU6lUqFDh064Ntvvy3WQKWlpSE6Ohrff/+90XQHBwc4OztbMswqg9WwkkhNTUXNmjURHR2Nl156CampqQAAnU4HT09PvPbaa8WeU1hYCGdnZ7z99tvStPPnz+OFF16Am5sbvLy8MG7cOGzevLnYMbRylXQOVH5+PsaNG4cGDRpApVKhXr16GDJkCC5fvlzqcrRaLZ5//nm4u7tj7969AAC9Xo/58+ejWbNmcHZ2hre3N15//XVcu3bNaP05OTnYsWOHtHv7wfMaStK1a1cA95tS4P+OtT5+/DgGDhyImjVromPHjkbzHvbNN9+gXbt2cHV1Rc2aNdG5c+div2j//PPP6NSpE9zc3FCjRg1ER0cjJyenzNiIKqpr166YOnUqzp8/j2+++QZAye9fjUaDjh07wsPDA9WrV0fjxo3x7rvvArh/2Gvbtm0B3P+xwfCZMhwiu2vXLrz88suoX78+VCoV/Pz8MG7cuGKHnBgOpfvrr7/Qp08fVK9eHXXq1MHbb7+NoqIio7F6vR4LFixAcHAwnJ2dUadOHfTo0QOHDh0yGvfNN98gJCQELi4u8PT0RExMDP73v/+Vuj1OnDiBbt26QaVSYfv27WjYsKHR/IfPgSrNtm3bpM+xh4cHevfujRMnThiNMWzn33//Ha+++irc3d1Rp04dTJ06FUII/O9//0Pv3r2hVqvh4+ODOXPmFFuPVqvF9OnT0ahRI2nbTpw4EVqtVhqjUChw8+ZNfPnll9Jr82D9/euvvzBs2DB4e3tDpVKhWbNm+OKLL4zWYzi0ecWKFZgyZQqeeOIJuLq6orCwEDqdDomJiXjyySfh7OyMWrVqoWPHjtBoNI/cTkQVxdr1fwYOHIiff/4Z+fn50rSDBw/i1KlTGDhwYLHxJZ0DVRI536cA4NChQ4iMjETt2rXh4uKCgIAADBs2rMxlV1ZVq32vxFJTU9G3b18olUoMGDAAS5cuxcGDB9G2bVu8+OKLWLNmDf7zn/8Y/aq6du1aaLVaxMTEALi/V6Vr1664ePEi/vWvf8HHxwdpaWnYvn27yeK8ceMGOnXqhBMnTmDYsGF4+umncfnyZaxbtw5//vknateuXew5t2/fRu/evXHo0CFs2bJFKoKvv/46UlJS8Nprr+Gtt97C2bNn8cknn+Dw4cPYs2cPnJycMH/+fLz55ptGhxh6e3uXGeOZM2cAALVq1TKa/vLLL+PJJ5/Ehx9+CCFEqc9PTExEQkICnnnmGSQlJUGpVGL//v3Ytm0bIiIiAABff/01YmNjERkZiVmzZuHWrVtYunQpOnbsiMOHD/METzKLwYMH491330V6ejpGjhxZbH5OTg6ef/55tGjRAklJSVCpVDh9+jT27NkD4P4hvElJSZg2bRpGjRqFTp06AQCeeeYZAMDq1atx69YtjBkzBrVq1cKBAwewaNEi/Pnnn1i9erXRuoqKihAZGYnQ0FB8/PHH2LJlC+bMmYPAwECMGTNGGjd8+HCkpKQgKioKI0aMwL1797Br1y7s27dP+qX6gw8+wNSpU9G/f3+MGDEC//zzDxYtWoTOnTvj8OHD8PDwMFr3yZMn0bVrV1SrVg3bt29HYGBghbbnli1bEBUVhYYNGyIhIQG3b9/GokWL0KFDB/zyyy/FPsevvPIKmjZtipkzZ2LDhg14//334enpif/85z/o2rUrZs2ahdTUVLz99tto27YtOnfuDOD+l5sXXngBu3fvxqhRo9C0aVMcPXoU8+bNw++//y6d8/T1119jxIgRaNeuHUaNGgUAUm55eXlo3749FAoF4uPjUadOHfz8888YPnw4CgsLMXbsWKNYZ8yYAaVSibfffhtarRZKpRIJCQlITk6W1lFYWIhDhw7hl19+Qffu3Su0DYnkYO26r2/fvhg9ejTWrFkjNS5paWlo0qQJnn766QpvXznfpy5duoSIiAjUqVMH77zzDjw8PHDu3DmsWbOmwuu1a4Ls3qFDhwQAodFohBBC6PV6Ua9ePfGvf/1LCCHE5s2bBQDx008/GT2vZ8+eomHDhtLjOXPmCABi7dq10rTbt2+LJk2aCABi+/btJa6/WbNm4tlnny1xnr+/v4iNjZUeT5s2TQAQa9asKTZWr9cLIYTYvn27ACBWr14trl+/Lp599llRu3ZtcfjwYWnsrl27BACRmppqtIxNmzYVm15afIb1fPHFF+Kff/4Rf//9t9iwYYNo0KCBUCgU4uDBg0IIIaZPny4AiAEDBhRbhmGewalTp4SDg4N48cUXRVFRUYn5Xb9+XXh4eIiRI0cazc/NzRXu7u7FphPJtXz5cgFAeu+WxN3dXbRu3VoIUfz9O2/ePAFA/PPPP6U+/+DBgwKAWL58ebF5t27dKjYtOTlZKBQKcf78eWlabGysACCSkpKMxrZu3VqEhIRIj7dt2yYAiLfeeqvYcg2fp3PnzglHR0fxwQcfGM0/evSoqFatmtH02NhY4eTkJOrWrSt8fX3F77//Xmqezz77rFHdOHv2bLG8W7VqJby8vMSVK1ekab/++qtwcHAQQ4YMkaYZtvOoUaOkaffu3RP16tUTCoVCzJw5U5p+7do14eLiYlQ3v/76a+Hg4CB27dplFOOyZcsEALFnzx5pmpubm9FzDYYPHy7q1q0rLl++bDQ9JiZGuLu7S6+doS42bNiw2OvZsmVLER0dXcLWIno8rF3/p7Ta5ebmJoQQ4qWXXhLdunUTQghRVFQkfHx8RGJiolSjPvroI+l5hs/zg9/fYmNjhb+/v/RY7vepH3744ZGvUVXCQ/gqgdTUVHh7e+O5554DcP8wjldeeQUrVqxAUVERunbtitq1a2PlypXSc65duwaNRoNXXnlFmrZp0yY88cQTeOGFF6Rpzs7OJf7aU1Hff/89WrZsiRdffLHYvId3xxcUFCAiIgK//fYbMjIyjE76XL16Ndzd3dG9e3dcvnxZ+hcSEoLq1auXa6/ZsGHDUKdOHfj6+iI6Olo6BObB47ABYPTo0Y9c1tq1a6HX6zFt2rRi5wsY8tNoNMjPz8eAAQOMYnd0dERoaKhJ9/gRPax69eqlXtHK8Gvnjz/+CL1eX+5lu7i4SP9/8+ZNXL58Gc888wyEEDh8+HCx8Q9/pjp16mR0Bczvv/8eCoWixPM5DZ+nNWvWQK/Xo3///kafJx8fHzz55JPFPk9FRUW4fPkyPD09S9zjLdfFixeRnZ2NoUOHwtPTU5reokULdO/eHRs3biz2nBEjRkj/7+joiDZt2kAIgeHDh0vTPTw80LhxY6PtsHr1ajRt2hRNmjQxytFwuPGjaoYQAt9//z169eoFIYTRMiIjI1FQUIBffvnF6DmxsbFGr6chtpycHJw6dUrGFiIyrapeuwwGDhyIjIwM5ObmYtu2bcjNzS3x8D255H6fMmzj9evXQ6fTVXh9lQUP4bNzRUVFWLFiBZ577jnpnB0ACA0NxZw5c7B161ZERESgX79+SEtLg1arhUqlwpo1a6DT6YwaqPPnzyMwMLBYI2PKq/mdOXMG/fr1kzV27NixuHPnDg4fPoxmzZoZzTt16hQKCgrg5eVV4nMvXbokO6Zp06ahU6dOcHR0RO3atdG0adMST0598ATz0pw5cwYODg4ICgoqdYzhy4fhy8/D1Gq1zMiJyu/GjRulfm5eeeUVfPbZZxgxYgTeeecddOvWDX379sVLL70k6wICFy5cwLRp07Bu3bpix84XFBQYPTacE/CgmjVrGj3vzJkz8PX1NWpQHnbq1CkIIfDkk0+WON/JycnosYuLCz777DMMGjQI0dHR0Gg0cHNze2RuDzt//jwAoHHjxsXmNW3aFJs3b5YuNmNQv359o3Hu7u5wdnYu1si5u7vjypUr0uNTp07hxIkTxbaXwaPq3T///IP8/Hx8+umn+PTTT2Uto6R6l5SUhN69e+Opp55C8+bN0aNHDwwePFi6MhqROVX12mXQs2dP1KhRAytXrkR2djbatm2LRo0aVfgWDHK/Tz377LPo168fEhMTMW/ePHTp0gV9+vTBwIED7eKCYabGBsrObdu2DRcvXsSKFSuwYsWKYvNTU1MRERGBmJgY/Oc//8HPP/+MPn36YNWqVWjSpAlatmxphajl6d27N1asWIGZM2fiq6++MiqCer0eXl5e0sUyHlbaF42SBAcHIzw8/JHjHv41tqIMv459/fXX8PHxKTa/ql1ZiCznzz//REFBQak/iri4uGDnzp3Yvn07NmzYgE2bNmHlypXo2rUr0tPT4ejoWOqyi4qK0L17d1y9ehWTJk1CkyZN4Obmhr/++gtDhw4t9qtwWcsqD71eD4VCgZ9//rnEZZZ036eYmBhcu3YNb7zxBvr27YuffvrJIlfdKym+0raDeOA8S71ej+DgYMydO7fEsX5+fmWu17DtX331VcTGxpY45uEmqKR617lzZ5w5cwY//vgj0tPT8dlnn2HevHlYtmyZ0d41IlNj7fo/KpUKffv2xZdffok//vgDCQkJjx2HnO9TCoUC3333Hfbt24effvoJmzdvxrBhwzBnzhzs27ev1HgrK35Ts3Opqanw8vLC4sWLi81bs2YNfvjhByxbtgydO3dG3bp1sXLlSnTs2BHbtm0rdt8mf39/HD9+HEIIo71Qp0+fNlm8gYGBOHbsmKyxffr0QUREBIYOHYoaNWpg6dKlRsvZsmULOnTo8MjGxpI39Q0MDIRer8fx48dLvc+E4aRuLy8vWY0bkakY7uEWGRlZ6hgHBwd069YN3bp1w9y5c/Hhhx/ivffew/bt2xEeHl7q5+no0aP4/fff8eWXX2LIkCHS9Me5QltgYCA2b96Mq1evlvpLbmBgIIQQCAgIwFNPPSV72WPGjMHVq1cxZcoUvPrqq1ixYkW5LtPt7+8P4P4FKR7222+/oXbt2hXas1WSwMBA/Prrr+jWrdsj61lJ8+vUqYMaNWqgqKjosWuO4aqur732Gm7cuIHOnTsjISGBDRSZFWuXsYEDB+KLL76Ag4ODdCGwx4lV7vcpAGjfvj3at2+PDz74AGlpaRg0aBBWrFhR5WoAz4GyY7dv38aaNWvw/PPP46WXXir2Lz4+HtevX8e6devg4OCAl156CT/99BO+/vpr3Lt3z+jwPeB+Yfrrr7+wbt06adqdO3fw3//+12Qx9+vXD7/++it++OGHYvNECVe2GzJkCBYuXIhly5Zh0qRJ0vT+/fujqKgIM2bMKPace/fuGV3i083NzeixOfXp0wcODg5ISkoq9quVIb/IyEio1Wp8+OGHJR5H/M8//1gkVqpatm3bhhkzZiAgIACDBg0qcczVq1eLTTP8EGC4XLahKXj4M2X4BfXBz7EQAgsWLKhwzP369YMQAomJicXmGdbTt29fODo6IjExsVgNEUIYHQr3sPfeew/jxo3D6tWr8frrr5crtrp166JVq1b48ssvjbbFsWPHkJ6ejp49e5ZreWXp378//vrrrxJr8e3bt3Hz5k3pcUn1ztHREf369cP3339f4g9YcmvOw9uyevXqaNSokdGl1IlMjbWruOeeew4zZszAJ598UuKRLOUh9/vUtWvXisX58DauSrgHyo6tW7cO169fN7row4Pat2+POnXqIDU1Fa+88gpeeeUVLFq0CNOnT0dwcDCaNm1qNP7111/HJ598ggEDBuBf//oX6tatK93dGjDNnpwJEybgu+++w8svv4xhw4YhJCQEV69exbp167Bs2bISDymMj49HYWEh3nvvPbi7u+Pdd9/Fs88+i9dffx3JycnIzs5GREQEnJyccOrUKaxevRoLFiyQbo4bEhKCpUuX4v3330ejRo3g5eVV6vlHj6tRo0Z47733MGPGDHTq1Al9+/aFSqXCwYMH4evri+TkZKjVaixduhSDBw/G008/jZiYGNSpUwcXLlzAhg0b0KFDB3zyySdmiY+qhp9//hm//fYb7t27h7y8PGzbtg0ajQb+/v5Yt25dqTdWTEpKws6dOxEdHQ1/f39cunQJS5YsQb169aR7nwUGBsLDwwPLli1DjRo14ObmhtDQUDRp0gSBgYF4++238ddff0GtVuP7778vdj5BeTz33HMYPHgwFi5ciFOnTqFHjx7Q6/XYtWsXnnvuOcTHxyMwMBDvv/8+Jk+ejHPnzqFPnz6oUaMGzp49ix9++AGjRo0yutfdw+bMmYNr167hs88+g6enJ2bNmiU7vo8++ghRUVEICwvD8OHDpcuYu7u7P/ZhNQ8aPHgwVq1ahdGjR2P79u3o0KEDioqK8Ntvv2HVqlXYvHmzdNGbkJAQbNmyBXPnzoWvry8CAgIQGhqKmTNnYvv27QgNDcXIkSMRFBSEq1ev4pdffsGWLVtK/AL6sKCgIHTp0gUhISHw9PTEoUOH8N133yE+Pt5kuVLVxtolr3Y5ODhgypQpFY7vQXK/T3355ZdYsmQJXnzxRQQGBuL69ev473//C7VabdIfjOyGpS73R6bXq1cv4ezsLG7evFnqmKFDhwonJydx+fJlodfrhZ+fnwAg3n///RLH//HHHyI6Olq4uLiIOnXqiH//+9/i+++/FwDEvn37SnxOeS5jLoQQV65cEfHx8eKJJ54QSqVS1KtXT8TGxkqX133wMuYPmjhxogAgPvnkE2nap59+KkJCQoSLi4uoUaOGCA4OFhMnThR///23NCY3N1dER0eLGjVqCABSrKWt52GGy6WWdHnUhy+lavDFF1+I1q1bC5VKJWrWrCmeffZZ6TLzBtu3bxeRkZHC3d1dODs7i8DAQDF06FBx6NChMuMhKo3hUsCGf0qlUvj4+Iju3buLBQsWiMLCQqPxD79/t27dKnr37i18fX2FUqkUvr6+YsCAAcUu9/3jjz+KoKAgUa1aNaPLAh8/flyEh4eL6tWri9q1a4uRI0eKX3/9tdilgx+8JG9Z8Qhx/3LfH330kWjSpIlQKpWiTp06IioqSmRlZRmN+/7770XHjh2Fm5ubcHNzE02aNBFxcXHi5MmTj1zvvXv3RJ8+fQQAkZycLISQdxlzIYTYsmWL6NChg3BxcRFqtVr06tVLHD9+vMS8Hq4hpcXz7LPPimbNmhlNu3v3rpg1a5Zo1qyZVFdCQkJEYmKiKCgokMb99ttvonPnzsLFxUUAMKq/eXl5Ii4uTvj5+QknJyfh4+MjunXrJj799FNpTFl18f333xft2rUTHh4ewsXFRTRp0kR88MEH4u7du8XGEpUHa1fFateDKnoZc4NHfZ/65ZdfxIABA0T9+vWFSqUSXl5e4vnnn6+y31kUQpRxR1AiAPPnz8e4cePw559/4oknnrB2OEREREREVsMGiozcvn3b6CTCO3fuoHXr1igqKsLvv/9uxciIiIiIiKyP50CRkb59+6J+/fpo1aoVCgoK8M033+C3334r9fKWRERERERVCRsoMhIZGYnPPvsMqampKCoqQlBQEFasWFHsin1ERERERFURD+EjIiIiIiKSifeBIiIiIiIikokNFBERERERkUxV+hwovV6Pv//+GzVq1DDJTWKJ6D4hBK5fvw5fX184OFS932lYW4jMh/WF9YXIXOTWlyrdQP3999/w8/OzdhhEldb//vc/1KtXz9phWBxrC5H5sb4Qkbk8qr5U6QaqRo0aAO5vJLVabeVoAJ1Oh/T0dERERMDJycna4chibzHbW7yA/cWs0+mwdu1ajBgxQvqMVTVya4u9vbYlqQw5AJUjj6qSQ2FhIfz8/FhfqkB9sRZuu8djz9tPbn2p0g2UYde3Wq22mQbK1dUVarXabt5w9hazvcUL2F/MhngBVNnDS+TWFnt7bUtSGXIAKkceVS0H1pfKX1+shdvu8VSG7feo+lL1Dh4mIru1dOlStGjRQvriEBYWhp9//lmaf+fOHcTFxaFWrVqoXr06+vXrh7y8PKNlXLhwAdHR0XB1dYWXlxcmTJiAe/fuGY3JyMjA008/DZVKhUaNGiElJcUS6RGRFbG+EJFcbKCIyG7Uq1cPM2fORFZWFg4dOoSuXbuid+/eyMnJAQCMGzcOP/30E1avXo0dO3bg77//Rt++faXnFxUVITo6Gnfv3sXevXvx5ZdfIiUlBdOmTZPGnD17FtHR0XjuueeQnZ2NsWPHYsSIEdi8ebPF8yUiy2F9ISK5qvQhfERkX3r16mX0+IMPPsDSpUuxb98+1KtXD59//jnS0tLQtWtXAMDy5cvRtGlT7Nu3D+3bt0d6ejqOHz+OLVu2wNvbG61atcKMGTMwadIkJCQkQKlUYtmyZQgICMCcOXMAAE2bNsXu3bsxb948REZGWjxnIrIM1hcikosNFBHZpaKiIqxevRo3b95EWFgYsrKyoNPpEB4eLo1p0qQJ6tevj8zMTLRv3x6ZmZkIDg6Gt7e3NCYyMhJjxoxBTk4OWrdujczMTKNlGMaMHTu21Fi0Wi20Wq30uLCwEMD948B1Ol2pzzPMK2uMrasMOQCVI4+qkoMl8mN9qdq47R6PPW8/uTGzgSIiu3L06FGEhYXhzp07qF69On744QcEBQUhOzsbSqUSHh4eRuO9vb2Rm5sLAMjNzTX6cmOYb5hX1pjCwkLcvn0bLi4uxWJKTk5GYmJisenp6enSBTXKotFoHjnG1lWGHIDKkUdlz+HWrVtmWy/rCz2I2+7x2OP2k1tf2EARkV1p3LgxsrOzUVBQgO+++w6xsbHYsWOHVWOaPHkyxo8fLz02XAY1IiLikVfJ0mg06N69u91eqagy5ABUjjyqSg6GPTDmwPpCALfd47Ln7Se3vrCBIiK7olQq0ahRIwBASEgIDh48iAULFuCVV17B3bt3kZ+fb/QrcV5eHnx8fAAAPj4+OHDggNHyDFfRenDMw1fWysvLg1qtLvHXYQBQqVRQqVTFpjs5Ocn64yF3nC2rDDkAlSOPyp6DOXNjfaEHcds9HnvcfnLjZQNFVVaDdzaYbFnnZkabbFlUPnq9HlqtFiEhIXBycsLWrVvRr18/AMDJkydx4cIFhIWFAQDCwsLwwQcf4NKlS/Dy8gJw/xADtVqNoKAgaczGjRuN1qHRaKRlmEPzhM3QFpnmnjZ8LxKZDuuLMdYXovvYQBGR3Zg8eTKioqJQv359XL9+HWlpacjIyMDmzZvh7u6O4cOHY/z48fD09IRarcabb76JsLAwtG/fHgAQERGBoKAgDB48GLNnz0Zubi6mTJmCuLg46Rfe0aNH45NPPsHEiRMxbNgwbNu2DatWrcKGDaZruInI9rC+EJFcbKCIyG5cunQJQ4YMwcWLF+Hu7o4WLVpg8+bN6N69OwBg3rx5cHBwQL9+/aDVahEZGYklS5ZIz3d0dMT69esxZswYhIWFwc3NDbGxsUhKSpLGBAQEYMOGDRg3bhwWLFiAevXq4bPPPuMlhm2QKfcin5oRYbJlkX1ifSGD5gmbMbud6fbecc9d5cMGiojsxueff17mfGdnZyxevBiLFy8udYy/v3+xQ2ge1qVLFxw+fLhCMRKRfWJ9ISK5HKwdABERERERkb3gHiiyG6Y4XEflKKTd8oBpTqolIiIioqqDe6CIiIiIiIhkYgNFREREREQkExsoIiIiIiIimdhAERERERERycQGioiIiIiISCY2UERERERERDKxgSIiIiIiIpKJDRQREREREZFMbKCIiIiIiIhkqmbtAIgqgwbvbDDp8s7NjDbp8oiIiIjINLgHioiIiIiISCY2UERERERERDLxED4yK1Mf2kZEREREZE3cA0VERERERCQTGygiIiIiIiKZeAgfERFZBA/pJSJzMWV9UTmabFFUSXEPFBERERERkUxsoIiIiIiIiGRiA0VERERERCQTGygiIiIiIiKZ2EARERERERHJxAaKiOxGcnIy2rZtixo1asDLywt9+vTByZMnjcZ06dIFCoXC6N/o0aONxly4cAHR0dFwdXWFl5cXJkyYgHv37hmNycjIwNNPPw2VSoVGjRohJSXF3OkRkRWxvhCRXGygiMhu7NixA3Fxcdi3bx80Gg10Oh0iIiJw8+ZNo3EjR47ExYsXpX+zZ8+W5hUVFSE6Ohp3797F3r178eWXXyIlJQXTpk2Txpw9exbR0dF47rnnkJ2djbFjx2LEiBHYvHmzxXIlIstifSEiuXgfKCKyG5s2bTJ6nJKSAi8vL2RlZaFz587SdFdXV/j4+JS4jPT0dBw/fhxbtmyBt7c3WrVqhRkzZmDSpElISEiAUqnEsmXLEBAQgDlz5gAAmjZtit27d2PevHmIjIw0X4JEZDWsL0Qkl8n3QO3cuRO9evWCr68vFAoF1q5dazR/6NChxXZ/9+jRw2jM1atXMWjQIKjVanh4eGD48OG4ceOG0ZgjR46gU6dOcHZ2hp+fn9EvQERUNRQUFAAAPD09jaanpqaidu3aaN68OSZPnoxbt25J8zIzMxEcHAxvb29pWmRkJAoLC5GTkyONCQ8PN1pmZGQkMjMzzZUKEdkY1hciKo3J90DdvHkTLVu2xLBhw9C3b98Sx/To0QPLly+XHqtUKqP5gwYNwsWLF6Vd6K+99hpGjRqFtLQ0AEBhYSEiIiIQHh6OZcuW4ejRoxg2bBg8PDwwatQoU6dUpZT3Tt4qR4HZ7YDmCZuhLVKYKSqi4vR6PcaOHYsOHTqgefPm0vSBAwfC398fvr6+OHLkCCZNmoSTJ09izZo1AIDc3FyjLzcApMe5ublljiksLMTt27fh4uJiNE+r1UKr1UqPCwsLAQA6nQ46na7UHAzzVA6iXLmXpaz1mYNhfXLWq3I0XZ6mVp48bFVVycES+bG+lL1MW2TK+mLYZqbadra83czBnmuR3JhN3kBFRUUhKiqqzDEqlarU3d8nTpzApk2bcPDgQbRp0wYAsGjRIvTs2RMff/wxfH19kZqairt37+KLL76AUqlEs2bNkJ2djblz57KBIqoi4uLicOzYMezevdto+oM1IDg4GHXr1kW3bt1w5swZBAYGmiWW5ORkJCYmFpuenp4OV1fXRz5/Rhu9yWLZuHGjyZZVHhqN5pFjZrezQCAVZIhfTh62rrLn8OAeH3NhfSmZteqLHOaoL6badra83czJHmuR3PpilXOgMjIy4OXlhZo1a6Jr1654//33UatWLQD3d217eHhIzRMAhIeHw8HBAfv378eLL76IzMxMdO7cGUqlUhoTGRmJWbNm4dq1a6hZs6bFcyIiy4mPj8f69euxc+dO1KtXr8yxoaGhAIDTp08jMDAQPj4+OHDggNGYvLw8AJB+2PHx8ZGmPThGrVYX+3UYACZPnozx48dLjwsLC+Hn54eIiAio1epSY9PpdNBoNJh6yAFavWn24B5LsOw5FIYcunfvDicnpzLHNk+w3ZPkD7/XVXYetqo8r4WtkpODYQ+MubC+lM7S9aU8TFlfVA4CM9roTbbtbHm7mYM91yK59cXiDVSPHj3Qt29fBAQE4MyZM3j33XcRFRWFzMxMODo6Ijc3F15eXsZBVqsGT09Po93fAQEBRmMe3EVeWgNV0d3glmILuzzLuwvc1Lu5zc1e4n3wPWAL74vyMGecQgi8+eab+OGHH5CRkVGsDpQkOzsbAFC3bl0AQFhYGD744ANcunRJqjUajQZqtRpBQUHSmId/MdRoNAgLCytxHSqVqtihyADg5OQk64+HVq8w2SGw1vpjJSdXWz7M1xC73NfMllX2HMyVG+vLo9ny+8oc9cVU286Wt5s52WMtkhuvxRuomJgY6f+Dg4PRokULBAYGIiMjA926dTPruh93N7ilWHOXZ0V3gZvyEAFLsPV4S9rdb4+7wk0tLi4OaWlp+PHHH1GjRg3pRxV3d3e4uLjgzJkzSEtLQ8+ePVGrVi0cOXIE48aNQ+fOndGiRQsAQEREBIKCgjB48GDMnj0bubm5mDJlCuLi4qQvKaNHj8Ynn3yCiRMnYtiwYdi2bRtWrVqFDRvKd44gEdkP1hciksvqlzFv2LAhateujdOnT6Nbt27w8fHBpUuXjMbcu3cPV69efeTub8O80lR0N7il2MIuz/LuAjf1bm5zs5d4H9zdbwvvi/LQ6XT48ccfzbLspUuXArh/M8sHLV++HEOHDoVSqcSWLVswf/583Lx5E35+fujXrx+mTJkijXV0dMT69esxZswYhIWFwc3NDbGxsUhKSpLGBAQEYMOGDRg3bhwWLFiAevXq4bPPPuMlhokqMdYXIpLL6g3Un3/+iStXrhjt/s7Pz0dWVhZCQkIAANu2bYNer5eONQ4LC8N7770HnU4nfaHUaDRo3Lhxmec/Pe5ucEuxZjwV3VVtykMELMHW4y3p9be196k1CFH2oZd+fn7YsWPHI5fj7+//yJN6u3TpgsOHD5crPiKyX6wvRCSXye8DdePGDWRnZ0vHBZ89exbZ2dm4cOECbty4gQkTJmDfvn04d+4ctm7dit69e6NRo0bSLy9NmzZFjx49MHLkSBw4cAB79uxBfHw8YmJi4OvrC+D+ZUSVSiWGDx+OnJwcrFy5EgsWLDDau0RERERERGRqJm+gDh06hNatW6N169YAgPHjx6N169aYNm0aHB0dceTIEbzwwgt46qmnMHz4cISEhGDXrl1Ge4ZSU1PRpEkTdOvWDT179kTHjh3x6aefSvPd3d2Rnp6Os2fPIiQkBP/+978xbdo0XsKciIiIiIjMyuSH8HXp0qXM3eCbNz/6HBtPT0/pprmladGiBXbt2lXu+IiIiIiIiCrK5HugiIiIiIiIKis2UERERERERDJZ/Sp89PgavMN7RxARERERWQL3QBEREREREcnEBoqIiIiIiEgmNlBEREREREQysYEiIiIiIiKSiQ0UERERERGRTGygiIiIiIiIZGIDRUREREREJBMbKCIiIiIiIpnYQBEREREREcnEBoqIiIiIiEgmNlBEREREREQysYEiIiIiIiKSiQ0UERERERGRTGygiIiIiIiIZGIDRUREREREJBMbKCIiIiIiIpnYQBEREREREcnEBoqIiIiIiEgmNlBEZDeSk5PRtm1b1KhRA15eXujTpw9OnjxpNObOnTuIi4tDrVq1UL16dfTr1w95eXlGYy5cuIDo6Gi4urrCy8sLEyZMwL1794zGZGRk4Omnn4ZKpUKjRo2QkpJi7vSIyIpYX4hIrmrWDqAqavDOhhKnqxwFZrcDmidshrZIYeGoiGzfjh07EBcXh7Zt2+LevXt49913ERERgePHj8PNzQ0AMG7cOGzYsAGrV6+Gu7s74uPj0bdvX+zZswcAUFRUhOjoaPj4+GDv3r24ePEihgwZAicnJ3z44YcAgLNnzyI6OhqjR49Gamoqtm7dihEjRqBu3bqIjIy0Wv5EZD6sL0QkFxsoIrIbmzZtMnqckpICLy8vZGVloXPnzigoKMDnn3+OtLQ0dO3aFQCwfPlyNG3aFPv27UP79u2Rnp6O48ePY8uWLfD29karVq0wY8YMTJo0CQkJCVAqlVi2bBkCAgIwZ84cAEDTpk2xe/duzJs3j19wiCop1hcikosNFBHZrYKCAgCAp6cnACArKws6nQ7h4eHSmCZNmqB+/frIzMxE+/btkZmZieDgYHh7e0tjIiMjMWbMGOTk5KB169bIzMw0WoZhzNixY0uMQ6vVQqvVSo8LCwsBADqdDjqdrtT4DfNUDqIcWZetrPWZg2F9ctarcjRdnqZWnjxsVVXJwVL5sb6UvkxbZMr6Ythmptp2trzdzMGea5HcmNlAEZFd0uv1GDt2LDp06IDmzZsDAHJzc6FUKuHh4WE01tvbG7m5udKYB7/cGOYb5pU1prCwELdv34aLi4vRvOTkZCQmJhaLMT09Ha6uro/MZUYb/SPHyLVx40aTLas8NBrNI8fMbmeBQCrIEL+cPGxdZc/h1q1bZl8/60vJrFVf5DBHfTHVtrPl7WZO9liL5NYXNlBEZJfi4uJw7Ngx7N6929qhYPLkyRg/frz0uLCwEH5+foiIiIBarS71eTqdDhqNBlMPOUCrN815j8cSLHsIkCGH7t27w8nJqcyxzRM2Wyiq8jv8XlfZediq8rwWtkpODoY9MObE+lIyS9eX8jBlfVE5CMxoozfZtrPl7WYO9lyL5NYXNlBEZHfi4+Oxfv167Ny5E/Xq1ZOm+/j44O7du8jPzzf6lTgvLw8+Pj7SmAMHDhgtz3AVrQfHPHxlrby8PKjV6mK/DgOASqWCSqUqNt3JyUnWHw+tXmGyC8dY64+VnFxt+eI4htjlvma2rLLnYO7cWF9KZ8vvK3PUF1NtO1vebuZkj7VIbry8jDkR2Q0hBOLj4/HDDz9g27ZtCAgIMJofEhICJycnbN26VZp28uRJXLhwAWFhYQCAsLAwHD16FJcuXZLGaDQaqNVqBAUFSWMeXIZhjGEZRFT5sL4QkVzcA0VEdiMuLg5paWn48ccfUaNGDemcAnd3d7i4uMDd3R3Dhw/H+PHj4enpCbVajTfffBNhYWFo3749ACAiIgJBQUEYPHgwZs+ejdzcXEyZMgVxcXHSr7yjR4/GJ598gokTJ2LYsGHYtm0bVq1ahQ0bSr4FARHZP9YXIpKLe6CIyG4sXboUBQUF6NKlC+rWrSv9W7lypTRm3rx5eP7559GvXz907twZPj4+WLNmjTTf0dER69evh6OjI8LCwvDqq69iyJAhSEpKksYEBARgw4YN0Gg0aNmyJebMmYPPPvuMlxgmqsRYX4hILu6BIiK7IcSjLynr7OyMxYsXY/HixaWO8ff3f+RVkbp06YLDhw+XO0Yisk+sL0QkF/dAERERERERycQGioiIiIiISCY2UERERERERDKxgSIiIiIiIpKJDRQREREREZFMbKCIiIiIiIhkYgNFREREREQkExsoIiIiIiIimdhAERERERERycQGioiIiIiISCY2UERERERERDKxgSIiIiIiIpKJDRQREREREZFMbKCIiIiIiIhkMnkDtXPnTvTq1Qu+vr5QKBRYu3at0XwhBKZNm4a6devCxcUF4eHhOHXqlNGYq1evYtCgQVCr1fDw8MDw4cNx48YNozFHjhxBp06d4OzsDD8/P8yePdvUqRARERERERkxeQN18+ZNtGzZEosXLy5x/uzZs7Fw4UIsW7YM+/fvh5ubGyIjI3Hnzh1pzKBBg5CTkwONRoP169dj586dGDVqlDS/sLAQERER8Pf3R1ZWFj766CMkJCTg008/NXU6REREREREkmqmXmBUVBSioqJKnCeEwPz58zFlyhT07t0bAPDVV1/B29sba9euRUxMDE6cOIFNmzbh4MGDaNOmDQBg0aJF6NmzJz7++GP4+voiNTUVd+/exRdffAGlUolmzZohOzsbc+fONWq0iIiIiIiITMnkDVRZzp49i9zcXISHh0vT3N3dERoaiszMTMTExCAzMxMeHh5S8wQA4eHhcHBwwP79+/Hiiy8iMzMTnTt3hlKplMZERkZi1qxZuHbtGmrWrFni+rVaLbRarfS4sLAQAKDT6aDT6UydbqlUjqLk6Q7C6L/2wN5itpd4H3w/Gv7fku/Rx2EvcRIRERFVhEUbqNzcXACAt7e30XRvb29pXm5uLry8vIzmV6tWDZ6enkZjAgICii3DMK+0Bio5ORmJiYnFpqenp8PV1bUCGVXM7HZlz5/RRm+ZQEzI3mK29Xg3btxYbJpGo7FCJERERET0IIs2UNY2efJkjB8/XnpcWFgIPz8/REREQK1WWyyO5gmbS5yuchCY0UaPqYccoNUrLBbP47C3mO0l3mMJkdL/63Q6aDQadO/eHU5OTlaMSh6dTocff/zR2mEQERERmYVFGygfHx8AQF5eHurWrStNz8vLQ6tWraQxly5dMnrevXv3cPXqVen5Pj4+yMvLMxpjeGwYUxKVSgWVSlVsupOTk0W/mGqLyv7irtUrHjnG1thbzLYeb0nvR0u/T4mIiIioOIveByogIAA+Pj7YunWrNK2wsBD79+9HWFgYACAsLAz5+fnIysqSxmzbtg16vR6hoaHSmJ07dxqda6HRaNC4ceNSD98jIiIiIiJ6XCZvoG7cuIHs7GxkZ2cDuH/hiOzsbFy4cAEKhQJjx47F+++/j3Xr1uHo0aMYMmQIfH190adPHwBA06ZN0aNHD4wcORIHDhzAnj17EB8fj5iYGPj6+gIABg4cCKVSieHDhyMnJwcrV67EggULjA7PIyIiIiIiMjWTN1CHDh1C69at0bp1awDA+PHj0bp1a0ybNg0AMHHiRLz55psYNWoU2rZtixs3bmDTpk1wdnaWlpGamoomTZqgW7du6NmzJzp27Gh0jyd3d3ekp6fj7NmzCAkJwb///W9MmzaNlzAnquQedaPuoUOHQqFQGP3r0aOH0RjeqJuISsL6QkRymfwcqC5dukCI0i8RrVAokJSUhKSkpFLHeHp6Ii0trcz1tGjRArt27apwnERkfww36h42bBj69u1b4pgePXpg+fLl0uOHz3scNGgQLl68CI1GA51Oh9deew2jRo2Sao7hRt3h4eFYtmwZjh49imHDhsHDw4M/0hBVYqwvRCRXlboKHxHZt7Ju1G2gUqlKvZgMb9RNRKVhfSEiuSx6EQkiInPLyMiAl5cXGjdujDFjxuDKlSvSvEfdqNswpqQbdZ88eRLXrl2zXCJEZHNYX4gI4B4oIqpEevTogb59+yIgIABnzpzBu+++i6ioKGRmZsLR0dFsN+rWarXQarXS48LCQgD374n14NVCH2aYp3Io/bDn8iprfeZgWJ+c9aocTZenqZUnD1tVVXKwVn6sL7b93jJlfTFsM1NtO1vebuZgz7VIbsxsoIio0oiJiZH+Pzg4GC1atEBgYCAyMjLQrVs3s603OTkZiYmJxaanp6fD1dX1kc+f0UZvslg2btxosmWVh0ajeeSY2e0sEEgFGeKXk4etq+w53Lp1y4KR/B/WF+vVFznMUV9Mte1sebuZkz3WIrn1hQ0UEVVaDRs2RO3atXH69Gl069bNbDfqnjx5stFtFAoLC+Hn54eIiAio1epS49PpdNBoNJh6yAFavWlu7HwsIdIky5HLkEP37t0feaPn5gmbLRRV+R1+r6vsPGxVeV4LWyUnB8MeGGtjfbEtpqwvKgeBGW30Jtt2trzdzMGea5Hc+sIGiogqrT///BNXrlxB3bp1ARjfqDskJARAyTfqfu+996DT6aTC/6gbdatUqmJX4wIAJycnWX88tHoFtEWm+YJjrT9WcnI1VY7mYIhd7mtmyyp7DraSG+uLbTFHfTHVtrPl7WZO9liL5MbLi0gQkd0o60bdN27cwIQJE7Bv3z6cO3cOW7duRe/evdGoUSNERt7/9Y836iai0rC+EJFcbKCIyG6UdaNuR0dHHDlyBC+88AKeeuopDB8+HCEhIdi1a5fRr7e8UTcRlYT1hYjk4iF8RGQ3HnWj7s2bH30MPG/UTUQlYX0hIrm4B4qIiIiIiEgmNlBEREREREQysYEiIiIiIiKSiQ0UERERERGRTLyIhAwN3tlg7RCIiIiIiMgGcA8UERERERGRTNwDRUREVV7zhM2Y3e7+f7VFisde3rmZ0SaIiogqA1MfycT6Yn3cA0VERERERCQTGygiIiIiIiKZ2EARERERERHJxAaKiIiIiIhIJjZQREREREREMrGBIiIiIiIikokNFBERERERkUxsoIiIiIiIiGRiA0VERERERCRTNWsHQETFPXjXcpWjwOx2QPOEzdAWKSq0PN61nIiIiMg0uAeKiIiIiIhIJjZQREREREREMrGBIiIiIiIikokNFBERERERkUxsoIiIiIiIiGRiA0VERERERCQTGygiIiIiIiKZ2EARkd3YuXMnevXqBV9fXygUCqxdu9ZovhAC06ZNQ926deHi4oLw8HCcOnXKaMzVq1cxaNAgqNVqeHh4YPjw4bhx44bRmCNHjqBTp05wdnaGn58fZs+ebe7UiMjKWF+ISC42UERkN27evImWLVti8eLFJc6fPXs2Fi5ciGXLlmH//v1wc3NDZGQk7ty5I40ZNGgQcnJyoNFosH79euzcuROjRo2S5hcWFiIiIgL+/v7IysrCRx99hISEBHz66admz4+IrIf1hYjkqmbtAIiI5IqKikJUVFSJ84QQmD9/PqZMmYLevXsDAL766it4e3tj7dq1iImJwYkTJ7Bp0yYcPHgQbdq0AQAsWrQIPXv2xMcffwxfX1+kpqbi7t27+OKLL6BUKtGsWTNkZ2dj7ty5Rl+EiKhyYX0hIrnYQBFRpXD27Fnk5uYiPDxcmubu7o7Q0FBkZmYiJiYGmZmZ8PDwkL7cAEB4eDgcHBywf/9+vPjii8jMzETnzp2hVCqlMZGRkZg1axauXbuGmjVrFlu3VquFVquVHhcWFgIAdDoddDpdqTEb5qkcRMUTL2WZlmJYn5z1qhxNl6epGV4DU70Wln4dHlynNdZtKnJysEZ+rC/Gy7RFpqwvpq4HpmbLrwNg37VIbsxsoIioUsjNzQUAeHt7G0339vaW5uXm5sLLy8tofrVq1eDp6Wk0JiAgoNgyDPNK+oKTnJyMxMTEYtPT09Ph6ur6yNhntNE/coxcGzduNNmyykOj0TxyzOx2FgjkMZnqtbDW6wDIey1sXVk53Lp1y4KR3Mf6cp8139ePYo76YsptZ0q2/Do8yB5rkdz6wgaKiOgxTZ48GePHj5ceFxYWws/PDxEREVCr1aU+T6fTQaPRYOohB2j1CpPEciwh0iTLkcuQQ/fu3eHk5FTm2OYJmy0UVfmpHARmtNGb7LWw9OsAlO+1sFVycjDsgakqqnJ9KQ9T1hdT1wNTs+XXAbDvWiS3vrCBIqJKwcfHBwCQl5eHunXrStPz8vLQqlUracylS5eMnnfv3j1cvXpVer6Pjw/y8vKMxhgeG8Y8TKVSQaVSFZvu5OQk64+HVq+Atsg0f6St9cdKTq6mytGcTPVaWPNLg9z3nS0rKwdr5Mb68n/rtFXmqC+m3HamZMuvw4PssRbJjZdX4SOiSiEgIAA+Pj7YunWrNK2wsBD79+9HWFgYACAsLAz5+fnIysqSxmzbtg16vR6hoaHSmJ07dxodB63RaNC4ceMSD68hosqP9YWIHsQGiojsxo0bN5CdnY3s7GwA90/szs7OxoULF6BQKDB27Fi8//77WLduHY4ePYohQ4bA19cXffr0AQA0bdoUPXr0wMiRI3HgwAHs2bMH8fHxiImJga+vLwBg4MCBUCqVGD58OHJycrBy5UosWLDA6BAaIqp8WF+ISC4ewkdEduPQoUN47rnnpMeGLx2xsbFISUnBxIkTcfPmTYwaNQr5+fno2LEjNm3aBGdnZ+k5qampiI+PR7du3eDg4IB+/fph4cKF0nx3d3ekp6cjLi4OISEhqF27NqZNm8ZLDBNVcqwvRCQXGygishtdunSBEKVfVlahUCApKQlJSUmljvH09ERaWlqZ62nRogV27dpV4TiJyP6wvhCRXDyEj4iIiIiISCarNFAJCQlQKBRG/5o0aSLNv3PnDuLi4lCrVi1Ur14d/fr1K3bVmgsXLiA6Ohqurq7w8vLChAkTcO/ePUunQkREREREVYjVDuFr1qwZtmzZ8n+BVPu/UMaNG4cNGzZg9erVcHd3R3x8PPr27Ys9e/YAAIqKihAdHQ0fHx/s3bsXFy9exJAhQ+Dk5IQPP/zQ4rkQEREREVHVYLUGqlq1aiXe86CgoACff/450tLS0LVrVwDA8uXL0bRpU+zbtw/t27dHeno6jh8/ji1btsDb2xutWrXCjBkzMGnSJCQkJECpVFo6HSIiIiIiqgKsdg7UqVOn4Ovri4YNG2LQoEG4cOECACArKws6nQ7h4eHS2CZNmqB+/frIzMwEAGRmZiI4OBje3t7SmMjISBQWFiInJ8eyiRARERERUZVhlT1QoaGhSElJQePGjXHx4kUkJiaiU6dOOHbsGHJzc6FUKuHh4WH0HG9vb+Tm5gIAcnNzjZonw3zDvNJotVpotVrpcWFhIQBAp9MZ3dTuYSrH0q/KY0oqB2H0X3tgbzHbW7yAaWIu6/1tapZcFxEREZGlWaWBioqKkv6/RYsWCA0Nhb+/P1atWgUXFxezrTc5ORmJiYnFpqenp8PV1bXU581uZ7aQSjSjjd6yKzQBe4vZ3uIFHi/mjRs3mjASIiIioqrLJu4D5eHhgaeeegqnT59G9+7dcffuXeTn5xvthcrLy5POmfLx8cGBAweMlmG4Sl9J51UZTJ482ehu34WFhfDz80NERATUanWpz2uesLkiaZWbykFgRhs9ph5ygFavsMg6H5e9xWxv8QKmiflYQqSJoyqdTqfDjz/+aLH1EREREVmSTTRQN27cwJkzZzB48GCEhITAyckJW7duRb9+/QAAJ0+exIULFxAWFgYACAsLwwcffIBLly7By8sLAKDRaKBWqxEUFFTqelQqFVQqVbHpTk5OcHJyKvV52iLLftHW6hUWX+fjsreY7S1e4PFiLuv9TURERETyWaWBevvtt9GrVy/4+/vj77//xvTp0+Ho6IgBAwbA3d0dw4cPx/jx4+Hp6Qm1Wo0333wTYWFhaN++PQAgIiICQUFBGDx4MGbPno3c3FxMmTIFcXFxJTZIRERVRYN3NphsWedmRptsWURk/1hfiO6zSgP1559/YsCAAbhy5Qrq1KmDjh07Yt++fahTpw4AYN68eXBwcEC/fv2g1WoRGRmJJUuWSM93dHTE+vXrMWbMGISFhcHNzQ2xsbFISkqyRjpERERERFRFWKWBWrFiRZnznZ2dsXjxYixevLjUMf7+/jwxnoiIiIiILMpq94EiIiIiIiKyNzZxEQkiIrI9cs53UDkKzG53/2ql9nZhFiKyHlOeT0VkaWygiKoAnvhLREREZBo8hI+IiIiIiEgmNlBEREREREQysYEiIiIiIiKSiedAERERmRjPOyQic2F9sT7ugSIiIiIiIpKJDRQREREREZFMbKCIiIiIiIhkYgNFREREREQkExsoIqpUEhISoFAojP41adJEmn/nzh3ExcWhVq1aqF69Ovr164e8vDyjZVy4cAHR0dFwdXWFl5cXJkyYgHv37lk6FSKyIawtRGTAq/ARUaXTrFkzbNmyRXpcrdr/lbpx48Zhw4YNWL16Ndzd3REfH4++fftiz549AICioiJER0fDx8cHe/fuxcWLFzFkyBA4OTnhww8/tHguRGQ7WFuICGADRUSVULVq1eDj41NsekFBAT7//HOkpaWha9euAIDly5ejadOm2LdvH9q3b4/09HQcP34cW7Zsgbe3N1q1aoUZM2Zg0qRJSEhIgFKptHQ6RGQjWFuICGADRUSV0KlTp+Dr6wtnZ2eEhYUhOTkZ9evXR1ZWFnQ6HcLDw6WxTZo0Qf369ZGZmYn27dsjMzMTwcHB8Pb2lsZERkZizJgxyMnJQevWra2RElVhcu/5onIUmN0OaJ6wGdoiRanjeN+XimNtocrGlPeUAqpOfWEDRUSVSmhoKFJSUtC4cWNcvHgRiYmJ6NSpE44dO4bc3FwolUp4eHgYPcfb2xu5ubkAgNzcXKMvOIb5hnkl0Wq10Gq10uPCwkIAgE6ng06nKzVWwzyVgyhfkjbEELs95wBUjjzk5lDWe9LaDLHJ+dxYmjVqC1C164u1VIZ6YC0Pvi9tudaURm7MbKCIqFKJioqS/r9FixYIDQ2Fv78/Vq1aBRcXF7OsMzk5GYmJicWmp6enw9XV9ZHPn9FGb46wLKoy5ABUjjwelcPGjRstFEnFaTSaUufdunXLgpH8H2vUFoD1xZq47crvwfpS1ufYVsmtL2ygiKhS8/DwwFNPPYXTp0+je/fuuHv3LvLz841+Kc7Ly5POa/Dx8cGBAweMlmG4klZJ5z4AwOTJkzF+/HjpcWFhIfz8/BAREQG1Wl1qbDqdDhqNBlMPOUCrL/2QK1umchCY0UZv1zkAlSMPuTkcS4i0YFTlY/hMdO/eHU5OTiWOMeyBsTZL1BagatcXa6kM9cBajiVEyvoc2yq59YUNFBFVajdu3MCZM2cwePBghISEwMnJCVu3bkW/fv0AACdPnsSFCxcQFhYGAAgLC8MHH3yAS5cuwcvLC8D9X9HUajWCgoJKXIdKpYJKpSo23cnJSdYfD61eUeY5K/agMuQAVI48HpWDPXyhKeuzYyvxW6K2AKwv1sRtV34Pviflvkdtidx42UARUaXy9ttvo1evXvD398fff/+N6dOnw9HREQMGDIC7uzuGDx+O8ePHw9PTE2q1Gm+++SbCwsLQvn17AEBERASCgoIwePBgzJ49G7m5uZgyZQri4uJK/BJDRFUDawsRGbCBIqJK5c8//8SAAQNw5coV1KlTBx07dsS+fftQp04dAMC8efPg4OCAfv36QavVIjIyEkuWLJGe7+joiPXr12PMmDEICwuDm5sbYmNjkZSUZK2UiMgGsLYQkQEbKCKqVFasWFHmfGdnZyxevBiLFy8udYy/v79dnGhPVBGmvGxxVblkMcDaQiRHg3c2yL6lwqPYcn1xsHYARERERERE9oINFBERERERkUxsoIiIiIiIiGRiA0VERERERCQTGygiIiIiIiKZ2EARERERERHJxAaKiIiIiIhIJjZQREREREREMrGBIiIiIiIikokNFBERERERkUxsoIiIiIiIiGRiA0VERERERCQTGygiIiIiIiKZ2EARERERERHJxAaKiIiIiIhIJjZQREREREREMrGBIiIiIiIikokNFBERERERkUxsoIiIiIiIiGRiA0VERERERCQTGygiIiIiIiKZqlk7ACIiIrJPDd7ZYNLlnZoRYdLlEZH9MnV9OTcz2mTL4h4oIiIiIiIimdhAERERERERyWT3DdTixYvRoEEDODs7IzQ0FAcOHLB2SERUSbC+EJG5sL4Q2S+7bqBWrlyJ8ePHY/r06fjll1/QsmVLREZG4tKlS9YOjYjsHOsLEZkL6wuRfbPrBmru3LkYOXIkXnvtNQQFBWHZsmVwdXXFF198Ye3QiMjOsb4QkbmwvhDZN7u9Ct/du3eRlZWFyZMnS9McHBwQHh6OzMzMEp+j1Wqh1WqlxwUFBQCAq1evQqfTlbquavdumijqslXTC9y6pUc1nQOK9AqLrPNx2VvM9hYvYHsxX7lypcz5Op0Ot27dAgAIISwRksmVt75UtLYYtpWtvLYVYWvvz4qqDHlUhhyuXLmCW7du4cqVK3BycipxzPXr1wGwvlSF+mItleGzZE22uv0e9f0FkF9f7LaBunz5MoqKiuDt7W003dvbG7/99luJz0lOTkZiYmKx6QEBAWaJsSIGWjuACrC3mO0tXsC2Yq49R/7Y69evw93d3XzBmEl564s91BZzsqX35+OoDHnYew51WV+Kja/q9cVa7P2zZG22uP1M+f3Fbhuoipg8eTLGjx8vPdbr9bh69Spq1aoFhcL6HXJhYSH8/Pzwv//9D2q12trhyGJvMdtbvID9xWyI9/jx4/D19bV2OBZR0dpib69tSSpDDkDlyKOq5CCEwPXr11lfqkB9sRZuu8djz9tPbn2x2waqdu3acHR0RF5entH0vLw8+Pj4lPgclUoFlUplNM3Dw8NcIVaYWq22uzecvcVsb/EC9hfzE088AQcH+zzNsrz15XFri729tiWpDDkAlSOPqpCDPe55MmB9sR/cdo/HXrefnPpin99uACiVSoSEhGDr1q3SNL1ej61btyIsLMyKkRGRvWN9ISJzYX0hsn92uwcKAMaPH4/Y2Fi0adMG7dq1w/z583Hz5k289tpr1g6NiOwc6wsRmQvrC5F9s+sG6pVXXsE///yDadOmITc3F61atcKmTZuKnZhpL1QqFaZPn15sV70ts7eY7S1ewP5itrd4S2OJ+lIZtlVlyAGoHHkwB/vB+mLbuO0eT1XYfgphr9cBJSIiIiIisjC7PQeKiIiIiIjI0thAERERERERycQGioiIiIiISCY2UERERERERDKxgTKz5ORktG3bFjVq1ICXlxf69OmDkydPGo3p0qULFAqF0b/Ro0cbjblw4QKio6Ph6uoKLy8vTJgwAffu3TNLzAkJCcXiadKkiTT/zp07iIuLQ61atVC9enX069ev2A0BLRlvgwYNisWrUCgQFxcHwDa2786dO9GrVy/4+vpCoVBg7dq1RvOFEJg2bRrq1q0LFxcXhIeH49SpU0Zjrl69ikGDBkGtVsPDwwPDhw/HjRs3jMYcOXIEnTp1grOzM/z8/DB79myTx6vT6TBp0iQEBwfDzc0Nvr6+GDJkCP7++2+jZZT0usycOdMs8dqrxYsXo0GDBnB2dkZoaCgOHDhglTgs9ZnPyMjA008/DZVKhUaNGiElJaXCMdvSZ2r16tVo0qQJnJ2dERwcjI0bN5osj6FDhxZ7bXr06GEzecj5G2fJ94+tfKZsQVXfFvZY16ylstRTixJkVpGRkWL58uXi2LFjIjs7W/Ts2VPUr19f3LhxQxrz7LPPipEjR4qLFy9K/woKCqT59+7dE82bNxfh4eHi8OHDYuPGjaJ27dpi8uTJZol5+vTpolmzZkbx/PPPP9L80aNHCz8/P7F161Zx6NAh0b59e/HMM89YLd5Lly4ZxarRaAQAsX37diGEbWzfjRs3ivfee0+sWbNGABA//PCD0fyZM2cKd3d3sXbtWvHrr7+KF154QQQEBIjbt29LY3r06CFatmwp9u3bJ3bt2iUaNWokBgwYIM0vKCgQ3t7eYtCgQeLYsWPi22+/FS4uLuI///mPSePNz88X4eHhYuXKleK3334TmZmZol27diIkJMRoGf7+/iIpKclouz/4vjdlvPZoxYoVQqlUii+++ELk5OSIkSNHCg8PD5GXl2fxWCzxmf/jjz+Eq6urGD9+vDh+/LhYtGiRcHR0FJs2bapQzLbymdqzZ49wdHQUs2fPFsePHxdTpkwRTk5O4ujRoybJIzY2VvTo0cPotbl69arRGGvmIedvnKXeP7b0mbI2bgv7rGvWUlnqqSWxgbKwS5cuCQBix44d0rRnn31W/Otf/yr1ORs3bhQODg4iNzdXmrZ06VKhVquFVqs1eYzTp08XLVu2LHFefn6+cHJyEqtXr5amnThxQgAQmZmZVon3Yf/6179EYGCg0Ov1Qgjb274PFye9Xi98fHzERx99JE3Lz88XKpVKfPvtt0IIIY4fPy4AiIMHD0pjfv75Z6FQKMRff/0lhBBiyZIlombNmkYxT5o0STRu3Nik8ZbkwIEDAoA4f/68NM3f31/Mmzev1OeYK1570a5dOxEXFyc9LioqEr6+viI5OdnisVjiMz9x4kTRrFkzo2W/8sorIjIy8rHjt+Znqn///iI6OtoontDQUPH6668/dh5C3G+gevfuXepzbC2Ph//GWfL9Y0ufKWvjtrD/umYtlaWemhsP4bOwgoICAICnp6fR9NTUVNSuXRvNmzfH5MmTcevWLWleZmYmgoODjW6wFxkZicLCQuTk5JglzlOnTsHX1xcNGzbEoEGDcOHCBQBAVlYWdDodwsPDpbFNmjRB/fr1kZmZabV4De7evYtvvvkGw4YNg0KhkKbb2vZ90NmzZ5Gbm2u0Td3d3REaGmq0TT08PNCmTRtpTHh4OBwcHLB//35pTOfOnaFUKo3yOHnyJK5du2bWHAoKCqBQKODh4WE0febMmahVqxZat26Njz76yOjQB2vGa213795FVlaW0Wvu4OCA8PBw6TW3NHN/5jMzM42WYRhjjnwt+ZmyRF4ZGRnw8vJC48aNMWbMGFy5ckWaZ2t5PPw3zlLvH1v8TFkLt8X/qUx1zVoqWz01lWrWDqAq0ev1GDt2LDp06IDmzZtL0wcOHAh/f3/4+vriyJEjmDRpEk6ePIk1a9YAAHJzc4vdndzwODc31+RxhoaGIiUlBY0bN8bFixeRmJiITp064dixY8jNzYVSqSz2Rdnb21uKxdLxPmjt2rXIz8/H0KFDpWm2tn0fZlhHSTE8uE29vLyM5lerVg2enp5GYwICAootwzCvZs2aZon/zp07mDRpEgYMGAC1Wi1Nf+utt/D000/D09MTe/fuxeTJk3Hx4kXMnTvXqvHagsuXL6OoqKjE1/y3336zeDyW+MyXNqawsBC3b9+Gi4uLyfKx5GeqtLxMVTt69OiBvn37IiAgAGfOnMG7776LqKgoZGZmwtHR0abyKOlvnKXeP9euXbOpz5Q12Vp9sZbKVtespTLVU1NiA2VBcXFxOHbsGHbv3m00fdSoUdL/BwcHo27duujWrRvOnDmDwMBAS4eJqKgo6f9btGiB0NBQ+Pv7Y9WqVTZfDD7//HNERUXB19dXmmZr27cy0el06N+/P4QQWLp0qdG88ePHS//fokULKJVKvP7660hOToZKpbJ0qFQGe/7MV3YxMTHS/wcHB6NFixYIDAxERkYGunXrZsXIiivtbxyRNbCukTnxED4LiY+Px/r167F9+3bUq1evzLGhoaEAgNOnTwMAfHx8il0ZxvDYx8fHDNEa8/DwwFNPPYXTp0/Dx8cHd+/eRX5+frF4DLFYK97z589jy5YtGDFiRJnjbG37GtZRUgwPbtNLly4Zzb937x6uXr1qte1uaJ7Onz8PjUZjtPepJKGhobh37x7OnTtnlXhtSe3ateHo6Fjma25N5vjMlzZGrVab/MuMJT9TpY0x1+vYsGFD1K5d26h+2UIepf2Ns9T7x9Y/U5bEbVEye69r1lKZ6+njYANlZkIIxMfH44cffsC2bduK7b4sSXZ2NgCgbt26AICwsDAcPXrU6M1p+MIaFBRklrgfdOPGDZw5cwZ169ZFSEgInJycsHXrVmn+yZMnceHCBYSFhVk13uXLl8PLywvR0dFljrO17RsQEAAfHx+jbVpYWIj9+/cbbdP8/HxkZWVJY7Zt2wa9Xi81hGFhYdi5cyd0Op1RHo0bNzb54XCG5unUqVPYsmULatWq9cjnZGdnw8HBQdrNb8l4bY1SqURISIjRa67X67F161bpNbcmc3zmw8LCjJZhGGOOfC35mbJkXgDw559/4sqVK0b1y5p5POpvnKXeP7b+mbIkbouS2Xtds5bKXE8fi5UvYlHpjRkzRri7u4uMjAyjS2neunVLCCHE6dOnRVJSkjh06JA4e/as+PHHH0XDhg1F586dpWUYLqUZEREhsrOzxaZNm0SdOnXMdlnwf//73yIjI0OcPXtW7NmzR4SHh4vatWuLS5cuCSHuX/qzfv36Ytu2beLQoUMiLCxMhIWFWS1eIe5fYah+/fpi0qRJRtNtZftev35dHD58WBw+fFgAEHPnzhWHDx+Wrlo3c+ZM4eHhIX788Udx5MgR0bt37xIvEdq6dWuxf/9+sXv3bvHkk08aXSI0Pz9feHt7i8GDB4tjx46JFStWCFdX1wpdFryseO/evSteeOEFUa9ePZGdnW30vjZcXWfv3r1i3rx5Ijs7W5w5c0Z88803ok6dOmLIkCFmidcerVixQqhUKpGSkiKOHz8uRo0aJTw8PIyu+GQplvjMGy73O2HCBHHixAmxePHix7rcr618pvbs2SOqVasmPv74Y3HixAkxffr0cl12t6w8rl+/Lt5++22RmZkpzp49K7Zs2SKefvpp8eSTT4o7d+7YRB6P+hsnhOXeP7b0mbI2bgv7rGvWUlnqqSWxgTIzACX+W758uRBCiAsXLojOnTsLT09PoVKpRKNGjcSECROM7lMkhBDnzp0TUVFRwsXFRdSuXVv8+9//Fjqdziwxv/LKK6Ju3bpCqVSKJ554Qrzyyivi9OnT0vzbt2+LN954Q9SsWVO4urqKF198UVy8eNFq8QohxObNmwUAcfLkSaPptrJ9t2/fXuL7IDY2Vghx/zKhU6dOFd7e3kKlUolu3boVy+XKlStiwIABonr16kKtVovXXntNXL9+3WjMr7/+Kjp27ChUKpV44oknxMyZM00e79mzZ0t9XxvuvZWVlSVCQ0OFu7u7cHZ2Fk2bNhUffvih0Zc+U8ZrrxYtWiTq168vlEqlaNeundi3b59V4rDUZ3779u2iVatWQqlUioYNG0p1sCJs6TO1atUq8dRTTwmlUimaNWsmNmzYYJI8bt26JSIiIkSdOnWEk5OT8Pf3FyNHjiz2JdiaeTzqb5wQln3/2MpnyhZU9W1hj3XNWipLPbUkhRBCmHy3FhERERERUSXEc6CIiIiIiIhkYgNFREREREQkExsoIiIiIiIimdhAERERERERycQGioiIiIiISCY2UERERERERDKxgSIiIiIiIpKJDRQREREREZFMbKCIiIiIiIhkYgNFREREREQkExsoIiIiIiIimdhAERERERERycQGioiIiIiISCY2UERERERERDKxgSIiIiIiIpKJDRQREREREZFMbKCIiIiIiIhkYgNFREREREQkExsoIiIiIiIimdhAERERERERycQGqpJr0KABhg4dKj3OyMiAQqFARkZGuZdleO53331nugBNTKFQICEhwdphlMiWYyMqD3utKykpKVAoFDh37pzZ10VEpsOaY1kPb28qjg2UHTN8MEv6984771g1trS0NMyfP7/Y9HPnzhnF6eTkhNq1a+OZZ57Bu+++iwsXLlg+2HJ4cJvv3r272HwhBPz8/KBQKPD8889bIUKix2NvdaVLly6lxvvgP2v/ePGoL21Dhw5F9erVLRwVkfWx5piHoeYoFAp88803JY7p0KEDFAoFmjdvbuHo7F81awdAjy8pKQkBAQFG00r7MHTu3Bm3b9+GUqk0a0xpaWk4duwYxo4dW+L8AQMGoGfPntDr9bh27RoOHjyI+fPnY8GCBfj8888RExNj1vgel7OzM9LS0tCxY0ej6Tt27MCff/4JlUpV7Dm3b99GtWr8yJF9sJe68t5772HEiBHS44MHD2LhwoV499130bRpU2l6ixYt0KxZM8TExJT4+SQi62LNMQ/D95VXX33VaPq5c+ewd+9eODs7F3vOyZMn4eDAfSxl4be5SiAqKgpt2rSRNdbBwaHED4ulPf3008U+zOfPn0dERARiY2PRtGlTtGzZ0krRPVrPnj2xevVqLFy40KgpSktLQ0hICC5fvlzsObaw3Ynkspe60r17d6PHzs7OWLhwIbp3744uXboUG+/o6GihyOzDnTt3oFQq+WWJrI41xzx69uyJdevW4fLly6hdu7Y0PS0tDd7e3njyySdx7do1o+fwR6ZHY8WsYko7bnjx4sVo2LAhXFxc0K5dO+zatQtdunQpsRjo9Xp88MEHqFevHpydndGtWzecPn1amt+lSxds2LAB58+fl3YfN2jQ4JGx+fv7IyUlBXfv3sXs2bON5uXn52Ps2LHw8/ODSqVCo0aNMGvWLOj1+jKXef78ebzxxhto3LgxXFxcUKtWLbz88stGxyP/8ccfUCgUmDdvXrHn7927FwqFAt9++63R9AEDBuDKlSvQaDTStLt37+K7777DwIEDS4zl4V36CQkJUCgUOH36NIYOHQoPDw+4u7vjtddew61bt8rMi8iW2HJdeVBJ5yM0aNAAzz//PDIyMtCmTRu4uLggODhYymXNmjUIDg6Gs7MzQkJCcPjw4WLL/e233/DSSy/B09MTzs7OaNOmDdatW1eu2EqzZMkSNGvWDCqVCr6+voiLi0N+fr7RmNLOV3h4WxtepxUrVmDKlCl44okn4OrqisLCQpPESmQprDnya07v3r2hUqmwevVqo+lpaWno379/iQ3ewzXFkMeePXswfvx41KlTB25ubnjxxRfxzz//lGubVBbcA1UJFBQUFNvj8eCvDI+ydOlSxMfHo1OnThg3bhzOnTuHPn36oGbNmqhXr16x8TNnzoSDgwPefvttFBQUYPbs2Rg0aBD2798P4P7u7YKCAvz5559SUyL32P6wsDAEBgYaNSa3bt3Cs88+i7/++guvv/466tevj71792Ly5Mm4ePFiiedaGRw8eBB79+5FTEwM6tWrh3PnzmHp0qXo0qULjh8/DldXVzRs2BAdOnRAamoqxo0bZ/T81NRU1KhRA7179zaa3qBBA4SFheHbb79FVFQUAODnn39GQUEBYmJisHDhQln5AkD//v0REBCA5ORk/PLLL/jss8/g5eWFWbNmyV4GkalVprryKKdPn8bAgQPx+uuv49VXX8XHH3+MXr16YdmyZXj33XfxxhtvAACSk5PRv39/o8NbcnJy0KFDBzzxxBN455134ObmhlWrVqFPnz74/vvv8eKLLxqt6/r16yXuodZqtcWmJSQkIDExEeHh4RgzZgxOnjyJpUuX4uDBg9izZw+cnJwqlO+MGTOgVCrx9ttvQ6vVmv0wKCI5WHPMU3NcXV3Ru3dvfPvttxgzZgwA4Ndff0VOTg4+++wzHDlyRHbcb775JmrWrInp06fj3LlzmD9/PuLj47Fy5UqTbBe7IshuLV++XAAo8Z+Bv7+/iI2NlR5v375dABDbt28XQgih1WpFrVq1RNu2bYVOp5PGpaSkCADi2WefLfbcpk2bCq1WK01fsGCBACCOHj0qTYuOjhb+/v7FYj579qwAID766KNS8+rdu7cAIAoKCoQQQsyYMUO4ubmJ33//3WjcO++8IxwdHcWFCxekaQDE9OnTpce3bt0qtvzMzEwBQHz11VfStP/85z8CgDhx4oQ07e7du6J27dpG28+wzQ8ePCg++eQTUaNGDWkdL7/8snjuueeEEPe3e3R0tNF6H45t+vTpAoAYNmyY0bgXX3xR1KpVq9TtQ2RO9lhXHrR69WqjWErK7ezZs0a5ABB79+6Vpm3evFkAEC4uLuL8+fPSdEOdeHDZ3bp1E8HBweLOnTvSNL1eL5555hnx5JNPFsuzrH9ubm7S+EuXLgmlUikiIiJEUVGRNP2TTz4RAMQXX3xhlMODr4fBs88+W+K2btiwYYm1kcgaWHPMW3NWr14t1q9fLxQKhfR9acKECaJhw4ZCiPt1olmzZkZxP7y9DXmEh4cLvV4vTR83bpxwdHQU+fn5ZW6jyoiH8FUCixcvhkajMfon16FDh3DlyhWMHDnS6FyeQYMGoWbNmiU+57XXXjP6xbJTp04A7h8KZwqGX3iuX78OAFi9ejU6deqEmjVr4vLly9K/8PBwFBUVYefOnaUuy8XFRfp/nU6HK1euoFGjRvDw8MAvv/wizevfvz+cnZ2RmpoqTdu8eTMuX75c7FytB59z+/ZtrF+/HtevX8f69etLPXyvLKNHjzZ63KlTJ1y5coWH1ZBVVba6UpagoCCEhYVJj0NDQwEAXbt2Rf369YtNN8R09epVbNu2Df3795f2LF2+fBlXrlxBZGQkTp06hb/++stoXdOmTSu2XTUaDSIiIozGbdmyBXfv3sXYsWONzk8aOXIk1Go1NmzYUOF8Y2NjjWojkS1gzTFPzQGAiIgIeHp6YsWKFRBCYMWKFRgwYEC54x41ahQUCoX0uFOnTigqKsL58+fLvSx7x0P4KoF27drJPvHyYYY3faNGjYymV6tWrdRjfR/8cAOQitPDJyFW1I0bNwAANWrUAACcOnUKR44cQZ06dUocf+nSpVKXdfv2bSQnJ2P58uX466+/IISQ5hUUFEj/7+HhgV69eiEtLQ0zZswAcP/wvSeeeAJdu3Ytcdl16tRBeHg40tLScOvWLRQVFeGll14qX7Ioe3uq1epyL4/IFCpbXSnLw+t2d3cHAPj5+ZU43RDT6dOnIYTA1KlTMXXq1BKXfenSJTzxxBPS4+DgYISHhxcb9/Blhg3bsHHjxkbTlUolGjZs+FhfWB6+0hmRLWDNMU/NAQAnJye8/PLLSEtLQ7t27fC///2vQj/4WnOb2Ro2UFRupV1R5sHm5HEcO3YMXl5eUvOg1+vRvXt3TJw4scTxTz31VKnLevPNN7F8+XKMHTsWYWFhcHd3h0KhQExMTLELUAwZMgSrV6/G3r17ERwcjHXr1uGNN94o8+pUAwcOxMiRI5Gbm4uoqCh4eHiUO19zb08ie2DNz0Fp635UTIYa8vbbbyMyMrLEsQ9/oTOHB38RflBRUVGJOXDvE1HVqzkDBw7EsmXLkJCQgJYtWyIoKKi8YfP7ygPYQFVx/v7+AO7/qvHcc89J0+/du4dz586hRYsWFVpuaX/QHyUzMxNnzpwxOmwuMDAQN27cKPFX20f57rvvEBsbizlz5kjT7ty5U+wqVgDQo0cP1KlTB6mpqQgNDcWtW7cwePDgMpf/4osv4vXXX8e+ffuq5kmURCWwtbpiLg0bNgRw/9fditSnshi24cmTJ6X1APev9nn27Fmj9dWsWbPEmnb+/Hmj5xJVVqw5j9axY0fUr18fGRkZvEiVCfAcqCquTZs2qFWrFv773//i3r170vTU1NTH2iXr5uZmdIicHOfPn8fQoUOhVCoxYcIEaXr//v2RmZmJzZs3F3tOfn6+UdwPc3R0LPbLyKJFi1BUVFRsbLVq1TBgwACsWrUKKSkpCA4OfmTRrV69OpYuXYqEhAT06tXrUSkSVQm2VFfMycvLC126dMF//vMfXLx4sdj8x7m8b3h4OJRKJRYuXGhUwz7//HMUFBQgOjpamhYYGIh9+/bh7t270rT169fjf//7X4XXT2RPWHPuK6vmKBQKLFy4ENOnT3/kj8P0aNwDVcUplUokJCTgzTffRNeuXdG/f3+cO3cOKSkpCAwMrPCvLyEhIVi5ciXGjx+Ptm3bonr16kYNxi+//IJvvvkGer0e+fn5OHjwIL7//nsoFAp8/fXXRo3LhAkTsG7dOjz//PMYOnQoQkJCcPPmTRw9ehTfffcdzp07V+qlTp9//nl8/fXXcHd3R1BQEDIzM7FlyxbUqlWrxPFDhgzBwoULsX37dtm/0MTGxpZjyxBVftaqK9awePFidOzYEcHBwRg5ciQaNmyIvLw8ZGZm4s8//8Svv/5aoeXWqVMHkydPRmJiInr06IEXXngBJ0+exJIlS9C2bVujvfQjRozAd999hx49eqB///44c+YMvvnmGwQGBpoqTSKbxpojr+b07t272G1ZqGLYQBHi4+MhhMCcOXPw9ttvo2XLlli3bh3eeuutCt/p+4033kB2djaWL1+OefPmwd/f36jofPvtt/j2229RrVo1qNVqPPnkkxg7dixGjx5d7CRFV1dX7NixAx9++CFWr16Nr776Cmq1Gk899RQSExOlkyxLsmDBAjg6OiI1NRV37txBhw4dsGXLllKPHQ4JCUGzZs1w4sQJDBo0qEK5E5F16oo1BAUF4dChQ0hMTERKSgquXLkCLy8vtG7dGtOmTXusZSckJKBOnTr45JNPMG7cOHh6emLUqFH48MMPje4BFRkZiTlz5mDu3LkYO3Ys2rRpg/Xr1+Pf//7346ZHZDdYcx6/5pB8ClEVz/yiR9Lr9ahTpw769u2L//73v9YOx6Jat24NT09PbN261dqhEFUqVbmuEJHlseaQufAcKMKdO3eKnSf01Vdf4erVq+jSpYt1grKSQ4cOITs7G0OGDLF2KER2jXWFiCyJNYcsiXugCBkZGRg3bhxefvll1KpVC7/88gs+//xzNG3aFFlZWUY3mqusjh07hqysLMyZMweXL1/GH3/8UeFd/kTEukJElsWaQ5bEc6AIDRo0gJ+fHxYuXIirV6/C09MTQ4YMwcyZM6tMwfnuu++QlJSExo0b49tvv2XzRPSYWFeIyJJYc8iSuAeKiIiIiIhIJp4DRUREREREJBMbKCIiIiIiIpmq9DlQer0ef//9N2rUqFHhm6wRUXFCCFy/fh2+vr5wcKh6v9OwthCZD+sL6wuRucitL1W6gfr777/h5+dn7TCIKq3//e9/qFevnrXDsDjWFiLzY30hInN5VH2p0g1UjRo1ANzfSGq1usQxOp0O6enpiIiIMLrze2VQWXNjXtZXWFgIPz8/6TNW1cipLYB9vaamxLyrTt7myJn1pWrWl8qUD3OxXXLrS5VuoAy7vtVqdZkNlKurK9RqdaV4YzyosubGvGxHVT28RE5tAezzNTUF5l118jZnzqwvVau+VKZ8mIvte1R9qXoHDxMREREREVUQGygiIiIiIiKZ2EARERERERHJxAaKiIiIiIhIpnI3UDt37kSvXr3g6+sLhUKBtWvXGs0XQmDatGmoW7cuXFxcEB4ejlOnThmNuXr1KgYNGgS1Wg0PDw8MHz4cN27cMBpz5MgRdOrUCc7OzvDz88Ps2bOLxbJ69Wo0adIEzs7OCA4OxsaNG8ubDhERERERkWzlbqBu3ryJli1bYvHixSXOnz17NhYuXIhly5Zh//79cHNzQ2RkJO7cuSONGTRoEHJycqDRaLB+/Xrs3LkTo0aNkuYXFhYiIiIC/v7+yMrKwkcffYSEhAR8+umn0pi9e/diwIABGD58OA4fPow+ffqgT58+OHbsWHlTIiIiIiIikqXclzGPiopCVFRUifOEEJg/fz6mTJmC3r17AwC++uoreHt7Y+3atYiJicGJEyewadMmHDx4EG3atAEALFq0CD179sTHH38MX19fpKam4u7du/jiiy+gVCrRrFkzZGdnY+7cuVKjtWDBAvTo0QMTJkwAAMyYMQMajQaffPIJli1bVqGNQUREREREVBaTngN19uxZ5ObmIjw8XJrm7u6O0NBQZGZmAgAyMzPh4eEhNU8AEB4eDgcHB+zfv18a07lzZyiVSmlMZGQkTp48iWvXrkljHlyPYYxhPURERERERKZm0hvp5ubmAgC8vb2Npnt7e0vzcnNz4eXlZRxEtWrw9PQ0GhMQEFBsGYZ5NWvWRG5ubpnrKYlWq4VWq5UeFxYWArh/EzCdTlficwzTQ5I2Qas3zU37jiVEmmQ5j8uQW2m52yvmZX32ECM9WoN3Nph0eedmRpt0eURkv8pbX1SOArPbAc0TNkNbVPz7GOsLWZJJGyhbl5ycjMTExGLT09PT4erqWuZzZ7TRmywOW7vYhUajsXYIZsG8rOfWrVvWDoGIiIjILEzaQPn4+AAA8vLyULduXWl6Xl4eWrVqJY25dOmS0fPu3buHq1evSs/38fFBXl6e0RjD40eNMcwvyeTJkzF+/HjpcWFhIfz8/BAREQG1Wl3ic3Q6HTQaDaYecqiUe6A0Gg26d+8OJycna4djMszL+gx7d4mIiIgqG5M2UAEBAfDx8cHWrVulhqmwsBD79+/HmDFjAABhYWHIz89HVlYWQkJCAADbtm2DXq9HaGioNOa9996DTqeTvihqNBo0btwYNWvWlMZs3boVY8eOldav0WgQFhZWanwqlQoqlarYdCcnp0d+IdXqFSXuMq4IW/vyKyd/e8S8rMfW4yMiIiKqqHJfROLGjRvIzs5GdnY2gPsXjsjOzsaFCxegUCgwduxYvP/++1i3bh2OHj2KIUOGwNfXF3369AEANG3aFD169MDIkSNx4MAB7NmzB/Hx8YiJiYGvry8AYODAgVAqlRg+fDhycnKwcuVKLFiwwGjv0b/+9S9s2rQJc+bMwW+//YaEhAQcOnQI8fHxj79ViIiIiIiISlDuPVCHDh3Cc889Jz02NDWxsbFISUnBxIkTcfPmTYwaNQr5+fno2LEjNm3aBGdnZ+k5qampiI+PR7du3eDg4IB+/fph4cKF0nx3d3ekp6cjLi4OISEhqF27NqZNm2Z0r6hnnnkGaWlpmDJlCt599108+eSTWLt2LZo3b16hDUFERERERPQo5W6gunTpAiFEqfMVCgWSkpKQlJRU6hhPT0+kpaWVuZ4WLVpg165dZY55+eWX8fLLL5cdMBERERERkYmY9D5QRERERERElRkbKCIiIiIiIpnYQBGR3Vi6dClatGgBtVoNtVqNsLAw/Pzzz9L8O3fuIC4uDrVq1UL16tXRr1+/Yrc7uHDhAqKjo+Hq6govLy9MmDAB9+7dMxqTkZGBp59+GiqVCo0aNUJKSool0iMiK2J9ISK52EARkd2oV68eZs6ciaysLBw6dAhdu3ZF7969kZOTAwAYN24cfvrpJ6xevRo7duzA33//jb59+0rPLyoqQnR0NO7evYu9e/fiyy+/REpKCqZNmyaNOXv2LKKjo/Hcc88hOzsbY8eOxYgRI7B582aL50tElsP6QkRymfQ+UERE5tSrVy+jxx988AGWLl2Kffv2oV69evj888+RlpaGrl27AgCWL1+Opk2bYt++fWjfvj3S09Nx/PhxbNmyBd7e3mjVqhVmzJiBSZMmISEhAUqlEsuWLUNAQADmzJkD4P6tF3bv3o158+YhMtI2boJNRKbH+kJEcrGBIiK7VFRUhNWrV+PmzZsICwtDVlYWdDodwsPDpTFNmjRB/fr1kZmZifbt2yMzMxPBwcHw9vaWxkRGRmLMmDHIyclB69atkZmZabQMw5gHb9r9MK1WC61WKz0uLCwEAOh0Ouh0ulKfZ5hX1hhrUjmWfsXVing4X1vN21yqYt7myNkS24/1xfzKW19UDsLovw+z1TxLYuuvTXlUplwA+XmwgSIiu3L06FGEhYXhzp07qF69On744QcEBQUhOzsbSqUSHh4eRuO9vb2Rm5sLAMjNzTX6cmOYb5hX1pjCwkLcvn0bLi4uxWJKTk5GYmJisenp6elwdXV9ZE4ajeaRY6xhdjvTLm/jxo1Gj201b3OrinmbMudbt26ZbFkPY32xnIrWlxlt9CVOf7i+2ANbfW0qorLkIre+sIEiIrvSuHFjZGdno6CgAN999x1iY2OxY8cOq8Y0efJk6abiwP1fiP38/BAREQG1Wl3q83Q6HTQaDbp37w4nJydLhFouzRNMe17GsYT7hyjZet7mUhXzNkfOhj0w5sD6YjnlrS8qB4EZbfSYesgBWr2i2HxDfbEHtv7alEdlygWQX1/YQBGRXVEqlWjUqBEAICQkBAcPHsSCBQvwyiuv4O7du8jPzzf6lTgvLw8+Pj4AAB8fHxw4cMBoeYaraD045uEra+Xl5UGtVpf46zAAqFQqqFSqYtOdnJxk/UGRO87StEXFv6Q8jodztNW8za0q5m3KnM257VhfLKei9UWrV5T4XFvM8VFs9bWpiMqSi9wceBU+IrJrer0eWq0WISEhcHJywtatW6V5J0+exIULFxAWFgYACAsLw9GjR3Hp0iVpjEajgVqtRlBQkDTmwWUYxhiWQURVB+sLEZWEe6CIyG5MnjwZUVFRqF+/Pq5fv460tDRkZGRg8+bNcHd3x/DhwzF+/Hh4enpCrVbjzTffRFhYGNq3bw8AiIiIQFBQEAYPHozZs2cjNzcXU6ZMQVxcnPQL7+jRo/HJJ59g4sSJGDZsGLZt24ZVq1Zhw4YN1kydiMyM9YWI5GIDRUR249KlSxgyZAguXrwId3d3tGjRAps3b0b37t0BAPPmzYODgwP69esHrVaLyMhILFmyRHq+o6Mj1q9fjzFjxiAsLAxubm6IjY1FUlKSNCYgIAAbNmzAuHHjsGDBAtSrVw+fffYZLzFMVMmxvhCRXGygiMhufP7552XOd3Z2xuLFi7F48eJSx/j7+z/yak1dunTB4cOHKxQjEdkn1hcikovnQBEREREREcnEBoqIiIiIiEgmNlBEREREREQy8RwoIiIra56w2WT3XDo3M9okyyGiyoH1hcj0uAeKiIiIiIhIJjZQREREREREMrGBIiIiIiIikokNFBERERERkUxsoIiIiIiIiGRiA0VERERERCQTGygiIiIiIiKZ2EARERERERHJxAaKiIiIiIhIJjZQREREREREMrGBIiIiIiIikokNFBERERERkUxsoIiIiIiIiGQyeQNVVFSEqVOnIiAgAC4uLggMDMSMGTMghJDGCCEwbdo01K1bFy4uLggPD8epU6eMlnP16lUMGjQIarUaHh4eGD58OG7cuGE05siRI+jUqROcnZ3h5+eH2bNnmzodIiIiIiIiickbqFmzZmHp0qX45JNPcOLECcyaNQuzZ8/GokWLpDGzZ8/GwoULsWzZMuzfvx9ubm6IjIzEnTt3pDGDBg1CTk4ONBoN1q9fj507d2LUqFHS/MLCQkRERMDf3x9ZWVn46KOPkJCQgE8//dTUKREREREREQEAqpl6gXv37kXv3r0RHR0NAGjQoAG+/fZbHDhwAMD9vU/z58/HlClT0Lt3bwDAV199BW9vb6xduxYxMTE4ceIENm3ahIMHD6JNmzYAgEWLFqFnz574+OOP4evri9TUVNy9exdffPEFlEolmjVrhuzsbMydO9eo0SIiIiIiIjIVkzdQzzzzDD799FP8/vvveOqpp/Drr79i9+7dmDt3LgDg7NmzyM3NRXh4uPQcd3d3hIaGIjMzEzExMcjMzISHh4fUPAFAeHg4HBwcsH//frz44ovIzMxE586doVQqpTGRkZGYNWsWrl27hpo1axaLTavVQqvVSo8LCwsBADqdDjqdrsR8DNNVDqLE+RVR2roszRCHrcRjKszL+uwhRiIiIqKKMHkD9c4776CwsBBNmjSBo6MjioqK8MEHH2DQoEEAgNzcXACAt7e30fO8vb2lebm5ufDy8jIOtFo1eHp6Go0JCAgotgzDvJIaqOTkZCQmJhabnp6eDldX1zLzmtFGX+b88ti4caPJlmUKGo3G2iGYBfOynlu3bpllucnJyVizZg1+++03uLi44JlnnsGsWbPQuHFjaUyXLl2wY8cOo+e9/vrrWLZsmfT4woULGDNmDLZv347q1asjNjYWycnJqFbt/0piRkYGxo8fj5ycHPj5+WHKlCkYOnSoWfKqKhq8swEAoHIUmN0OaJ6wGdoiRYWXd25mtKlCI2J9sXOG+mIKrC30KCZvoFatWoXU1FSkpaVJh9WNHTsWvr6+iI2NNfXqymXy5MkYP3689LiwsBB+fn6IiIiAWq0u8Tk6nQ4ajQZTDzlAq6/4H/oHHUuINMlyHpcht+7du8PJycna4ZgM87I+w95dU9uxYwfi4uLQtm1b3Lt3D++++y4iIiJw/PhxuLm5SeNGjhyJpKQk6fGDP5AUFRUhOjoaPj4+2Lt3Ly5evIghQ4bAyckJH374IYD7e8qjo6MxevRopKamYuvWrRgxYgTq1q2LyEjb+PwSkWmxvhCRXCZvoCZMmIB33nkHMTExAIDg4GCcP38eycnJiI2NhY+PDwAgLy8PdevWlZ6Xl5eHVq1aAQB8fHxw6dIlo+Xeu3cPV69elZ7v4+ODvLw8ozGGx4YxD1OpVFCpVMWmOzk5PfILqVaveKxfSh9eny2Rk789Yl7WY674Nm3aZPQ4JSUFXl5eyMrKQufOnaXprq6updaB9PR0HD9+HFu2bIG3tzdatWqFGTNmYNKkSUhISIBSqcSyZcsQEBCAOXPmAACaNm2K3bt3Y968efyCQ1RJsb4QkVwmb6Bu3boFBwfji/s5OjpCr79/CFxAQAB8fHywdetWqWEqLCzE/v37MWbMGABAWFgY8vPzkZWVhZCQEADAtm3boNfrERoaKo157733oNPppC9rGo0GjRs3LvHwPSKqfAoKCgAAnp6eRtNTU1PxzTffwMfHB7169cLUqVOlX4kzMzMRHBxsdBhxZGQkxowZg5ycHLRu3RqZmZlG52kaxowdO7bEOCpyfqVhPmC751iqHE0Xl9Fy/3++j5u3vZ1rZ0/nMZqKOXK21PZjfSl9maZQ3vpiqrohh7nfY5WpFlSmXAD5eZi8gerVqxc++OAD1K9fH82aNcPhw4cxd+5cDBs2DACgUCgwduxYvP/++3jyyScREBCAqVOnwtfXF3369AFw/9eYHj16YOTIkVi2bBl0Oh3i4+MRExMDX19fAMDAgQORmJiI4cOHY9KkSTh27BgWLFiAefPmmTolIrJBer0eY8eORYcOHdC8eXNp+sCBA+Hv7w9fX18cOXIEkyZNwsmTJ7FmzRoA98+RLOkcTMO8ssYUFhbi9u3bcHFxMZr3OOdXArZ7juXsdiZbVIkeN29bO59ULns4j9HUTJmzuc6xfBDrS8lsob6YMp/SWKq2VKZaUFlykVtfTN5ALVq0CFOnTsUbb7yBS5cuwdfXF6+//jqmTZsmjZk4cSJu3ryJUaNGIT8/Hx07dsSmTZvg7OwsjUlNTUV8fDy6desGBwcH9OvXDwsXLpTmu7u7Iz09HXFxcQgJCUHt2rUxbdo0XsKcqIqIi4vDsWPHsHv3bqPpD9aA4OBg1K1bF926dcOZM2cQGBhollgqcn4lYPvnWDZP2GyyZT1I5SAwo43+sfO2lfNJ5bKn8xhNxRw5m+scywexvpTMmvXFVHVDDnPXlspUCypTLoD8+mLyBqpGjRqYP38+5s+fX+oYhUKBpKQko5MwH+bp6Ym0tLQy19WiRQvs2rWroqESkZ2Kj4+XbrBdr169MscaDvs9ffo0AgMD4ePjI92XzuDh8ydLO8dSrVYX+3UYeLzzKwHbPcfSVDGVuvzHzNte/1jbw3mMpmbKnM297VhfSmcL9cWU+ZTGUp/PylQLKksucnNwePQQIiLbIIRAfHw8fvjhB2zbtq3YrQxKkp2dDQDSRWvCwsJw9OhRowvVaDQaqNVqBAUFSWO2bt1qtByNRoOwsDATZUJEtob1hYjkYgNFRHYjLi4O33zzDdLS0lCjRg3k5uYiNzcXt2/fBgCcOXMGM2bMQFZWFs6dO4d169ZhyJAh6Ny5M1q0aAEAiIiIQFBQEAYPHoxff/0VmzdvxpQpUxAXFyf9yjt69Gj88ccfmDhxIn777TcsWbIEq1atwrhx46yWOxGZF+sLEcnFBoqI7MbSpUtRUFCALl26oG7dutK/lStXAgCUSiW2bNmCiIgINGnSBP/+97/Rr18//PTTT9IyHB0dsX79ejg6OiIsLAyvvvoqhgwZYnRIcUBAADZs2ACNRoOWLVtizpw5+Oyzz3iJYaJKjPWFiOQy+TlQRETmIkTZl6/18/PDjh07Hrkcf3//R15lqUuXLjh8+HC54iMi+8X6QkRycQ8UERERERGRTGygiIiIiIiIZGIDRUREREREJBMbKCIiIiIiIpnYQBEREREREcnEBoqIiIiIiEgmNlBEREREREQysYEiIiIiIiKSiQ0UERERERGRTGygiIiIiIiIZGIDRUREREREJBMbKCIiIiIiIpnYQBEREREREcnEBoqIiIiIiEgmNlBEREREREQysYEiIiIiIiKSiQ0UERERERGRTGygiIiIiIiIZGIDRUREREREJBMbKCIiIiIiIpnYQBGR3UhOTkbbtm1Ro0YNeHl5oU+fPjh58qTRmDt37iAuLg61atVC9erV0a9fP+Tl5RmNuXDhAqKjo+Hq6govLy9MmDAB9+7dMxqTkZGBp59+GiqVCo0aNUJKSoq50yMiK2J9ISK52EARkd3YsWMH4uLisG/fPmg0Guh0OkRERODmzZvSmHHjxuGnn37C6tWrsWPHDvz999/o27evNL+oqAjR0dG4e/cu9u7diy+//BIpKSmYNm2aNObs2bOIjo7Gc889h+zsbIwdOxYjRozA5s2bLZovEVkO6wsRyVXN2gEQEcm1adMmo8cpKSnw8vJCVlYWOnfujIKCAnz++edIS0tD165dAQDLly9H06ZNsW/fPrRv3x7p6ek4fvw4tmzZAm9vb7Rq1QozZszApEmTkJCQAKVSiWXLliEgIABz5swBADRt2hS7d+/GvHnzEBkZafG8icj8WF+ISC7ugSIiu1VQUAAA8PT0BABkZWVBp9MhPDxcGtOkSRPUr18fmZmZAIDMzEwEBwfD29tbGhMZGYnCwkLk5ORIYx5chmGMYRlEVPmxvhBRabgHiojskl6vx9ixY9GhQwc0b94cAJCbmwulUgkPDw+jsd7e3sjNzZXGPPjlxjDfMK+sMYWFhbh9+zZcXFyM5mm1Wmi1WulxYWEhAECn00Gn05Wag2GeykHIylmOstZXXipH08VltNz/n+/j5m3KXC3BEK+9xf04zJGzJbYf60vZyzSF8tYXU9UNOcz9HqtMtaAy5QLIz8MsDdRff/2FSZMm4eeff8atW7fQqFEjLF++HG3atAEACCEwffp0/Pe//0V+fj46dOiApUuX4sknn5SWcfXqVbz55pv46aef4ODggH79+mHBggWoXr26NObIkSOIi4vDwYMHUadOHbz55puYOHGiOVIiIhsTFxeHY8eOYffu3dYOBcnJyUhMTCw2PT09Ha6uro98/ow2epPFsnHjRpMta3Y7ky2qRI+btylztSSNRmPtECzOlDnfunXLZMsqDetLyWyhvpgyn9JYqrZUplpQWXKRW19M3kBdu3YNHTp0wHPPPYeff/4ZderUwalTp1CzZk1pzOzZs7Fw4UJ8+eWXCAgIwNSpUxEZGYnjx4/D2dkZADBo0CBcvHhROpHztddew6hRo5CWlgbg/i8wERERCA8Px7Jly3D06FEMGzYMHh4eGDVqlKnTIiIbEh8fj/Xr12Pnzp2oV6+eNN3Hxwd3795Ffn6+0a/EeXl58PHxkcYcOHDAaHmGq2g9OObhK2vl5eVBrVYX+3UYACZPnozx48dLjwsLC+Hn54eIiAio1epS89DpdNBoNJh6yAFavUJm9mU7lmC6cyiaJ5jnpHaVg8CMNvrHztuUuVqC4fXu3r07nJycrB2ORZgjZ8MeGHNhfSmdNeuLqeqGHOauLZWpFlSmXAD59cXkDdSsWbPg5+eH5cuXS9MCAgKk/xdCYP78+ZgyZQp69+4NAPjqq6/g7e2NtWvXIiYmBidOnMCmTZtw8OBBaa/VokWL0LNnT3z88cfw9fVFamoq7t69iy+++AJKpRLNmjVDdnY25s6dywaKqJISQuDNN9/EDz/8gIyMDKPaAgAhISFwcnLC1q1b0a9fPwDAyZMnceHCBYSFhQEAwsLC8MEHH+DSpUvw8vICcP+XM7VajaCgIGnMw79AajQaaRkPU6lUUKlUxaY7OTnJ+oOi1SugLTLNFwJT/gEzVUylLv8x87bXP9Zy3xeViSlzNte2Y315NFuoL6bMpzSW+nxWplpQWXKRm4PJLyKxbt06tGnTBi+//DK8vLzQunVr/Pe//5Xmnz17Frm5uUYnULq7uyM0NNToJEwPDw+peQKA8PBwODg4YP/+/dKYzp07Q6lUSmMiIyNx8uRJXLt2zdRpEZENiIuLwzfffIO0tDTUqFEDubm5yM3Nxe3btwHcryXDhw/H+PHjsX37dmRlZeG1115DWFgY2rdvDwCIiIhAUFAQBg8ejF9//RWbN2/GlClTEBcXJ31JGT16NP744w9MnDgRv/32G5YsWYJVq1Zh3LhxVsudiMyL9YWI5DL5Hqg//vgDS5cuxfjx4/Huu+/i4MGDeOutt6BUKhEbGyudRFnSCZQPnmBp+OVGCrRaNXh6ehqNefjXoQdP1HzwkEGDipyIaesnYT6OynbinwHzsj5zxbh06VIAQJcuXYymL1++HEOHDgUAzJs3TzpvUqvVIjIyEkuWLJHGOjo6Yv369RgzZgzCwsLg5uaG2NhYJCUlSWMCAgKwYcMGjBs3DgsWLEC9evXw2Wef8RLDRJUY6wsRyWXyBkqv16NNmzb48MMPAQCtW7fGsWPHsGzZMsTGxpp6deXyOCdi2upJmKZQWU78exjzsh5zneQtxKN/yHB2dsbixYuxePHiUsf4+/s/8nPYpUsXHD58uNwxEpF9Yn0hIrlM3kDVrVtXOs7XoGnTpvj+++8B/N9JlHl5eahbt640Ji8vD61atZLGXLp0yWgZ9+7dw9WrVx95EuaD63hYRU7EtPWTMB9HZTvxz4B5WZ+5T/ImIiIishaTN1AdOnTAyZMnjab9/vvv8Pf3B3B/17WPjw+2bt0qNUyFhYXYv38/xowZA+D+CZb5+fnIyspCSEgIAGDbtm3Q6/UIDQ2Vxrz33nvQ6XTSl0mNRoPGjRuXePge8HgnYtrqSZimUFlO/HsY87IeW4+PiIiIqKJMfhGJcePGYd++ffjwww9x+vRppKWl4dNPP0VcXBwAQKFQYOzYsXj//fexbt06HD16FEOGDIGvry/69OkD4P4eqx49emDkyJE4cOAA9uzZg/j4eMTExMDX1xcAMHDgQCiVSgwfPhw5OTlYuXIlFixYYLSHiYiIiIiIyJRMvgeqbdu2+OGHHzB58mQkJSUhICAA8+fPx6BBg6QxEydOxM2bNzFq1Cjk5+ejY8eO2LRpk3QPKABITU1FfHw8unXrJp2wuXDhQmm+u7s70tPTERcXh5CQENSuXRvTpk3jJcyJiIiIiMhsTN5AAcDzzz+P559/vtT5CoUCSUlJRleleZinp6d009zStGjRArt27apwnEREREREROVh8kP4iIiIiIiIKis2UERERERERDKxgSIiIiIiIpKJDRQREREREZFMbKCIiIiIiIhkYgNFREREREQkExsoIiIiIiIimdhAERERERERycQGioiIiIiISCY2UERERERERDKxgSIiIiIiIpKJDRQREREREZFM1awdABERmU6DdzZYOwQiqqRYX4ju4x4oIiIiIiIimdhAERERERERycQGioiIiIiISCY2UERkN3bu3IlevXrB19cXCoUCa9euNZo/dOhQKBQKo389evQwGnP16lUMGjQIarUaHh4eGD58OG7cuGE05siRI+jUqROcnZ3h5+eH2bNnmzs1IrIy1hcikosNFBHZjZs3b6Jly5ZYvHhxqWN69OiBixcvSv++/fZbo/mDBg1CTk4ONBoN1q9fj507d2LUqFHS/MLCQkRERMDf3x9ZWVn46KOPkJCQgE8//dRseRGR9bG+EJFcvAofEdmNqKgoREVFlTlGpVLBx8enxHknTpzApk2bcPDgQbRp0wYAsGjRIvTs2RMff/wxfH19kZqairt37+KLL76AUqlEs2bNkJ2djblz5xp9ESLrM+UVwc7NjDbZssg+sb6QgamvNsj6UvmwgSKiSiUjIwNeXl6oWbMmunbtivfffx+1atUCAGRmZsLDw0P6cgMA4eHhcHBwwP79+/Hiiy8iMzMTnTt3hlKplMZERkZi1qxZuHbtGmrWrFlsnVqtFlqtVnpcWFgIANDpdNDpdKXGapinchCPl7SdMeRrS3mX9TqZeh2WWJetMEfO1tx+rC/WY4t1Q66HX6fKVAsqUy6A/DzYQBFRpdGjRw/07dsXAQEBOHPmDN59911ERUUhMzMTjo6OyM3NhZeXl9FzqlWrBk9PT+Tm5gIAcnNzERAQYDTG29tbmlfSF5zk5GQkJiYWm56eng5XV9dHxj2jjV52jpWJLeW9ceNGi61Lo9FYbF22wpQ537p1y2TLKg/WF9tgj/mUVl8qUy2oLLnIrS9soIio0oiJiZH+Pzg4GC1atEBgYCAyMjLQrVs3s6138uTJGD9+vPS4sLAQfn5+iIiIgFqtLvV5Op0OGo0GUw85QKtXmC0+W6NyEJjRRm9TeR9LiDT7Ogyvd/fu3eHk5GT29dkCc+Rs2ANjaawv1mWLdUOuh+tLZaoFlSkXQH59YQNF/6+9e4+Oor7/P/7a3DYESMItCSkBgygX5WaCYbkVJSRgtFJpFaWAluJXGvwWU7XSn+UitlEUUDSKVgVtpaA9gggUEoNcDSCRlIuWguI3UkkQkISAJJtkfn94MnXNhQE2u9nN83FOzmFnPjv7fk+ST/bF7MwAfqtr165q3769Dh8+rBEjRigmJkbHjx93GVNZWalTp06Z5zXExMSouLjYZUzN4/rOfbDb7bLb7bWWBwcHW/qDUl5tU3mVb70hcIem1Lcn//Bb/bnwJ+7suansO+YX7/DFfur7PvnTXOAvvVjtgavwAfBbR48e1cmTJ9WxY0dJksPh0OnTp5Wfn2+O2bhxo6qrq5WUlGSO2bJli8vnoHNyctS9e/c6P14DoHlifgGaLwIUAJ9RVlamgoICFRQUSJKOHDmigoICFRYWqqysTA899JB27NihL774Qrm5ubr11lvVrVs3paZ+9/GJnj17atSoUZoyZYp27dql7du3a9q0aRo3bpxiY2MlSXfddZdCQkI0efJkHThwQCtWrNCzzz7r8hEaAP6H+QWAVQQoAD5j9+7d6t+/v/r37y9JysjIUP/+/TVz5kwFBgZq7969+slPfqKrr75akydPVkJCgrZu3ery8Zc333xTPXr00IgRI3TTTTdpyJAhLvdgiYiIUHZ2to4cOaKEhAT99re/1cyZM7nEMODnmF8AWMU5UAB8xvDhw2UY9V/CdsOGDRfcRtu2bbVs2bIGx/Tp00dbt2696PoA+C7mFwBWcQQKAAAAACwiQAEAAACARQQoAAAAALCo0QPUE088IZvNpunTp5vLzp8/r/T0dLVr106tWrXS2LFja90XobCwUGlpaQoLC1NUVJQeeughVVZWuozZtGmTrrvuOtntdnXr1k1Lly5t7HYAAAAANGONGqA++ugjvfTSS+rTp4/L8gceeEDvvfee3n77bW3evFlfffWVbrvtNnN9VVWV0tLSVFFRoQ8//FCvv/66li5dqpkzZ5pjjhw5orS0NN1www0qKCjQ9OnT9atf/crSSZ4AAAAAcCkaLUCVlZVp/Pjx+vOf/+xyc7iSkhK9+uqrWrBggW688UYlJCRoyZIl+vDDD7Vjxw5JUnZ2tj755BP99a9/Vb9+/TR69GjNnTtXWVlZqqiokCQtXrxY8fHxmj9/vnr27Klp06bpZz/7mRYuXNhYLQEAAABo5hrtMubp6elKS0tTcnKyHn/8cXN5fn6+nE6nkpOTzWU9evRQ586dlZeXp4EDByovL0+9e/dWdHS0OSY1NVVTp07VgQMH1L9/f+Xl5blso2bM9z8q+EPl5eUqLy83H5eWlkqSnE6ny13Bv69muT2g/kubXqz6XsvTaupoKvW4C315ny/UCAAAcCkaJUAtX75cH3/8sT766KNa64qKihQSEqLIyEiX5dHR0SoqKjLHfD881ayvWdfQmNLSUn377bdq0aJFrdfOzMzUnDlzai3Pzs5WWFhYgz3NTaxucP3FWLdundu25Q45OTneLqFR0Jf3nDt3ztslAAAANAq3B6gvv/xSv/nNb5STk6PQ0FB3b/6yzJgxQxkZGebj0tJSxcXFKSUlReHh4XU+x+l0KicnR3/YHaDyaptb6tg/O9Ut27lcNb2NHDlSwcHB3i7HbejL+2qO7gIAAPgbtweo/Px8HT9+XNddd525rKqqSlu2bNHzzz+vDRs2qKKiQqdPn3Y5ClVcXKyYmBhJUkxMjHbt2uWy3Zqr9H1/zA+v3FdcXKzw8PA6jz5Jkt1ul91ur7U8ODj4gm9Iy6ttKq9yT4Bqam9+rfTvi+jLe5p6fQAAAJfK7ReRGDFihPbt26eCggLzKzExUePHjzf/HRwcrNzcXPM5Bw8eVGFhoRwOhyTJ4XBo3759On78uDkmJydH4eHh6tWrlznm+9uoGVOzDQAAAABwN7cfgWrdurWuvfZal2UtW7ZUu3btzOWTJ09WRkaG2rZtq/DwcN1///1yOBwaOHCgJCklJUW9evXShAkTNG/ePBUVFenRRx9Venq6eQTpvvvu0/PPP6+HH35Yv/zlL7Vx40a99dZbWrt2rbtbAgAAAABJjXgVvoYsXLhQAQEBGjt2rMrLy5WamqoXXnjBXB8YGKg1a9Zo6tSpcjgcatmypSZNmqTHHnvMHBMfH6+1a9fqgQce0LPPPqtOnTrplVdeUWpq0zi/CAAAAID/8UiA2rRpk8vj0NBQZWVlKSsrq97ndOnS5YJXqxs+fLj27NnjjhIBAAAA4IIa7Ua6AAAAAOBvCFAAAAAAYBEBCgAAAAAsIkABAAAAgEUEKAAAAACwiAAFAAAAABYRoAAAAADAIgIUAJ+xZcsW3XLLLYqNjZXNZtOqVatc1huGoZkzZ6pjx45q0aKFkpOTdejQIZcxp06d0vjx4xUeHq7IyEhNnjxZZWVlLmP27t2roUOHKjQ0VHFxcZo3b15jtwbAy5hfAFhFgALgM86ePau+ffvWexPuefPmadGiRVq8eLF27typli1bKjU1VefPnzfHjB8/XgcOHFBOTo7WrFmjLVu26N577zXXl5aWKiUlRV26dFF+fr6eeuopzZ49Wy+//HKj9wfAe5hfAFgV5O0CAMCq0aNHa/To0XWuMwxDzzzzjB599FHdeuutkqQ33nhD0dHRWrVqlcaNG6dPP/1U69ev10cffaTExERJ0nPPPaebbrpJTz/9tGJjY/Xmm2+qoqJCr732mkJCQnTNNdeooKBACxYscHkjBMC/ML8AsIoABcAvHDlyREVFRUpOTjaXRUREKCkpSXl5eRo3bpzy8vIUGRlpvrmRpOTkZAUEBGjnzp366U9/qry8PA0bNkwhISHmmNTUVD355JP65ptv1KZNm1qvXV5ervLycvNxaWmpJMnpdMrpdNZbc806e4Bx6Y37oJp+m1LfDX2f3P0annitpqIxevbG/mN+8b6mOG9Y9cPvkz/NBf7Ui2S9DwIUAL9QVFQkSYqOjnZZHh0dba4rKipSVFSUy/qgoCC1bdvWZUx8fHytbdSsq+sNTmZmpubMmVNreXZ2tsLCwi5Y+9zE6guO8UdNqe9169Z57LVycnI89lpNhTt7PnfunNu2ZRXzS9Phi/3UN7/401zgL71YnV8IUABwmWbMmKGMjAzzcWlpqeLi4pSSkqLw8PB6n+d0OpWTk6M/7A5QebXNE6U2CfYAQ3MTq5tU3/tnpzb6a9R8v0eOHKng4OBGf72moDF6rjkC01wwv3ynKc4bVv1wfvGnucCfepGszy8EKAB+ISYmRpJUXFysjh07msuLi4vVr18/c8zx48ddnldZWalTp06Zz4+JiVFxcbHLmJrHNWN+yG63y26311oeHBxs6Q9KebVN5VW+9YbAHZpS3578w2/158KfuLNnb+w75pemwxf7qe/75E9zgb/0YrUHrsIHwC/Ex8crJiZGubm55rLS0lLt3LlTDodDkuRwOHT69Gnl5+ebYzZu3Kjq6molJSWZY7Zs2eLyOeicnBx17969zo/XAPB/zC8Avo8ABcBnlJWVqaCgQAUFBZK+O7G7oKBAhYWFstlsmj59uh5//HGtXr1a+/bt08SJExUbG6sxY8ZIknr27KlRo0ZpypQp2rVrl7Zv365p06Zp3Lhxio2NlSTdddddCgkJ0eTJk3XgwAGtWLFCzz77rMtHaAD4H+YXAFbxET4APmP37t264YYbzMc1bzomTZqkpUuX6uGHH9bZs2d177336vTp0xoyZIjWr1+v0NBQ8zlvvvmmpk2bphEjRiggIEBjx47VokWLzPURERHKzs5Wenq6EhIS1L59e82cOZNLDAN+jvkFgFUEKAA+Y/jw4TKM+i9ha7PZ9Nhjj+mxxx6rd0zbtm21bNmyBl+nT58+2rp16yXXCcD3ML8AsIqP8AEAAACARQQoAAAAALCIAAUAAAAAFhGgAAAAAMAiAhQAAAAAWESAAgAAAACLCFAAAAAAYBEBCgAAAAAsIkABAAAAgEUEKAAAAACwKMjbBQAA4G1XPLLWrdv74ok0t24PgO/64fxiDzQ073rp2tkbVF5lu+jtMb94n9uPQGVmZmrAgAFq3bq1oqKiNGbMGB08eNBlzPnz55Wenq527dqpVatWGjt2rIqLi13GFBYWKi0tTWFhYYqKitJDDz2kyspKlzGbNm3SddddJ7vdrm7dumnp0qXubgcAAAAATG4PUJs3b1Z6erp27NihnJwcOZ1OpaSk6OzZs+aYBx54QO+9957efvttbd68WV999ZVuu+02c31VVZXS0tJUUVGhDz/8UK+//rqWLl2qmTNnmmOOHDmitLQ03XDDDSooKND06dP1q1/9Shs2bHB3SwAAAAAgqRE+wrd+/XqXx0uXLlVUVJTy8/M1bNgwlZSU6NVXX9WyZct04403SpKWLFminj17aseOHRo4cKCys7P1ySef6P3331d0dLT69eunuXPn6ne/+51mz56tkJAQLV68WPHx8Zo/f74kqWfPntq2bZsWLlyo1NRUd7cFAAAAAI1/EYmSkhJJUtu2bSVJ+fn5cjqdSk5ONsf06NFDnTt3Vl5eniQpLy9PvXv3VnR0tDkmNTVVpaWlOnDggDnm+9uoGVOzDQAAAABwt0a9iER1dbWmT5+uwYMH69prr5UkFRUVKSQkRJGRkS5jo6OjVVRUZI75fniqWV+zrqExpaWl+vbbb9WiRYta9ZSXl6u8vNx8XFpaKklyOp1yOp119lCz3B5gWOrZivpey9Nq6mgq9bgLfXmfL9QIAABwKRo1QKWnp2v//v3atm1bY76MZZmZmZozZ06t5dnZ2QoLC2vwuXMTq91Wx7p169y2LXfIycnxdgmNgr6859y5c94uAQAAoFE0WoCaNm2a1qxZoy1btqhTp07m8piYGFVUVOj06dMuR6GKi4sVExNjjtm1a5fL9mqu0vf9MT+8cl9xcbHCw8PrPPokSTNmzFBGRob5uLS0VHFxcUpJSVF4eHidz3E6ncrJydEfdgeovPriLzVZl/2zm8Y5WjW9jRw5UsHBwd4ux23oy/tqju4CAAD4G7cHKMMwdP/992vlypXatGmT4uPjXdYnJCQoODhYubm5Gjt2rCTp4MGDKiwslMPhkCQ5HA798Y9/1PHjxxUVFSXpu/91Dw8PV69evcwxPzySk5OTY26jLna7XXa7vdby4ODgC74hLa+2XdK1+uvS1N78WunfF9GX9zT1+gAAAC6V2wNUenq6li1bpnfffVetW7c2z1mKiIhQixYtFBERocmTJysjI0Nt27ZVeHi47r//fjkcDg0cOFCSlJKSol69emnChAmaN2+eioqK9Oijjyo9Pd0MQPfdd5+ef/55Pfzww/rlL3+pjRs36q233tLate69GSIAAAAA1HD7VfhefPFFlZSUaPjw4erYsaP5tWLFCnPMwoULdfPNN2vs2LEaNmyYYmJi9M4775jrAwMDtWbNGgUGBsrhcOgXv/iFJk6cqMcee8wcEx8fr7Vr1yonJ0d9+/bV/Pnz9corr3AJc6CZmz17tmw2m8tXjx49zPXuupE3gOaFuQVAjUb5CN+FhIaGKisrS1lZWfWO6dKlywUvtjB8+HDt2bPnomsE4N+uueYavf/+++bjoKD/TnUPPPCA1q5dq7ffflsRERGaNm2abrvtNm3fvl3Sf2/kHRMTow8//FDHjh3TxIkTFRwcrD/96U8e7wVA08HcAkBq5KvwAYA3BAUFmRec+T533cgbQPPE3AJA8sCNdAHA0w4dOqTY2Fh17dpV48ePV2FhoST33cgbQPPE3AJA4ggUAD+TlJSkpUuXqnv37jp27JjmzJmjoUOHav/+/W67kfcPXcpNumvWS+69UbcvqOnXn/uu6/vuSzfDdpfG6Nlb+88bc4vE/FLDn+aNy+2lKc0h/javWe2DAAXAr4wePdr8d58+fZSUlKQuXbrorbfeqvcecZfrcm7SLbn3Rt2+xJ/7bugcXl+4Gba7ubNnb92o2xtzi8T88kP+1M+l9nKhawR4g7/Ma1bnFwIUAL8WGRmpq6++WocPH9bIkSPdciPvH7qUm3RLjXOjbl9gDzA0N7Har/uu64bpvnQzbHdpjJ6byo26PTG3SMwvNfxp3rjcXuqaX7zF3+Y1q/MLAQqAXysrK9Nnn32mCRMmuO1G3j90OTfpltx7o25f4s99N/R994WbYbubO3tuKvvOE3OLxPzyQ/7Uz6X20lR+B77PX+Y1qz0QoAD4lQcffFC33HKLunTpoq+++kqzZs1SYGCg7rzzTrfdyBtA88PcAqAGAQqAXzl69KjuvPNOnTx5Uh06dNCQIUO0Y8cOdejQQdJ3N/IOCAjQ2LFjVV5ertTUVL3wwgvm82tu5D116lQ5HA61bNlSkyZNcrmRN4Dmh7kFQA0CFAC/snz58gbXu+tG3gCaF+YWADW4DxQAAAAAWESAAgAAAACLCFAAAAAAYBEBCgAAAAAsIkABAAAAgEUEKAAAAACwiMuYAwDgZlc8srbWMnugoXnXS9fO3qDyKpvlbX3xRJo7SwPg4+qaXy4V88ul4QgUAAAAAFhEgAIAAAAAiwhQAAAAAGARAQoAAAAALCJAAQAAAIBFBCgAAAAAsIgABQAAAAAWEaAAAAAAwCJupAsAQBPmzptmStw4E8B/Xe788sMbhDeX+YUABbgBb3AAAACaBwKUH7jUN+8//F8DqWm/cbfaZ1191aUp9+pu7gx4zWm/AQAA/BDnQAEAAACARRyBQrPl7o/dAQAAwP8RoLygKb9xb8q1NSd1fR+sfjQRAAAAjcfnP8KXlZWlK664QqGhoUpKStKuXbu8XRIAP8H8AqCxML8Avsunj0CtWLFCGRkZWrx4sZKSkvTMM88oNTVVBw8eVFRUlLfLA+DDmF/gr7iojPcxv8BfNZf5xaePQC1YsEBTpkzRPffco169emnx4sUKCwvTa6+95u3SAPg45hcAjYX5BfBtPnsEqqKiQvn5+ZoxY4a5LCAgQMnJycrLy6vzOeXl5SovLzcfl5SUSJJOnTolp9NZ53OcTqfOnTunIGeAqqr967yToGpD585V+11v9NW4Tp48ecExZ86ckSQZhtHY5TSKi51fLmVukfx7fmlIU/lZ9jR/7PtC80HNz/jJkycVHBzsltdkfmme84s//f7QizVW3m+4m9X5xWcD1IkTJ1RVVaXo6GiX5dHR0frXv/5V53MyMzM1Z86cWsvj4+MbpUZfcJe3C2gk9NV42s+3PvbMmTOKiIhovGIaycXOL8wtF68p/Cx7g7/1fTHzgbsxvzS/+cWffn/o5cKa8vziswHqUsyYMUMZGRnm4+rqap06dUrt2rWTzVZ3ai4tLVVcXJy+/PJLhYeHe6pUj/DX3ujL+wzD0JkzZxQbG+vtUjziUuYWybe+p+5E382n78bomfmlec4v/tQPvTRdVucXnw1Q7du3V2BgoIqLi12WFxcXKyYmps7n2O122e12l2WRkZGWXi88PNwvfjDq4q+90Zd3+eL/DNe42PnlcuYWyXe+p+5G382Hu3tmfom0/Hr+9vPmT/3QS9NkZX7x2YtIhISEKCEhQbm5ueay6upq5ebmyuFweLEyAL6O+QVAY2F+AXyfzx6BkqSMjAxNmjRJiYmJuv766/XMM8/o7Nmzuueee7xdGgAfx/wCoLEwvwC+zacD1B133KGvv/5aM2fOVFFRkfr166f169fXOjHzctjtds2aNavW4XN/4K+90Rfcgfml8dB38+m7OfZsBfPLxfOnfujF99kMX70OKAAAAAB4mM+eAwUAAAAAnkaAAgAAAACLCFAAAAAAYBEBCgAAAAAsIkBdQFZWlq644gqFhoYqKSlJu3bt8nZJDdqyZYtuueUWxcbGymazadWqVS7rDcPQzJkz1bFjR7Vo0ULJyck6dOiQy5hTp05p/PjxCg8PV2RkpCZPnqyysjIPdlFbZmamBgwYoNatWysqKkpjxozRwYMHXcacP39e6enpateunVq1aqWxY8fWulFhYWGh0tLSFBYWpqioKD300EOqrKz0ZCsuXnzxRfXp08e8AZ3D4dA//vEPc70v9gTrfG1+uVjumI98jbvmKl/jjrkM7tXU55fZs2fLZrO5fPXo0cNc39T//nnq/dbevXs1dOhQhYaGKi4uTvPmzfN4L3fffXet79WoUaOaZC8eY6Bey5cvN0JCQozXXnvNOHDggDFlyhQjMjLSKC4u9nZp9Vq3bp3x//7f/zPeeecdQ5KxcuVKl/VPPPGEERERYaxatcr45z//afzkJz8x4uPjjW+//dYcM2rUKKNv377Gjh07jK1btxrdunUz7rzzTg934io1NdVYsmSJsX//fqOgoMC46aabjM6dOxtlZWXmmPvuu8+Ii4szcnNzjd27dxsDBw40Bg0aZK6vrKw0rr32WiM5OdnYs2ePsW7dOqN9+/bGjBkzvNGSYRiGsXr1amPt2rXGv//9b+PgwYPG73//eyM4ONjYv3+/YRi+2ROs8cX55WK5Yz7yNe6Yq3zR5c5lcC9fmF9mzZplXHPNNcaxY8fMr6+//tpc39T//nni/VZJSYkRHR1tjB8/3ti/f7/xt7/9zWjRooXx0ksvebSXSZMmGaNGjXL5Xp06dcplTFPpxVMIUA24/vrrjfT0dPNxVVWVERsba2RmZnqxKut++EtQXV1txMTEGE899ZS57PTp04bdbjf+9re/GYZhGJ988okhyfjoo4/MMf/4xz8Mm81m/Oc///FY7Rdy/PhxQ5KxefNmwzC+6yM4ONh4++23zTGffvqpIcnIy8szDOO7CSIgIMAoKioyx7z44otGeHi4UV5e7tkGGtCmTRvjlVde8aueUJuvzy8X61LmI39wKXOVv7iYuQzu5Qvzy6xZs4y+ffvWuc7X/v411vutF154wWjTpo1LP7/73e+M7t27e6wXw/guQN166631Pqep9tKY+AhfPSoqKpSfn6/k5GRzWUBAgJKTk5WXl+fFyi7dkSNHVFRU5NJTRESEkpKSzJ7y8vIUGRmpxMREc0xycrICAgK0c+dOj9dcn5KSEklS27ZtJUn5+flyOp0uvfXo0UOdO3d26a13794uNypMTU1VaWmpDhw44MHq61ZVVaXly5fr7NmzcjgcftET6uaP88vFsjIf+YNLmat83aXMZXAfX5pfDh06pNjYWHXt2lXjx49XYWGhJN//m+6u91t5eXkaNmyYQkJCzDGpqak6ePCgvvnmGw91851NmzYpKipK3bt319SpU3Xy5Elzna/14g4EqHqcOHFCVVVVte4KHh0draKiIi9VdXlq6m6op6KiIkVFRbmsDwoKUtu2bZtM39XV1Zo+fboGDx6sa6+9VtJ3dYeEhCgyMtJl7A97q6v3mnXesm/fPrVq1Up2u1333XefVq5cqV69evl0T2iYP84vF8vKfOTrLnWu8lWXM5fBfXxlfklKStLSpUu1fv16vfjiizpy5IiGDh2qM2fO+PzfP3e932oqPY4aNUpvvPGGcnNz9eSTT2rz5s0aPXq0qqqqzFp8pRd3CfJ2AcDFSk9P1/79+7Vt2zZvl+IW3bt3V0FBgUpKSvT3v/9dkyZN0ubNm71dFoDL5G9z1YUwl+FijB492vx3nz59lJSUpC5duuitt95SixYtvFgZfmjcuHHmv3v37q0+ffroyiuv1KZNmzRixAgvVuY9HIGqR/v27RUYGFjrii/FxcWKiYnxUlWXp6buhnqKiYnR8ePHXdZXVlbq1KlTTaLvadOmac2aNfrggw/UqVMnc3lMTIwqKip0+vRpl/E/7K2u3mvWeUtISIi6deumhIQEZWZmqm/fvnr22Wd9uic0zB/nl4tlZT7yZZczV/mqy5nL4D6+Or9ERkbq6quv1uHDh33+75+73m811R67du2q9u3b6/Dhw2YtvtrLpSJA1SMkJEQJCQnKzc01l1VXVys3N1cOh8OLlV26+Ph4xcTEuPRUWlqqnTt3mj05HA6dPn1a+fn55piNGzequrpaSUlJHq+5hmEYmjZtmlauXKmNGzcqPj7eZX1CQoKCg4Ndejt48KAKCwtdetu3b5/LL3lOTo7Cw8PVq1cvzzRiQXV1tcrLy/2qJ7jyx/nlYlmZj3yRO+Yqf3Excxncx1fnl7KyMn322Wfq2LGjz//9c9f7LYfDoS1btsjpdJpjcnJy1L17d7Vp08ZD3dR29OhRnTx5Uh07dpTk271cMm9fxaIpW758uWG3242lS5can3zyiXHvvfcakZGRLld8aWrOnDlj7Nmzx9izZ48hyViwYIGxZ88e4//+7/8Mw/juspqRkZHGu+++a+zdu9e49dZb67ysZv/+/Y2dO3ca27ZtM6666iqvX8Z86tSpRkREhLFp0yaXy2ieO3fOHHPfffcZnTt3NjZu3Gjs3r3bcDgchsPhMNfXXPI0JSXFKCgoMNavX2906NDBq5f8fuSRR4zNmzcbR44cMfbu3Ws88sgjhs1mM7Kzsw3D8M2eYI0vzi8Xyx3zka9xx1zliy53LoN7+cL88tvf/tbYtGmTceTIEWP79u1GcnKy0b59e+P48eOGYTT9v3+eeL91+vRpIzo62pgwYYKxf/9+Y/ny5UZYWJjbL/3dUC9nzpwxHnzwQSMvL884cuSI8f777xvXXXedcdVVVxnnz59vcr14CgHqAp577jmjc+fORkhIiHH99dcbO3bs8HZJDfrggw8MSbW+Jk2aZBjGd5fW/MMf/mBER0cbdrvdGDFihHHw4EGXbZw8edK48847jVatWhnh4eHGPffcY5w5c8YL3fxXXT1JMpYsWWKO+fbbb41f//rXRps2bYywsDDjpz/9qXHs2DGX7XzxxRfG6NGjjRYtWhjt27c3fvvb3xpOp9PD3fzXL3/5S6NLly5GSEiI0aFDB2PEiBHmGw7D8M2eYJ2vzS8Xyx3zka9x11zla9wxl8G9mvr8cscddxgdO3Y0QkJCjB/96EfGHXfcYRw+fNhc39T//nnq/dY///lPY8iQIYbdbjd+9KMfGU888YRHezl37pyRkpJidOjQwQgODja6dOliTJkypVYYbyq9eIrNMAyjcY9xAQAAAIB/4BwoAAAAALCIAAUAAAAAFhGgAAAAAMAiAhQAAAAAWESAAgAAAACLCFAAAAAAYBEBCgAAAAAsIkABAAAAgEUEKAAAAACwiAAFAAAAABYRoAAAAADAIgIUAAAAAFhEgAIAAAAAiwhQAAAAAGARAQoAAAAALCJAAQAAAIBFBCgAAAAAsIgABQAAAAAWEaAAAAAAwCICFAAAAABYRICCi9mzZ8tms3m7DBeVlZV6+OGHFRcXp4CAAI0ZM8bbJdXyxRdfyGaz6emnn/Z2KQAAAGhEBCh4nNPp1KJFizRgwAC1bt1arVq10oABA7Ro0SI5nc5a41977TU99dRT+tnPfqbXX39dDzzwgMLDw3XrrbfWGrtw4ULZbDZNmjSp1rqZM2fKZrPp3//+d6P0BQAAAP8X5O0C0LycPXtWaWlp2rx5s26++WbdfffdCggI0Pr16/Wb3/xG77zzjtauXauWLVuaz9m4caN+9KMfaeHCheaygQMH6sMPP6y1/e3btysoKEjbt2+vc11UVJSuvvrqxmkOAAAAfo8jUPCojIwMbd68Wc8995zee+89paena+rUqXr33Xf1/PPPa/PmzXrwwQddnnP8+HFFRka6LBsyZIhOnDihTz/91GX59u3bdfvtt+uzzz5TUVGRubyyslI7d+7U4MGDG603AAAA+D8CVDO2bds2DRgwQKGhobryyiv10ksv1RqzZMkS3XjjjYqKipLdblevXr304osvuoyZNGmS2rdvX+fH71JSUtS9e3dJ0tGjR/Xqq6/qxhtv1LRp02qNTU9P1w033KBXXnlFR48eNc8r+uCDD3TgwAHZbDbZbDZt2rRJQ4YMkSSXI02ff/65ioqKNG3aNIWGhrqsKygo0NmzZ83nSdK//vUv/exnP1Pbtm0VGhqqxMRErV69ulZdp0+f1vTp0xUXFye73a5u3brpySefVHV1dYP71zAM3XvvvQoJCdE777zT4FgAAAD4BgJUM7Vv3z6lpKTo+PHjmj17tu655x7NmjVLK1eudBn34osvqkuXLvr973+v+fPnKy4uTr/+9a+VlZVljpkwYYJOnjypDRs2uDy3qKhIGzdu1C9+8QtJ0j/+8Q9VVVVp4sSJ9dY1ceJEVVZWav369erQoYP+8pe/qEePHurUqZP+8pe/6C9/+Yt69uypgQMHKigoSNu2bTOfu337drVs2VIDBgxQYmKiS4Cq+XdNgDpw4IAGDhyoTz/9VI888ojmz5+vli1basyYMS774Ny5c/rxj3+sv/71r5o4caIWLVqkwYMHa8aMGcrIyKi3j6qqKt1999164403tHLlSt122231jgUAAIAPMdAsjRkzxggNDTX+7//+z1z2ySefGIGBgcb3fyzOnTtX67mpqalG165dzcdVVVVGp06djDvuuMNl3IIFCwybzWZ8/vnnhmEYxvTp0w1Jxp49e+qt6+OPPzYkGRkZGeayH//4x8Y111xTa+yAAQOMK6+80nz8P//zP8YNN9xgGIZhPPzww8aAAQPMdT/72c+MsLAww+l0GoZhGCNGjDB69+5tnD9/3hxTXV1tDBo0yLjqqqvMZXPnzjVatmxp/Pvf/3Z57UceecQIDAw0CgsLDcMwjCNHjhiSjKeeespwOp3GHXfcYbRo0cLYsGFDvb0CAADA93AEqhmqqqrShg0bNGbMGHXu3Nlc3rNnT6WmprqMbdGihfnvkpISnThxQj/+8Y/1+eefq6SkRJIUEBCg8ePHa/Xq1Tpz5ow5/s0339SgQYMUHx8vSea61q1b11tbzbrS0tIL9jFkyBCXc522b9+uQYMGSZIGDx6sPXv26Ny5c+a6pKQkBQUF6dSpU9q4caNuv/12nTlzRidOnNCJEyd08uRJpaam6tChQ/rPf/4jSXr77bc1dOhQtWnTxhx34sQJJScnq6qqSlu2bHGpqaKiQj//+c+1Zs0arVu3TikpKRfsAwAAAL6DANUMff311/r222911VVX1VpXc75Sje3btys5OVktW7ZUZGSkOnTooN///veSZAYo6buP3n377bfmx98OHjyo/Px8TZgwwRxTE46+H7J+yErIqvH986BOnz6tAwcOmBeJGDRokCorK7Vr1y4dOXJEx44dM8cfPnxYhmHoD3/4gzp06ODyNWvWLEnfXbhCkg4dOmR+nPD7X8nJyS7jamRmZmrVqlX6+9//ruHDh1+wBwAAAPgWLmOOen322WcaMWKEevTooQULFiguLk4hISFat26dFi5c6HIRhV69eikhIcE8V+ivf/2rQkJCdPvtt5tjevbsKUnau3ev+vXrV+dr7t2719zehdQEom3btiksLEyS5HA4JEnt27fXVVddpW3btunLL790GV9T94MPPljriFuNbt26mWNHjhyphx9+uM5xP7wkempqqtavX6958+Zp+PDhCg0NvWAfAAAA8B0EqGaoQ4cOatGihQ4dOlRr3cGDB81/v/feeyovL9fq1atdPur3wQcf1LndiRMnKiMjQ8eOHdOyZcuUlpamNm3amOtHjx6twMBA/eUvf6n3QhJvvPGGgoKCNGrUqAv2ERUVZYakli1bqlevXi6XOx80aJC2b9+uo0ePKjAw0AxXXbt2lSQFBwebR5Lqc+WVV6qsrOyC42oMHDhQ9913n26++Wb9/Oc/18qVKxUUxK8ZAACAv+AjfM1QYGCgUlNTtWrVKhUWFprLP/30U5cr6QUGBkr67nLcNUpKSrRkyZI6t3vnnXfKZrPpN7/5jT7//HPz6ns14uLidM899+j999+vdSl0SVq8eLE2btyoyZMnq1OnTpZ6GTJkiAoKCpSdnW2e/1Rj0KBBysvL09atW9WnTx/zY4FRUVEaPny4XnrpJR07dqzWNr/++mvz37fffrvy8vJqXWFQ+u7y5pWVlbWWJycna/ny5Vq/fr0mTJhwwcudAwAAwHfwX+PN1Jw5c7R+/XoNHTpUv/71r1VZWannnntO11xzjfkxupSUFIWEhOiWW27R//zP/6isrEx//vOfFRUVVWfw6NChg0aNGqW3335bkZGRSktLqzVm4cKF+te//qVf//rXWr9+vXmkacOGDXr33Xf14x//WPPnz7fcx5AhQ7RkyRJ99NFHSk9Pd1k3aNAglZSUqKSkRPfff7/LuqysLA0ZMkS9e/fWlClT1LVrVxUXFysvL09Hjx7VP//5T0nSQw89pNWrV+vmm2/W3XffrYSEBJ09e1b79u3T3//+d33xxRdq3759rbrGjBmjJUuWaOLEiQoPD6/zHlsAAADwQd6+DCC8Z/PmzUZCQoIREhJidO3a1Vi8eLExa9Ysl8uYr1692ujTp48RGhpqXHHFFcaTTz5pvPbaa4Yk48iRI7W2+dZbbxmSjHvvvbfe1y0vLzcWLlxoJCQkGC1btjTCwsKM6667znjmmWeMioqKWuPru4y5YRjGwYMHDUmGpFqXGq+urjYiIyMNScaKFStqPfezzz4zJk6caMTExBjBwcHGj370I+Pmm282/v73v7uMO3PmjDFjxgyjW7duRkhIiNG+fXtj0KBBxtNPP23W+/3LmH/fCy+8YEgyHnzwwXr3BwAAAHyHzTC+9/ks4DK9++67GjNmjLZs2aKhQ4d6uxwAAADArQhQcKubb75Zn376qQ4fPiybzebtcgAAAAC34hwouMXy5cu1d+9erV27Vs8++yzhCQAAAH6JI1BwC5vNplatWumOO+7Q4sWLuXQ3AAAA/BLvcuEW5HAAAAA0B9wHCgAAAAAsIkABAAAAgEXN+iN81dXV+uqrr9S6dWsuegC4kWEYOnPmjGJjYxUQwP/TAAAA/9GsA9RXX32luLg4b5cB+K0vv/xSnTp18nYZAAAAbtOsA1Tr1q0lffcmLzw8vM4xTqdT2dnZSklJUXBwsCfLa1LYD+wDyfo+KC0tVVxcnPk7BgAA4C+adYCq+dheeHh4gwEqLCxM4eHhzfZNs8R+kNgH0sXvAz4aCwAA/A0nJwAAAACARQQoAAAAALCIAAUAAAAAFhGgAAAAAMAiAhQAAAAAWESAAgAAAACL3B6gMjMzNWDAALVu3VpRUVEaM2aMDh486DLm/PnzSk9PV7t27dSqVSuNHTtWxcXFLmMKCwuVlpamsLAwRUVF6aGHHlJlZaXLmE2bNum6666T3W5Xt27dtHTpUne3AwAAAAAmtweozZs3Kz09XTt27FBOTo6cTqdSUlJ09uxZc8wDDzyg9957T2+//bY2b96sr776Srfddpu5vqqqSmlpaaqoqNCHH36o119/XUuXLtXMmTPNMUeOHFFaWppuuOEGFRQUaPr06frVr36lDRs2uLslAAAAAJDUCDfSXb9+vcvjpUuXKioqSvn5+Ro2bJhKSkr06quvatmyZbrxxhslSUuWLFHPnj21Y8cODRw4UNnZ2frkk0/0/vvvKzo6Wv369dPcuXP1u9/9TrNnz1ZISIgWL16s+Ph4zZ8/X5LUs2dPbdu2TQsXLlRqaqq729K1szeovMo9NwX94ok0t2wHAAAAgGc1+jlQJSUlkqS2bdtKkvLz8+V0OpWcnGyO6dGjhzp37qy8vDxJUl5ennr37q3o6GhzTGpqqkpLS3XgwAFzzPe3UTOmZhsAAAAA4G5uPwL1fdXV1Zo+fboGDx6sa6+9VpJUVFSkkJAQRUZGuoyNjo5WUVGROeb74almfc26hsaUlpbq22+/VYsWLWrVU15ervLycvNxaWmpJMnpdMrpdNbZQ81ye4BhqWcr6nutpqymZl+s3V3YB9b3QXPeRwAAwL81aoBKT0/X/v37tW3btsZ8GcsyMzM1Z86cWsuzs7MVFhbW4HPnJla7rY5169a5bVuelpOT4+0SvI59cOF9cO7cOQ9VAgAA4FmNFqCmTZumNWvWaMuWLerUqZO5PCYmRhUVFTp9+rTLUaji4mLFxMSYY3bt2uWyvZqr9H1/zA+v3FdcXKzw8PA6jz5J0owZM5SRkWE+Li0tVVxcnFJSUhQeHl7nc5xOp3JycvSH3QEqr3bPOVD7Z7v/HK3GVrMfRo4cqeDgYG+X4xbXzr64C47YAwzNTayu82fBF7+nl8Lqz0HN0V0AAAB/4/YAZRiG7r//fq1cuVKbNm1SfHy8y/qEhAQFBwcrNzdXY8eOlSQdPHhQhYWFcjgckiSHw6E//vGPOn78uKKioiR99z/e4eHh6tWrlznmh0dycnJyzG3UxW63y26311oeHBx8wVBQXm1z20UkfDmAWNlXvuJSv591/Sz4yz6x6kI/B81tfwAAgObD7QEqPT1dy5Yt07vvvqvWrVub5yxFRESoRYsWioiI0OTJk5WRkaG2bdsqPDxc999/vxwOhwYOHChJSklJUa9evTRhwgTNmzdPRUVFevTRR5Wenm4GoPvuu0/PP/+8Hn74Yf3yl7/Uxo0b9dZbb2nt2rXubgkAAAAAJDXCVfhefPFFlZSUaPjw4erYsaP5tWLFCnPMwoULdfPNN2vs2LEaNmyYYmJi9M4775jrAwMDtWbNGgUGBsrhcOgXv/iFJk6cqMcee8wcEx8fr7Vr1yonJ0d9+/bV/Pnz9corrzTKJcwBAAAAQGqkj/BdSGhoqLKyspSVlVXvmC5dulzwYgvDhw/Xnj17LrpG1O+KR+o+gmcPNDTv+ou/Hxb3vAIAAIA/adSr8KFu9YWUS0VIAQAAADyj0W+kCwAAAAD+giNQ8BnuPnLXlHGUEgAAoGniCBQAAAAAWESAAgAAAACLCFAAAAAAYBEBCgAAAAAsIkABAAAAgEUEKAAAAACwiAAFAAAAABYRoAAAAADAIgIUAAAAAFhEgAIAAAAAiwhQAAAAAGARAQoAAAAALCJAAQAAAIBFBCgAAAAAsIgABQAAAAAWEaAAAAAAwCICFAAAAABYRIACAAAAAIsIUAAAAABgEQEKAAAAACwiQAEAAACARQQoAAAAALCIAAUAAAAAFhGgAAAAAMAiAhQAAAAAWESAAgAAAACLCFAAAAAAYBEBCgAAAAAsIkABAAAAgEUEKAAAAACwiAAFAAAAABYRoAAAAADAIgIUAAAAAFhEgAIAAAAAiwhQAAAAAGARAQoAAAAALCJAAQAAAIBFbg9QW7Zs0S233KLY2FjZbDatWrXKZf3dd98tm83m8jVq1CiXMadOndL48eMVHh6uyMhITZ48WWVlZS5j9u7dq6FDhyo0NFRxcXGaN2+eu1sBAAAAABduD1Bnz55V3759lZWVVe+YUaNG6dixY+bX3/72N5f148eP14EDB5STk6M1a9Zoy5Ytuvfee831paWlSklJUZcuXZSfn6+nnnpKs2fP1ssvv+zudgAAAADAFOTuDY4ePVqjR49ucIzdbldMTEyd6z799FOtX79eH330kRITEyVJzz33nG666SY9/fTTio2N1ZtvvqmKigq99tprCgkJ0TXXXKOCggItWLDAJWgBAAAAgDu5PUBZsWnTJkVFRalNmza68cYb9fjjj6tdu3aSpLy8PEVGRprhSZKSk5MVEBCgnTt36qc//any8vI0bNgwhYSEmGNSU1P15JNP6ptvvlGbNm3qfN3y8nKVl5ebj0tLSyVJTqdTTqezzufULLcHGJfXdCOqr/ZLYQ+su8+a/i92P3iiNk9paB+4s0/J/b26q76a7Vxoe+7eHwAAAE2FxwPUqFGjdNtttyk+Pl6fffaZfv/732v06NHKy8tTYGCgioqKFBUV5VpkUJDatm2roqIiSVJRUZHi4+NdxkRHR5vr6gtQmZmZmjNnTq3l2dnZCgsLa7DuuYnVlnv0tHXr1rltW/Oub3j9xe4HT9bmKXXtA3f2Kbm/V3fXl5OT0+D6c+fOufX1AAAAmgqPB6hx48aZ/+7du7f69OmjK6+8Ups2bdKIESMa9bVnzJihjIwM83Fpaani4uKUkpKi8PDwOp/jdDqVk5OjP+wOUHm1rVHru1T7Z6e6bVvXzt5Q53J7gKG5idUXvR88UZunNLQP3Nmn5P5e3VVfze/DyJEjFRwcXO+4mqO7AAAA/sYrH+H7vq5du6p9+/Y6fPiwRowYoZiYGB0/ftxlTGVlpU6dOmWeNxUTE6Pi4mKXMTWP6zu3Svru3Cu73V5reXBwcINvBiWpvNqm8qqmGaAuVPvFuFCPF7sfPFmbp9S1D9zZp+T+Xt1d34V+Z9z9egAAAE2F1+8DdfToUZ08eVIdO3aUJDkcDp0+fVr5+fnmmI0bN6q6ulpJSUnmmC1btricZ5GTk6Pu3bvX+/E9AAAAALhcbg9QZWVlKigoUEFBgSTpyJEjKigoUGFhocrKyvTQQw9px44d+uKLL5Sbm6tbb71V3bp1U2rqdx8x6tmzp0aNGqUpU6Zo165d2r59u6ZNm6Zx48YpNjZWknTXXXcpJCREkydP1oEDB7RixQo9++yzLh/PAwAAAAB3c3uA2r17t/r376/+/ftLkjIyMtS/f3/NnDlTgYGB2rt3r37yk5/o6quv1uTJk5WQkKCtW7e6fLTuzTffVI8ePTRixAjddNNNGjJkiMs9niIiIpSdna0jR44oISFBv/3tbzVz5kwuYQ4AAACgUbn9HKjhw4fLMOq/BPOGDRc+Ob5t27ZatmxZg2P69OmjrVu3XnR9AAAAAHCpvH4OFAAAAAD4CgIUAAAAAFhEgAIAAAAAiwhQAAAAAGARAQoAAAAALCJAAQAAAIBFBCgAAAAAsIgABQAAAAAWEaAAAAAAwCICFAAAAABYRIACAAAAAIsIUAAAAABgUZC3CwDQ+K54ZK1btmMPNDTverdsCgAAwCdxBAoAAAAALCJAAQAAAIBFBCgAAAAAsIgABQAAAAAWEaAAAAAAwCICFAAAAABYRIACAAAAAIsIUAAAAABgEQEKAAAAACwiQAEAAACARQQoAAAAALCIAAUAAAAAFhGgAAAAAMAiAhQAAAAAWESAAgAAAACLCFAAAAAAYBEBCgAAAAAsIkABAAAAgEUEKAAAAACwiAAFAAAAABYRoAAAAADAIgIUAAAAAFhEgAIAAAAAiwhQAAAAAGARAQoAAAAALCJAAQAAAIBFbg9QW7Zs0S233KLY2FjZbDatWrXKZb1hGJo5c6Y6duyoFi1aKDk5WYcOHXIZc+rUKY0fP17h4eGKjIzU5MmTVVZW5jJm7969Gjp0qEJDQxUXF6d58+a5uxUAAAAAcOH2AHX27Fn17dtXWVlZda6fN2+eFi1apMWLF2vnzp1q2bKlUlNTdf78eXPM+PHjdeDAAeXk5GjNmjXasmWL7r33XnN9aWmpUlJS1KVLF+Xn5+upp57S7Nmz9fLLL7u7HQAAAAAwBbl7g6NHj9bo0aPrXGcYhp555hk9+uijuvXWWyVJb7zxhqKjo7Vq1SqNGzdOn376qdavX6+PPvpIiYmJkqTnnntON910k55++mnFxsbqzTffVEVFhV577TWFhITommuuUUFBgRYsWOAStAAAAADAndweoBpy5MgRFRUVKTk52VwWERGhpKQk5eXlady4ccrLy1NkZKQZniQpOTlZAQEB2rlzp376058qLy9Pw4YNU0hIiDkmNTVVTz75pL755hu1adOmztcvLy9XeXm5+bi0tFSS5HQ65XQ663xOzXJ7gHHpjTey+mq/FPbAuvus6f9i94MnavOUhvaBO/uUvN9rfWp6v1C/7t4fAAAATYVHA1RRUZEkKTo62mV5dHS0ua6oqEhRUVEu64OCgtS2bVuXMfHx8bW2UbOuvgCVmZmpOXPm1FqenZ2tsLCwBmufm1jd4HpvWrdundu2Ne/6htdf7H7wZG2eUtc+cGefUtPptT45OTkNrj937pyHKgEAAPAsjwYob5sxY4YyMjLMx6WlpYqLi1NKSorCw8PrfI7T6VROTo7+sDtA5dU2T5V6UfbPTnXbtq6dvaHO5fYAQ3MTqy96P3iiNk9paB+4s0/J+73Wp2YfjBw5UsHBwfWOqzm6CwAA4G88GqBiYmIkScXFxerYsaO5vLi4WP369TPHHD9+3OV5lZWVOnXqlPn8mJgYFRcXu4ypeVwzpi52u112u73W8uDg4AbfDEpSebVN5VVNM0BdqPaLcaEeL3Y/eLI2T6lrH7izT6np9FqfC/3OuHt/AAAANBUevQ9UfHy8YmJilJubay4rLS3Vzp075XA4JEkOh0OnT59Wfn6+OWbjxo2qrq5WUlKSOWbLli0u51nk5OSoe/fu9X58DwAAAAAul9sDVFlZmQoKClRQUCDpuwtHFBQUqLCwUDabTdOnT9fjjz+u1atXa9++fZo4caJiY2M1ZswYSVLPnj01atQoTZkyRbt27dL27ds1bdo0jRs3TrGxsZKku+66SyEhIZo8ebIOHDigFStW6Nlnn3X5eB4AAAAAuJvbP8K3e/du3XDDDebjmlAzadIkLV26VA8//LDOnj2re++9V6dPn9aQIUO0fv16hYaGms958803NW3aNI0YMUIBAQEaO3asFi1aZK6PiIhQdna20tPTlZCQoPbt22vmzJlcwhwAAABAo3J7gBo+fLgMo/5LMNtsNj322GN67LHH6h3Ttm1bLVu2rMHX6dOnj7Zu3XrJdQIAAADAxfLoOVAAAAAA4MsIUAAAAABgEQEKAAAAACwiQAEAAACARQQoAAAAALCIAAUAAAAAFhGgAAAAAMAiAhQAAAAAWESAAgAAAACLCFAAAAAAYBEBCgAAAAAsIkABAAAAgEUEKAAAAACwiAAFAAAAABYRoAAAAADAIgIUAAAAAFhEgAIAAAAAiwhQAAAAAGARAQoAAAAALCJAAQAAAIBFBCgAAAAAsIgABQAAAAAWEaAAAAAAwCICFAAAAABYRIACAAAAAIsIUAAAAABgEQEKAAAAACwiQAEAAACARQQoAAAAALCIAAUAAAAAFhGgAAAAAMAiAhQAAAAAWESAAgAAAACLCFAAAAAAYBEBCgAAAAAsIkABAAAAgEUEKAAAAACwiAAFAAAAABYRoAAAAADAIq8EqNmzZ8tms7l89ejRw1x//vx5paenq127dmrVqpXGjh2r4uJil20UFhYqLS1NYWFhioqK0kMPPaTKykpPtwIAAACgGQny1gtfc801ev/99/9bSNB/S3nggQe0du1avf3224qIiNC0adN02223afv27ZKkqqoqpaWlKSYmRh9++KGOHTumiRMnKjg4WH/605883gsAAACA5sFrASooKEgxMTG1lpeUlOjVV1/VsmXLdOONN0qSlixZop49e2rHjh0aOHCgsrOz9cknn+j9999XdHS0+vXrp7lz5+p3v/udZs+erZCQEE+3AwAAAKAZ8FqAOnTokGJjYxUaGiqHw6HMzEx17txZ+fn5cjqdSk5ONsf26NFDnTt3Vl5engYOHKi8vDz17t1b0dHR5pjU1FRNnTpVBw4cUP/+/et8zfLycpWXl5uPS0tLJUlOp1NOp7PO59QstwcYl91zY6mv9kthD6y7z5r+L3Y/eKI2T2loH7izT8n7vdanpvcL9evu/QEAANBUeCVAJSUlaenSperevbuOHTumOXPmaOjQodq/f7+KiooUEhKiyMhIl+dER0erqKhIklRUVOQSnmrW16yrT2ZmpubMmVNreXZ2tsLCwhqseW5itZXWvGLdunVu29a86xtef7H7wZO1eUpd+8CdfUpNp9f65OTkNLj+3LlzHqoEAADAs7wSoEaPHm3+u0+fPkpKSlKXLl301ltvqUWLFo32ujNmzFBGRob5uLS0VHFxcUpJSVF4eHidz3E6ncrJydEfdgeovNrWaLVdjv2zU922rWtnb6hzuT3A0NzE6oveD56ozVMa2gfu7FPyfq/1qdkHI0eOVHBwcL3jao7uAgAA+BuvfYTv+yIjI3X11Vfr8OHDGjlypCoqKnT69GmXo1DFxcXmOVMxMTHatWuXyzZqrtJX13lVNex2u+x2e63lwcHBDb4ZlKTyapvKq5pmgLpQ7RfjQj1e7H7wZG2eUtc+cGefUtPptT4X+p1x9/4AAABoKprEfaDKysr02WefqWPHjkpISFBwcLByc3PN9QcPHlRhYaEcDockyeFwaN++fTp+/Lg5JicnR+Hh4erVq5fH6wcAAADQPHjlCNSDDz6oW265RV26dNFXX32lWbNmKTAwUHfeeaciIiI0efJkZWRkqG3btgoPD9f9998vh8OhgQMHSpJSUlLUq1cvTZgwQfPmzVNRUZEeffRRpaen13mECQAAAADcwSsB6ujRo7rzzjt18uRJdejQQUOGDNGOHTvUoUMHSdLChQsVEBCgsWPHqry8XKmpqXrhhRfM5wcGBmrNmjWaOnWqHA6HWrZsqUmTJumxxx7zRjsAAAAAmgmvBKjly5c3uD40NFRZWVnKysqqd0yXLl3cfuUzAAAAAGhIkzgHCgAAAAB8AQEKAAAAACwiQAEAAACARQQoAAAAALCIAAUAAAAAFhGgAAAAAMAiAhQAAAAAWESAAgAAAACLCFAAAAAAYBEBCgAAAAAsIkABAAAAgEUEKAAAAACwiAAFAAAAABYRoAAAAADAIgIUAAAAAFhEgAIAAAAAiwhQAAAAAGARAQoAAAAALCJAAQAAAIBFBCgAAAAAsIgABQAAAAAWEaAAAAAAwCICFAAAAABYRIACAAAAAIsIUAAAAABgEQEKAAAAACwiQAEAAACARQQoAAAAALCIAAUAAAAAFhGgAAAAAMAiAhQAAAAAWESAAgAAAACLCFAAAAAAYBEBCgAAAAAsIkABAAAAgEUEKAAAAACwiAAFAAAAABYRoAAAAADAIgIUAAAAAFjk8wEqKytLV1xxhUJDQ5WUlKRdu3Z5uyQAAAAAfsqnA9SKFSuUkZGhWbNm6eOPP1bfvn2Vmpqq48ePe7s0AAAAAH7IpwPUggULNGXKFN1zzz3q1auXFi9erLCwML322mveLg0AAACAHwrydgGXqqKiQvn5+ZoxY4a5LCAgQMnJycrLy6vzOeXl5SovLzcfl5SUSJJOnTolp9NZ53OcTqfOnTunIGeAqqptbuzAfU6ePOm2bQVVnq17ebWhc+eqL3o/eKI2T2loH7izT8n7vdanZh+cPHlSwcHB9Y47c+aMJMkwDE+VBgAA4BE+G6BOnDihqqoqRUdHuyyPjo7Wv/71rzqfk5mZqTlz5tRaHh8f3yg1ekr7+Z55nbsu4Tmeqs1T6tsH/tZnQy7m5+DMmTOKiIhotFoAAAA8zWcD1KWYMWOGMjIyzMfV1dU6deqU2rVrJ5ut7qMqpaWliouL05dffqnw8HBPldrksB/YB5L1fWAYhs6cOaPY2FgPVgcAAND4fDZAtW/fXoGBgSouLnZZXlxcrJiYmDqfY7fbZbfbXZZFRkZaer3w8PBm+6b5+9gP7APJ2j7gyBMAAPBHPnsRiZCQECUkJCg3N9dcVl1drdzcXDkcDi9WBgAAAMBf+ewRKEnKyMjQpEmTlJiYqOuvv17PPPOMzp49q3vuucfbpQEAAADwQz4doO644w59/fXXmjlzpoqKitSvXz+tX7++1oUlLofdbtesWbNqffSvuWE/sA8k9gEAAIDN4DrDAAAAAGCJz54DBQAAAACeRoACAAAAAIsIUAAAAABgEQEKAAAAACwiQF1AVlaWrrjiCoWGhiopKUm7du3ydkkek5mZqQEDBqh169aKiorSmDFjdPDgQW+X5VVPPPGEbDabpk+f7u1SPO4///mPfvGLX6hdu3Zq0aKFevfurd27d3u7LAAAAI8iQDVgxYoVysjI0KxZs/Txxx+rb9++Sk1N1fHjx71dmkds3rxZ6enp2rFjh3JycuR0OpWSkqKzZ896uzSv+Oijj/TSSy+pT58+3i7F47755hsNHjxYwcHB+sc//qFPPvlE8+fPV5s2bbxdGgAAgEdxGfMGJCUlacCAAXr++eclSdXV1YqLi9P999+vRx55xMvVed7XX3+tqKgobd68WcOGDfN2OR5VVlam6667Ti+88IIef/xx9evXT88884y3y/KYRx55RNu3b9fWrVu9XQoAAIBXcQSqHhUVFcrPz1dycrK5LCAgQMnJycrLy/NiZd5TUlIiSWrbtq2XK/G89PR0paWlufw8NCerV69WYmKifv7znysqKkr9+/fXn//8Z2+XBQAA4HEEqHqcOHFCVVVVio6OdlkeHR2toqIiL1XlPdXV1Zo+fboGDx6sa6+91tvleNTy5cv18ccfKzMz09uleM3nn3+uF198UVdddZU2bNigqVOn6n//93/1+uuve7s0AAAAjwrydgHwDenp6dq/f7+2bdvm7VI86ssvv9RvfvMb5eTkKDQ01NvleE11dbUSExP1pz/9SZLUv39/7d+/X4sXL9akSZO8XB0AAIDncASqHu3bt1dgYKCKi4tdlhcXFysmJsZLVXnHtGnTtGbNGn3wwQfq1KmTt8vxqPz8fB0/flzXXXedgoKCFBQUpM2bN2vRokUKCgpSVVWVt0v0iI4dO6pXr14uy3r27KnCwkIvVQQAAOAdBKh6hISEKCEhQbm5ueay6upq5ebmyuFweLEyzzEMQ9OmTdPKlSu1ceNGxcfHe7skjxsxYoT27dungoIC8ysxMVHjx49XQUGBAgMDvV2iRwwePLjWJez//e9/q0uXLl6qCAAAwDv4CF8DMjIyNGnSJCUmJur666/XM888o7Nnz+qee+7xdmkekZ6ermXLlundd99V69atzXO/IiIi1KJFCy9X5xmtW7eudc5Xy5Yt1a5du2Z1LtgDDzygQYMG6U9/+pNuv/127dq1Sy+//LJefvllb5cGAADgUVzG/AKef/55PfXUUyoqKlK/fv20aNEiJSUlebssj7DZbHUuX7Jkie6++27PFtOEDB8+vNldxlyS1qxZoxkzZujQoUOKj49XRkaGpkyZ4u2yAAAAPIoABQAAAAAWcQ4UAAAAAFhEgAIAAAAAiwhQAAAAAGARAQoAAAAALCJAAQAAAIBFBCgAAAAAsIgABQAAAAAWEaAAAAAAwCICFAAAAABYRIACAAAAAIsIUAAAAABgEQEKAAAAACz6/3iTn/BEFYojAAAAAElFTkSuQmCC\n"
-          },
-          "metadata": {}
-        }
-      ],
-      "source": [
-        "pd_flights.select_dtypes(include=np.number).hist(figsize=[10,10])\n",
-        "plt.show()"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 58,
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2021-12-15T20:25:01.270515Z",
-          "iopub.status.busy": "2021-12-15T20:25:01.269865Z",
-          "iopub.status.idle": "2021-12-15T20:25:02.205574Z",
-          "shell.execute_reply": "2021-12-15T20:25:02.205194Z"
-        },
-        "pycharm": {
-          "is_executing": false
-        },
-        "id": "VylFZ0feNRFp",
-        "outputId": "63b16fa7-8293-4460-f845-959aa93e3c7c",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 853
-        }
-      },
-      "outputs": [
-        {
-          "output_type": "display_data",
-          "data": {
-            "text/plain": [
-              "<Figure size 1000x1000 with 9 Axes>"
-            ],
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAA1AAAANECAYAAAC+XM68AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjcuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/bCgiHAAAACXBIWXMAAA9hAAAPYQGoP6dpAADRcElEQVR4nOzdeVhUdfs/8PeAzLDogKiAJCJiqSguoSK5ZIogkmlahppibmlQj/qkZrkAVqjlnsvTU0kL5FJmpqaMC664kaSimZrLUwnmAriOI/P5/eFvzteRxQPOCu/XdXnVnPOZc+77zMzN3HM2hRBCgIiIiIiIiB7JwdoBEBERERER2Qs2UERERERERDKxgSIiIiIiIpKJDRQREREREZFMbKCIiIiIiIhkYgNFREREREQkExsoIiIiIiIimdhAERERERERycQGioiIiIiISCY2UGRWDRo0wNChQ8v1nIyMDCgUCnz33XfmCcqEEhISoFAorB0GUYXw/Vu6Ll26oEuXLtLjc+fOQaFQICUlxWoxEdF9rF3yGL5PZWRkSNOGDh2KBg0aWC2myoINVCWyZMkSKBQKhIaGmm0dhg+jnH+2YsmSJSV+6Xk4FycnJzRs2BBDhgzBH3/8YflAiR5TSkqK0Xva2dkZvr6+iIyMxMKFC3H9+vXHXsfff/+NhIQEZGdnP37AFjZ06FBUr1692PQjR46gdu3aaNCgAc6dO2f5wEzoww8/xNq1a60dBlG5sHaVbejQoVAoFFCr1bh9+3ax+adOnZK23ccff2yFCKueatYOgEwnNTUVDRo0wIEDB3D69Gk0atTI5Oto2rQpvv76a6NpkydPRvXq1fHee+8VG3/y5Ek4OFi3T1+yZAlq165d6p6wt956C23btoVOp8Mvv/yCTz/9FBs2bMDRo0fh6+tb5rKnTJmCd955xwxRE1VcUlISAgICoNPpkJubi4yMDIwdOxZz587FunXr0KJFCwAVe//+/fffSExMRIMGDdCqVSszRG9Zx44dQ7du3eDm5obt27dLv8ymp6dbN7AK+vDDD/HSSy+hT58+1g6FqNxYu0pXrVo13Lp1Cz/99BP69+9vNC81NRXOzs64c+eO0fTOnTvj9u3bUCqVlgy1SmADVUmcPXsWe/fuxZo1a/D6668jNTUV06dPN/l6vL298eqrrxpNmzlzJmrXrl1sOgCoVCqTx2BqnTp1wksvvQQAeO211/DUU0/hrbfewpdffonJkyeX+JybN2/Czc0N1apVQ7Vq/BiRbYmKikKbNm2kx5MnT8a2bdvw/PPP44UXXsCJEyfg4uJS5d+/OTk56Nq1K1xcXLB9+3YEBARI8/iF4//cuXMHSqXS6j+GUeXH2lU6lUqFDh064Ntvvy3WQKWlpSE6Ohrff/+90XQHBwc4OztbMswqg9WwkkhNTUXNmjURHR2Nl156CampqQAAnU4HT09PvPbaa8WeU1hYCGdnZ7z99tvStPPnz+OFF16Am5sbvLy8MG7cOGzevLnYMbRylXQOVH5+PsaNG4cGDRpApVKhXr16GDJkCC5fvlzqcrRaLZ5//nm4u7tj7969AAC9Xo/58+ejWbNmcHZ2hre3N15//XVcu3bNaP05OTnYsWOHtHv7wfMaStK1a1cA95tS4P+OtT5+/DgGDhyImjVromPHjkbzHvbNN9+gXbt2cHV1Rc2aNdG5c+div2j//PPP6NSpE9zc3FCjRg1ER0cjJyenzNiIKqpr166YOnUqzp8/j2+++QZAye9fjUaDjh07wsPDA9WrV0fjxo3x7rvvArh/2Gvbtm0B3P+xwfCZMhwiu2vXLrz88suoX78+VCoV/Pz8MG7cuGKHnBgOpfvrr7/Qp08fVK9eHXXq1MHbb7+NoqIio7F6vR4LFixAcHAwnJ2dUadOHfTo0QOHDh0yGvfNN98gJCQELi4u8PT0RExMDP73v/+Vuj1OnDiBbt26QaVSYfv27WjYsKHR/IfPgSrNtm3bpM+xh4cHevfujRMnThiNMWzn33//Ha+++irc3d1Rp04dTJ06FUII/O9//0Pv3r2hVqvh4+ODOXPmFFuPVqvF9OnT0ahRI2nbTpw4EVqtVhqjUChw8+ZNfPnll9Jr82D9/euvvzBs2DB4e3tDpVKhWbNm+OKLL4zWYzi0ecWKFZgyZQqeeOIJuLq6orCwEDqdDomJiXjyySfh7OyMWrVqoWPHjtBoNI/cTkQVxdr1fwYOHIiff/4Z+fn50rSDBw/i1KlTGDhwYLHxJZ0DVRI536cA4NChQ4iMjETt2rXh4uKCgIAADBs2rMxlV1ZVq32vxFJTU9G3b18olUoMGDAAS5cuxcGDB9G2bVu8+OKLWLNmDf7zn/8Y/aq6du1aaLVaxMTEALi/V6Vr1664ePEi/vWvf8HHxwdpaWnYvn27yeK8ceMGOnXqhBMnTmDYsGF4+umncfnyZaxbtw5//vknateuXew5t2/fRu/evXHo0CFs2bJFKoKvv/46UlJS8Nprr+Gtt97C2bNn8cknn+Dw4cPYs2cPnJycMH/+fLz55ptGhxh6e3uXGeOZM2cAALVq1TKa/vLLL+PJJ5/Ehx9+CCFEqc9PTExEQkICnnnmGSQlJUGpVGL//v3Ytm0bIiIiAABff/01YmNjERkZiVmzZuHWrVtYunQpOnbsiMOHD/METzKLwYMH491330V6ejpGjhxZbH5OTg6ef/55tGjRAklJSVCpVDh9+jT27NkD4P4hvElJSZg2bRpGjRqFTp06AQCeeeYZAMDq1atx69YtjBkzBrVq1cKBAwewaNEi/Pnnn1i9erXRuoqKihAZGYnQ0FB8/PHH2LJlC+bMmYPAwECMGTNGGjd8+HCkpKQgKioKI0aMwL1797Br1y7s27dP+qX6gw8+wNSpU9G/f3+MGDEC//zzDxYtWoTOnTvj8OHD8PDwMFr3yZMn0bVrV1SrVg3bt29HYGBghbbnli1bEBUVhYYNGyIhIQG3b9/GokWL0KFDB/zyyy/FPsevvPIKmjZtipkzZ2LDhg14//334enpif/85z/o2rUrZs2ahdTUVLz99tto27YtOnfuDOD+l5sXXngBu3fvxqhRo9C0aVMcPXoU8+bNw++//y6d8/T1119jxIgRaNeuHUaNGgUAUm55eXlo3749FAoF4uPjUadOHfz8888YPnw4CgsLMXbsWKNYZ8yYAaVSibfffhtarRZKpRIJCQlITk6W1lFYWIhDhw7hl19+Qffu3Su0DYnkYO26r2/fvhg9ejTWrFkjNS5paWlo0qQJnn766QpvXznfpy5duoSIiAjUqVMH77zzDjw8PHDu3DmsWbOmwuu1a4Ls3qFDhwQAodFohBBC6PV6Ua9ePfGvf/1LCCHE5s2bBQDx008/GT2vZ8+eomHDhtLjOXPmCABi7dq10rTbt2+LJk2aCABi+/btJa6/WbNm4tlnny1xnr+/v4iNjZUeT5s2TQAQa9asKTZWr9cLIYTYvn27ACBWr14trl+/Lp599llRu3ZtcfjwYWnsrl27BACRmppqtIxNmzYVm15afIb1fPHFF+Kff/4Rf//9t9iwYYNo0KCBUCgU4uDBg0IIIaZPny4AiAEDBhRbhmGewalTp4SDg4N48cUXRVFRUYn5Xb9+XXh4eIiRI0cazc/NzRXu7u7FphPJtXz5cgFAeu+WxN3dXbRu3VoIUfz9O2/ePAFA/PPPP6U+/+DBgwKAWL58ebF5t27dKjYtOTlZKBQKcf78eWlabGysACCSkpKMxrZu3VqEhIRIj7dt2yYAiLfeeqvYcg2fp3PnzglHR0fxwQcfGM0/evSoqFatmtH02NhY4eTkJOrWrSt8fX3F77//Xmqezz77rFHdOHv2bLG8W7VqJby8vMSVK1ekab/++qtwcHAQQ4YMkaYZtvOoUaOkaffu3RP16tUTCoVCzJw5U5p+7do14eLiYlQ3v/76a+Hg4CB27dplFOOyZcsEALFnzx5pmpubm9FzDYYPHy7q1q0rLl++bDQ9JiZGuLu7S6+doS42bNiw2OvZsmVLER0dXcLWIno8rF3/p7Ta5ebmJoQQ4qWXXhLdunUTQghRVFQkfHx8RGJiolSjPvroI+l5hs/zg9/fYmNjhb+/v/RY7vepH3744ZGvUVXCQ/gqgdTUVHh7e+O5554DcP8wjldeeQUrVqxAUVERunbtitq1a2PlypXSc65duwaNRoNXXnlFmrZp0yY88cQTeOGFF6Rpzs7OJf7aU1Hff/89WrZsiRdffLHYvId3xxcUFCAiIgK//fYbMjIyjE76XL16Ndzd3dG9e3dcvnxZ+hcSEoLq1auXa6/ZsGHDUKdOHfj6+iI6Olo6BObB47ABYPTo0Y9c1tq1a6HX6zFt2rRi5wsY8tNoNMjPz8eAAQOMYnd0dERoaKhJ9/gRPax69eqlXtHK8Gvnjz/+CL1eX+5lu7i4SP9/8+ZNXL58Gc888wyEEDh8+HCx8Q9/pjp16mR0Bczvv/8eCoWixPM5DZ+nNWvWQK/Xo3///kafJx8fHzz55JPFPk9FRUW4fPkyPD09S9zjLdfFixeRnZ2NoUOHwtPTU5reokULdO/eHRs3biz2nBEjRkj/7+joiDZt2kAIgeHDh0vTPTw80LhxY6PtsHr1ajRt2hRNmjQxytFwuPGjaoYQAt9//z169eoFIYTRMiIjI1FQUIBffvnF6DmxsbFGr6chtpycHJw6dUrGFiIyrapeuwwGDhyIjIwM5ObmYtu2bcjNzS3x8D255H6fMmzj9evXQ6fTVXh9lQUP4bNzRUVFWLFiBZ577jnpnB0ACA0NxZw5c7B161ZERESgX79+SEtLg1arhUqlwpo1a6DT6YwaqPPnzyMwMLBYI2PKq/mdOXMG/fr1kzV27NixuHPnDg4fPoxmzZoZzTt16hQKCgrg5eVV4nMvXbokO6Zp06ahU6dOcHR0RO3atdG0adMST0598ATz0pw5cwYODg4ICgoqdYzhy4fhy8/D1Gq1zMiJyu/GjRulfm5eeeUVfPbZZxgxYgTeeecddOvWDX379sVLL70k6wICFy5cwLRp07Bu3bpix84XFBQYPTacE/CgmjVrGj3vzJkz8PX1NWpQHnbq1CkIIfDkk0+WON/JycnosYuLCz777DMMGjQI0dHR0Gg0cHNze2RuDzt//jwAoHHjxsXmNW3aFJs3b5YuNmNQv359o3Hu7u5wdnYu1si5u7vjypUr0uNTp07hxIkTxbaXwaPq3T///IP8/Hx8+umn+PTTT2Uto6R6l5SUhN69e+Opp55C8+bN0aNHDwwePFi6MhqROVX12mXQs2dP1KhRAytXrkR2djbatm2LRo0aVfgWDHK/Tz377LPo168fEhMTMW/ePHTp0gV9+vTBwIED7eKCYabGBsrObdu2DRcvXsSKFSuwYsWKYvNTU1MRERGBmJgY/Oc//8HPP/+MPn36YNWqVWjSpAlatmxphajl6d27N1asWIGZM2fiq6++MiqCer0eXl5e0sUyHlbaF42SBAcHIzw8/JHjHv41tqIMv459/fXX8PHxKTa/ql1ZiCznzz//REFBQak/iri4uGDnzp3Yvn07NmzYgE2bNmHlypXo2rUr0tPT4ejoWOqyi4qK0L17d1y9ehWTJk1CkyZN4Obmhr/++gtDhw4t9qtwWcsqD71eD4VCgZ9//rnEZZZ036eYmBhcu3YNb7zxBvr27YuffvrJIlfdKym+0raDeOA8S71ej+DgYMydO7fEsX5+fmWu17DtX331VcTGxpY45uEmqKR617lzZ5w5cwY//vgj0tPT8dlnn2HevHlYtmyZ0d41IlNj7fo/KpUKffv2xZdffok//vgDCQkJjx2HnO9TCoUC3333Hfbt24effvoJmzdvxrBhwzBnzhzs27ev1HgrK35Ts3Opqanw8vLC4sWLi81bs2YNfvjhByxbtgydO3dG3bp1sXLlSnTs2BHbtm0rdt8mf39/HD9+HEIIo71Qp0+fNlm8gYGBOHbsmKyxffr0QUREBIYOHYoaNWpg6dKlRsvZsmULOnTo8MjGxpI39Q0MDIRer8fx48dLvc+E4aRuLy8vWY0bkakY7uEWGRlZ6hgHBwd069YN3bp1w9y5c/Hhhx/ivffew/bt2xEeHl7q5+no0aP4/fff8eWXX2LIkCHS9Me5QltgYCA2b96Mq1evlvpLbmBgIIQQCAgIwFNPPSV72WPGjMHVq1cxZcoUvPrqq1ixYkW5LtPt7+8P4P4FKR7222+/oXbt2hXas1WSwMBA/Prrr+jWrdsj61lJ8+vUqYMaNWqgqKjosWuO4aqur732Gm7cuIHOnTsjISGBDRSZFWuXsYEDB+KLL76Ag4ODdCGwx4lV7vcpAGjfvj3at2+PDz74AGlpaRg0aBBWrFhR5WoAz4GyY7dv38aaNWvw/PPP46WXXir2Lz4+HtevX8e6devg4OCAl156CT/99BO+/vpr3Lt3z+jwPeB+Yfrrr7+wbt06adqdO3fw3//+12Qx9+vXD7/++it++OGHYvNECVe2GzJkCBYuXIhly5Zh0qRJ0vT+/fujqKgIM2bMKPace/fuGV3i083NzeixOfXp0wcODg5ISkoq9quVIb/IyEio1Wp8+OGHJR5H/M8//1gkVqpatm3bhhkzZiAgIACDBg0qcczVq1eLTTP8EGC4XLahKXj4M2X4BfXBz7EQAgsWLKhwzP369YMQAomJicXmGdbTt29fODo6IjExsVgNEUIYHQr3sPfeew/jxo3D6tWr8frrr5crtrp166JVq1b48ssvjbbFsWPHkJ6ejp49e5ZreWXp378//vrrrxJr8e3bt3Hz5k3pcUn1ztHREf369cP3339f4g9YcmvOw9uyevXqaNSokdGl1IlMjbWruOeeew4zZszAJ598UuKRLOUh9/vUtWvXisX58DauSrgHyo6tW7cO169fN7row4Pat2+POnXqIDU1Fa+88gpeeeUVLFq0CNOnT0dwcDCaNm1qNP7111/HJ598ggEDBuBf//oX6tatK93dGjDNnpwJEybgu+++w8svv4xhw4YhJCQEV69exbp167Bs2bISDymMj49HYWEh3nvvPbi7u+Pdd9/Fs88+i9dffx3JycnIzs5GREQEnJyccOrUKaxevRoLFiyQbo4bEhKCpUuX4v3330ejRo3g5eVV6vlHj6tRo0Z47733MGPGDHTq1Al9+/aFSqXCwYMH4evri+TkZKjVaixduhSDBw/G008/jZiYGNSpUwcXLlzAhg0b0KFDB3zyySdmiY+qhp9//hm//fYb7t27h7y8PGzbtg0ajQb+/v5Yt25dqTdWTEpKws6dOxEdHQ1/f39cunQJS5YsQb169aR7nwUGBsLDwwPLli1DjRo14ObmhtDQUDRp0gSBgYF4++238ddff0GtVuP7778vdj5BeTz33HMYPHgwFi5ciFOnTqFHjx7Q6/XYtWsXnnvuOcTHxyMwMBDvv/8+Jk+ejHPnzqFPnz6oUaMGzp49ix9++AGjRo0yutfdw+bMmYNr167hs88+g6enJ2bNmiU7vo8++ghRUVEICwvD8OHDpcuYu7u7P/ZhNQ8aPHgwVq1ahdGjR2P79u3o0KEDioqK8Ntvv2HVqlXYvHmzdNGbkJAQbNmyBXPnzoWvry8CAgIQGhqKmTNnYvv27QgNDcXIkSMRFBSEq1ev4pdffsGWLVtK/AL6sKCgIHTp0gUhISHw9PTEoUOH8N133yE+Pt5kuVLVxtolr3Y5ODhgypQpFY7vQXK/T3355ZdYsmQJXnzxRQQGBuL69ev473//C7VabdIfjOyGpS73R6bXq1cv4ezsLG7evFnqmKFDhwonJydx+fJlodfrhZ+fnwAg3n///RLH//HHHyI6Olq4uLiIOnXqiH//+9/i+++/FwDEvn37SnxOeS5jLoQQV65cEfHx8eKJJ54QSqVS1KtXT8TGxkqX133wMuYPmjhxogAgPvnkE2nap59+KkJCQoSLi4uoUaOGCA4OFhMnThR///23NCY3N1dER0eLGjVqCABSrKWt52GGy6WWdHnUhy+lavDFF1+I1q1bC5VKJWrWrCmeffZZ6TLzBtu3bxeRkZHC3d1dODs7i8DAQDF06FBx6NChMuMhKo3hUsCGf0qlUvj4+Iju3buLBQsWiMLCQqPxD79/t27dKnr37i18fX2FUqkUvr6+YsCAAcUu9/3jjz+KoKAgUa1aNaPLAh8/flyEh4eL6tWri9q1a4uRI0eKX3/9tdilgx+8JG9Z8Qhx/3LfH330kWjSpIlQKpWiTp06IioqSmRlZRmN+/7770XHjh2Fm5ubcHNzE02aNBFxcXHi5MmTj1zvvXv3RJ8+fQQAkZycLISQdxlzIYTYsmWL6NChg3BxcRFqtVr06tVLHD9+vMS8Hq4hpcXz7LPPimbNmhlNu3v3rpg1a5Zo1qyZVFdCQkJEYmKiKCgokMb99ttvonPnzsLFxUUAMKq/eXl5Ii4uTvj5+QknJyfh4+MjunXrJj799FNpTFl18f333xft2rUTHh4ewsXFRTRp0kR88MEH4u7du8XGEpUHa1fFateDKnoZc4NHfZ/65ZdfxIABA0T9+vWFSqUSXl5e4vnnn6+y31kUQpRxR1AiAPPnz8e4cePw559/4oknnrB2OEREREREVsMGiozcvn3b6CTCO3fuoHXr1igqKsLvv/9uxciIiIiIiKyP50CRkb59+6J+/fpo1aoVCgoK8M033+C3334r9fKWRERERERVCRsoMhIZGYnPPvsMqampKCoqQlBQEFasWFHsin1ERERERFURD+EjIiIiIiKSifeBIiIiIiIikokNFBERERERkUxV+hwovV6Pv//+GzVq1DDJTWKJ6D4hBK5fvw5fX184OFS932lYW4jMh/WF9YXIXOTWlyrdQP3999/w8/OzdhhEldb//vc/1KtXz9phWBxrC5H5sb4Qkbk8qr5U6QaqRo0aAO5vJLVabeVoAJ1Oh/T0dERERMDJycna4chibzHbW7yA/cWs0+mwdu1ajBgxQvqMVTVya4u9vbYlqQw5AJUjj6qSQ2FhIfz8/FhfqkB9sRZuu8djz9tPbn2p0g2UYde3Wq22mQbK1dUVarXabt5w9hazvcUL2F/MhngBVNnDS+TWFnt7bUtSGXIAKkceVS0H1pfKX1+shdvu8VSG7feo+lL1Dh4mIru1dOlStGjRQvriEBYWhp9//lmaf+fOHcTFxaFWrVqoXr06+vXrh7y8PKNlXLhwAdHR0XB1dYWXlxcmTJiAe/fuGY3JyMjA008/DZVKhUaNGiElJcUS6RGRFbG+EJFcbKCIyG7Uq1cPM2fORFZWFg4dOoSuXbuid+/eyMnJAQCMGzcOP/30E1avXo0dO3bg77//Rt++faXnFxUVITo6Gnfv3sXevXvx5ZdfIiUlBdOmTZPGnD17FtHR0XjuueeQnZ2NsWPHYsSIEdi8ebPF8yUiy2F9ISK5qvQhfERkX3r16mX0+IMPPsDSpUuxb98+1KtXD59//jnS0tLQtWtXAMDy5cvRtGlT7Nu3D+3bt0d6ejqOHz+OLVu2wNvbG61atcKMGTMwadIkJCQkQKlUYtmyZQgICMCcOXMAAE2bNsXu3bsxb948REZGWjxnIrIM1hcikosNFBHZpaKiIqxevRo3b95EWFgYsrKyoNPpEB4eLo1p0qQJ6tevj8zMTLRv3x6ZmZkIDg6Gt7e3NCYyMhJjxoxBTk4OWrdujczMTKNlGMaMHTu21Fi0Wi20Wq30uLCwEMD948B1Ol2pzzPMK2uMrasMOQCVI4+qkoMl8mN9qdq47R6PPW8/uTGzgSIiu3L06FGEhYXhzp07qF69On744QcEBQUhOzsbSqUSHh4eRuO9vb2Rm5sLAMjNzTX6cmOYb5hX1pjCwkLcvn0bLi4uxWJKTk5GYmJisenp6enSBTXKotFoHjnG1lWGHIDKkUdlz+HWrVtmWy/rCz2I2+7x2OP2k1tf2EARkV1p3LgxsrOzUVBQgO+++w6xsbHYsWOHVWOaPHkyxo8fLz02XAY1IiLikVfJ0mg06N69u91eqagy5ABUjjyqSg6GPTDmwPpCALfd47Ln7Se3vrCBIiK7olQq0ahRIwBASEgIDh48iAULFuCVV17B3bt3kZ+fb/QrcV5eHnx8fAAAPj4+OHDggNHyDFfRenDMw1fWysvLg1qtLvHXYQBQqVRQqVTFpjs5Ocn64yF3nC2rDDkAlSOPyp6DOXNjfaEHcds9HnvcfnLjZQNFVVaDdzaYbFnnZkabbFlUPnq9HlqtFiEhIXBycsLWrVvRr18/AMDJkydx4cIFhIWFAQDCwsLwwQcf4NKlS/Dy8gJw/xADtVqNoKAgaczGjRuN1qHRaKRlmEPzhM3QFpnmnjZ8LxKZDuuLMdYXovvYQBGR3Zg8eTKioqJQv359XL9+HWlpacjIyMDmzZvh7u6O4cOHY/z48fD09IRarcabb76JsLAwtG/fHgAQERGBoKAgDB48GLNnz0Zubi6mTJmCuLg46Rfe0aNH45NPPsHEiRMxbNgwbNu2DatWrcKGDaZruInI9rC+EJFcbKCIyG5cunQJQ4YMwcWLF+Hu7o4WLVpg8+bN6N69OwBg3rx5cHBwQL9+/aDVahEZGYklS5ZIz3d0dMT69esxZswYhIWFwc3NDbGxsUhKSpLGBAQEYMOGDRg3bhwWLFiAevXq4bPPPuMlhm2QKfcin5oRYbJlkX1ifSGD5gmbMbud6fbecc9d5cMGiojsxueff17mfGdnZyxevBiLFy8udYy/v3+xQ2ge1qVLFxw+fLhCMRKRfWJ9ISK5HKwdABERERERkb3gHiiyG6Y4XEflKKTd8oBpTqolIiIioqqDe6CIiIiIiIhkYgNFREREREQkExsoIiIiIiIimdhAERERERERycQGioiIiIiISCY2UERERERERDKxgSIiIiIiIpKJDRQREREREZFMbKCIiIiIiIhkqmbtAIgqgwbvbDDp8s7NjDbp8oiIiIjINLgHioiIiIiISCY2UERERERERDLxED4yK1Mf2kZEREREZE3cA0VERERERCQTGygiIiIiIiKZeAgfERFZBA/pJSJzMWV9UTmabFFUSXEPFBERERERkUxsoIiIiIiIiGRiA0VERERERCQTGygiIiIiIiKZ2EARERERERHJxAaKiOxGcnIy2rZtixo1asDLywt9+vTByZMnjcZ06dIFCoXC6N/o0aONxly4cAHR0dFwdXWFl5cXJkyYgHv37hmNycjIwNNPPw2VSoVGjRohJSXF3OkRkRWxvhCRXGygiMhu7NixA3Fxcdi3bx80Gg10Oh0iIiJw8+ZNo3EjR47ExYsXpX+zZ8+W5hUVFSE6Ohp3797F3r178eWXXyIlJQXTpk2Txpw9exbR0dF47rnnkJ2djbFjx2LEiBHYvHmzxXIlIstifSEiuXgfKCKyG5s2bTJ6nJKSAi8vL2RlZaFz587SdFdXV/j4+JS4jPT0dBw/fhxbtmyBt7c3WrVqhRkzZmDSpElISEiAUqnEsmXLEBAQgDlz5gAAmjZtit27d2PevHmIjIw0X4JEZDWsL0Qkl8n3QO3cuRO9evWCr68vFAoF1q5dazR/6NChxXZ/9+jRw2jM1atXMWjQIKjVanh4eGD48OG4ceOG0ZgjR46gU6dOcHZ2hp+fn9EvQERUNRQUFAAAPD09jaanpqaidu3aaN68OSZPnoxbt25J8zIzMxEcHAxvb29pWmRkJAoLC5GTkyONCQ8PN1pmZGQkMjMzzZUKEdkY1hciKo3J90DdvHkTLVu2xLBhw9C3b98Sx/To0QPLly+XHqtUKqP5gwYNwsWLF6Vd6K+99hpGjRqFtLQ0AEBhYSEiIiIQHh6OZcuW4ejRoxg2bBg8PDwwatQoU6dUpZT3Tt4qR4HZ7YDmCZuhLVKYKSqi4vR6PcaOHYsOHTqgefPm0vSBAwfC398fvr6+OHLkCCZNmoSTJ09izZo1AIDc3FyjLzcApMe5ublljiksLMTt27fh4uJiNE+r1UKr1UqPCwsLAQA6nQ46na7UHAzzVA6iXLmXpaz1mYNhfXLWq3I0XZ6mVp48bFVVycES+bG+lL1MW2TK+mLYZqbadra83czBnmuR3JhN3kBFRUUhKiqqzDEqlarU3d8nTpzApk2bcPDgQbRp0wYAsGjRIvTs2RMff/wxfH19kZqairt37+KLL76AUqlEs2bNkJ2djblz57KBIqoi4uLicOzYMezevdto+oM1IDg4GHXr1kW3bt1w5swZBAYGmiWW5ORkJCYmFpuenp4OV1fXRz5/Rhu9yWLZuHGjyZZVHhqN5pFjZrezQCAVZIhfTh62rrLn8OAeH3NhfSmZteqLHOaoL6badra83czJHmuR3PpilXOgMjIy4OXlhZo1a6Jr1654//33UatWLQD3d217eHhIzRMAhIeHw8HBAfv378eLL76IzMxMdO7cGUqlUhoTGRmJWbNm4dq1a6hZs6bFcyIiy4mPj8f69euxc+dO1KtXr8yxoaGhAIDTp08jMDAQPj4+OHDggNGYvLw8AJB+2PHx8ZGmPThGrVYX+3UYACZPnozx48dLjwsLC+Hn54eIiAio1epSY9PpdNBoNJh6yAFavWn24B5LsOw5FIYcunfvDicnpzLHNk+w3ZPkD7/XVXYetqo8r4WtkpODYQ+MubC+lM7S9aU8TFlfVA4CM9roTbbtbHm7mYM91yK59cXiDVSPHj3Qt29fBAQE4MyZM3j33XcRFRWFzMxMODo6Ijc3F15eXsZBVqsGT09Po93fAQEBRmMe3EVeWgNV0d3glmILuzzLuwvc1Lu5zc1e4n3wPWAL74vyMGecQgi8+eab+OGHH5CRkVGsDpQkOzsbAFC3bl0AQFhYGD744ANcunRJqjUajQZqtRpBQUHSmId/MdRoNAgLCytxHSqVqtihyADg5OQk64+HVq8w2SGw1vpjJSdXWz7M1xC73NfMllX2HMyVG+vLo9ny+8oc9cVU286Wt5s52WMtkhuvxRuomJgY6f+Dg4PRokULBAYGIiMjA926dTPruh93N7ilWHOXZ0V3gZvyEAFLsPV4S9rdb4+7wk0tLi4OaWlp+PHHH1GjRg3pRxV3d3e4uLjgzJkzSEtLQ8+ePVGrVi0cOXIE48aNQ+fOndGiRQsAQEREBIKCgjB48GDMnj0bubm5mDJlCuLi4qQvKaNHj8Ynn3yCiRMnYtiwYdi2bRtWrVqFDRvKd44gEdkP1hciksvqlzFv2LAhateujdOnT6Nbt27w8fHBpUuXjMbcu3cPV69efeTub8O80lR0N7il2MIuz/LuAjf1bm5zs5d4H9zdbwvvi/LQ6XT48ccfzbLspUuXArh/M8sHLV++HEOHDoVSqcSWLVswf/583Lx5E35+fujXrx+mTJkijXV0dMT69esxZswYhIWFwc3NDbGxsUhKSpLGBAQEYMOGDRg3bhwWLFiAevXq4bPPPuMlhokqMdYXIpLL6g3Un3/+iStXrhjt/s7Pz0dWVhZCQkIAANu2bYNer5eONQ4LC8N7770HnU4nfaHUaDRo3Lhxmec/Pe5ucEuxZjwV3VVtykMELMHW4y3p9be196k1CFH2oZd+fn7YsWPHI5fj7+//yJN6u3TpgsOHD5crPiKyX6wvRCSXye8DdePGDWRnZ0vHBZ89exbZ2dm4cOECbty4gQkTJmDfvn04d+4ctm7dit69e6NRo0bSLy9NmzZFjx49MHLkSBw4cAB79uxBfHw8YmJi4OvrC+D+ZUSVSiWGDx+OnJwcrFy5EgsWLDDau0RERERERGRqJm+gDh06hNatW6N169YAgPHjx6N169aYNm0aHB0dceTIEbzwwgt46qmnMHz4cISEhGDXrl1Ge4ZSU1PRpEkTdOvWDT179kTHjh3x6aefSvPd3d2Rnp6Os2fPIiQkBP/+978xbdo0XsKciIiIiIjMyuSH8HXp0qXM3eCbNz/6HBtPT0/pprmladGiBXbt2lXu+IiIiIiIiCrK5HugiIiIiIiIKis2UERERERERDJZ/Sp89PgavMN7RxARERERWQL3QBEREREREcnEBoqIiIiIiEgmNlBEREREREQysYEiIiIiIiKSiQ0UERERERGRTGygiIiIiIiIZGIDRUREREREJBMbKCIiIiIiIpnYQBEREREREcnEBoqIiIiIiEgmNlBEREREREQysYEiIiIiIiKSiQ0UERERERGRTGygiIiIiIiIZGIDRUREREREJBMbKCIiIiIiIpnYQBEREREREcnEBoqIiIiIiEgmNlBEZDeSk5PRtm1b1KhRA15eXujTpw9OnjxpNObOnTuIi4tDrVq1UL16dfTr1w95eXlGYy5cuIDo6Gi4urrCy8sLEyZMwL1794zGZGRk4Omnn4ZKpUKjRo2QkpJi7vSIyIpYX4hIrmrWDqAqavDOhhKnqxwFZrcDmidshrZIYeGoiGzfjh07EBcXh7Zt2+LevXt49913ERERgePHj8PNzQ0AMG7cOGzYsAGrV6+Gu7s74uPj0bdvX+zZswcAUFRUhOjoaPj4+GDv3r24ePEihgwZAicnJ3z44YcAgLNnzyI6OhqjR49Gamoqtm7dihEjRqBu3bqIjIy0Wv5EZD6sL0QkFxsoIrIbmzZtMnqckpICLy8vZGVloXPnzigoKMDnn3+OtLQ0dO3aFQCwfPlyNG3aFPv27UP79u2Rnp6O48ePY8uWLfD29karVq0wY8YMTJo0CQkJCVAqlVi2bBkCAgIwZ84cAEDTpk2xe/duzJs3j19wiCop1hcikosNFBHZrYKCAgCAp6cnACArKws6nQ7h4eHSmCZNmqB+/frIzMxE+/btkZmZieDgYHh7e0tjIiMjMWbMGOTk5KB169bIzMw0WoZhzNixY0uMQ6vVQqvVSo8LCwsBADqdDjqdrtT4DfNUDqIcWZetrPWZg2F9ctarcjRdnqZWnjxsVVXJwVL5sb6UvkxbZMr6Ythmptp2trzdzMGea5HcmNlAEZFd0uv1GDt2LDp06IDmzZsDAHJzc6FUKuHh4WE01tvbG7m5udKYB7/cGOYb5pU1prCwELdv34aLi4vRvOTkZCQmJhaLMT09Ha6uro/MZUYb/SPHyLVx40aTLas8NBrNI8fMbmeBQCrIEL+cPGxdZc/h1q1bZl8/60vJrFVf5DBHfTHVtrPl7WZO9liL5NYXNlBEZJfi4uJw7Ngx7N6929qhYPLkyRg/frz0uLCwEH5+foiIiIBarS71eTqdDhqNBlMPOUCrN815j8cSLHsIkCGH7t27w8nJqcyxzRM2Wyiq8jv8XlfZediq8rwWtkpODoY9MObE+lIyS9eX8jBlfVE5CMxoozfZtrPl7WYO9lyL5NYXNlBEZHfi4+Oxfv167Ny5E/Xq1ZOm+/j44O7du8jPzzf6lTgvLw8+Pj7SmAMHDhgtz3AVrQfHPHxlrby8PKjV6mK/DgOASqWCSqUqNt3JyUnWHw+tXmGyC8dY64+VnFxt+eI4htjlvma2rLLnYO7cWF9KZ8vvK3PUF1NtO1vebuZkj7VIbry8jDkR2Q0hBOLj4/HDDz9g27ZtCAgIMJofEhICJycnbN26VZp28uRJXLhwAWFhYQCAsLAwHD16FJcuXZLGaDQaqNVqBAUFSWMeXIZhjGEZRFT5sL4QkVzcA0VEdiMuLg5paWn48ccfUaNGDemcAnd3d7i4uMDd3R3Dhw/H+PHj4enpCbVajTfffBNhYWFo3749ACAiIgJBQUEYPHgwZs+ejdzcXEyZMgVxcXHSr7yjR4/GJ598gokTJ2LYsGHYtm0bVq1ahQ0bSr4FARHZP9YXIpKLe6CIyG4sXboUBQUF6NKlC+rWrSv9W7lypTRm3rx5eP7559GvXz907twZPj4+WLNmjTTf0dER69evh6OjI8LCwvDqq69iyJAhSEpKksYEBARgw4YN0Gg0aNmyJebMmYPPPvuMlxgmqsRYX4hILu6BIiK7IcSjLynr7OyMxYsXY/HixaWO8ff3f+RVkbp06YLDhw+XO0Yisk+sL0QkF/dAERERERERycQGioiIiIiISCY2UERERERERDKxgSIiIiIiIpKJDRQREREREZFMbKCIiIiIiIhkYgNFREREREQkExsoIiIiIiIimdhAERERERERycQGioiIiIiISCY2UERERERERDKxgSIiIiIiIpKJDRQREREREZFMbKCIiIiIiIhkMnkDtXPnTvTq1Qu+vr5QKBRYu3at0XwhBKZNm4a6devCxcUF4eHhOHXqlNGYq1evYtCgQVCr1fDw8MDw4cNx48YNozFHjhxBp06d4OzsDD8/P8yePdvUqRARERERERkxeQN18+ZNtGzZEosXLy5x/uzZs7Fw4UIsW7YM+/fvh5ubGyIjI3Hnzh1pzKBBg5CTkwONRoP169dj586dGDVqlDS/sLAQERER8Pf3R1ZWFj766CMkJCTg008/NXU6REREREREkmqmXmBUVBSioqJKnCeEwPz58zFlyhT07t0bAPDVV1/B29sba9euRUxMDE6cOIFNmzbh4MGDaNOmDQBg0aJF6NmzJz7++GP4+voiNTUVd+/exRdffAGlUolmzZohOzsbc+fONWq0iIiIiIiITMnkDVRZzp49i9zcXISHh0vT3N3dERoaiszMTMTExCAzMxMeHh5S8wQA4eHhcHBwwP79+/Hiiy8iMzMTnTt3hlKplMZERkZi1qxZuHbtGmrWrFni+rVaLbRarfS4sLAQAKDT6aDT6UydbqlUjqLk6Q7C6L/2wN5itpd4H3w/Gv7fku/Rx2EvcRIRERFVhEUbqNzcXACAt7e30XRvb29pXm5uLry8vIzmV6tWDZ6enkZjAgICii3DMK+0Bio5ORmJiYnFpqenp8PV1bUCGVXM7HZlz5/RRm+ZQEzI3mK29Xg3btxYbJpGo7FCJERERET0IIs2UNY2efJkjB8/XnpcWFgIPz8/REREQK1WWyyO5gmbS5yuchCY0UaPqYccoNUrLBbP47C3mO0l3mMJkdL/63Q6aDQadO/eHU5OTlaMSh6dTocff/zR2mEQERERmYVFGygfHx8AQF5eHurWrStNz8vLQ6tWraQxly5dMnrevXv3cPXqVen5Pj4+yMvLMxpjeGwYUxKVSgWVSlVsupOTk0W/mGqLyv7irtUrHjnG1thbzLYeb0nvR0u/T4mIiIioOIveByogIAA+Pj7YunWrNK2wsBD79+9HWFgYACAsLAz5+fnIysqSxmzbtg16vR6hoaHSmJ07dxqda6HRaNC4ceNSD98jIiIiIiJ6XCZvoG7cuIHs7GxkZ2cDuH/hiOzsbFy4cAEKhQJjx47F+++/j3Xr1uHo0aMYMmQIfH190adPHwBA06ZN0aNHD4wcORIHDhzAnj17EB8fj5iYGPj6+gIABg4cCKVSieHDhyMnJwcrV67EggULjA7PIyIiIiIiMjWTN1CHDh1C69at0bp1awDA+PHj0bp1a0ybNg0AMHHiRLz55psYNWoU2rZtixs3bmDTpk1wdnaWlpGamoomTZqgW7du6NmzJzp27Gh0jyd3d3ekp6fj7NmzCAkJwb///W9MmzaNlzAnquQedaPuoUOHQqFQGP3r0aOH0RjeqJuISsL6QkRymfwcqC5dukCI0i8RrVAokJSUhKSkpFLHeHp6Ii0trcz1tGjRArt27apwnERkfww36h42bBj69u1b4pgePXpg+fLl0uOHz3scNGgQLl68CI1GA51Oh9deew2jRo2Sao7hRt3h4eFYtmwZjh49imHDhsHDw4M/0hBVYqwvRCRXlboKHxHZt7Ju1G2gUqlKvZgMb9RNRKVhfSEiuSx6EQkiInPLyMiAl5cXGjdujDFjxuDKlSvSvEfdqNswpqQbdZ88eRLXrl2zXCJEZHNYX4gI4B4oIqpEevTogb59+yIgIABnzpzBu+++i6ioKGRmZsLR0dFsN+rWarXQarXS48LCQgD374n14NVCH2aYp3Io/bDn8iprfeZgWJ+c9aocTZenqZUnD1tVVXKwVn6sL7b93jJlfTFsM1NtO1vebuZgz7VIbsxsoIio0oiJiZH+Pzg4GC1atEBgYCAyMjLQrVs3s603OTkZiYmJxaanp6fD1dX1kc+f0UZvslg2btxosmWVh0ajeeSY2e0sEEgFGeKXk4etq+w53Lp1y4KR/B/WF+vVFznMUV9Mte1sebuZkz3WIrn1hQ0UEVVaDRs2RO3atXH69Gl069bNbDfqnjx5stFtFAoLC+Hn54eIiAio1epS49PpdNBoNJh6yAFavWlu7HwsIdIky5HLkEP37t0feaPn5gmbLRRV+R1+r6vsPGxVeV4LWyUnB8MeGGtjfbEtpqwvKgeBGW30Jtt2trzdzMGea5Hc+sIGiogqrT///BNXrlxB3bp1ARjfqDskJARAyTfqfu+996DT6aTC/6gbdatUqmJX4wIAJycnWX88tHoFtEWm+YJjrT9WcnI1VY7mYIhd7mtmyyp7DraSG+uLbTFHfTHVtrPl7WZO9liL5MbLi0gQkd0o60bdN27cwIQJE7Bv3z6cO3cOW7duRe/evdGoUSNERt7/9Y836iai0rC+EJFcbKCIyG6UdaNuR0dHHDlyBC+88AKeeuopDB8+HCEhIdi1a5fRr7e8UTcRlYT1hYjk4iF8RGQ3HnWj7s2bH30MPG/UTUQlYX0hIrm4B4qIiIiIiEgmNlBEREREREQysYEiIiIiIiKSiQ0UERERERGRTLyIhAwN3tlg7RCIiIiIiMgGcA8UERERERGRTNwDRUREVV7zhM2Y3e7+f7VFisde3rmZ0SaIiogqA1MfycT6Yn3cA0VERERERCQTGygiIiIiIiKZ2EARERERERHJxAaKiIiIiIhIJjZQREREREREMrGBIiIiIiIikokNFBERERERkUxsoIiIiIiIiGRiA0VERERERCRTNWsHQETFPXjXcpWjwOx2QPOEzdAWKSq0PN61nIiIiMg0uAeKiIiIiIhIJjZQREREREREMrGBIiIiIiIikokNFBERERERkUxsoIiIiIiIiGRiA0VERERERCQTGygiIiIiIiKZ2EARkd3YuXMnevXqBV9fXygUCqxdu9ZovhAC06ZNQ926deHi4oLw8HCcOnXKaMzVq1cxaNAgqNVqeHh4YPjw4bhx44bRmCNHjqBTp05wdnaGn58fZs+ebe7UiMjKWF+ISC42UERkN27evImWLVti8eLFJc6fPXs2Fi5ciGXLlmH//v1wc3NDZGQk7ty5I40ZNGgQcnJyoNFosH79euzcuROjRo2S5hcWFiIiIgL+/v7IysrCRx99hISEBHz66admz4+IrIf1hYjkqmbtAIiI5IqKikJUVFSJ84QQmD9/PqZMmYLevXsDAL766it4e3tj7dq1iImJwYkTJ7Bp0yYcPHgQbdq0AQAsWrQIPXv2xMcffwxfX1+kpqbi7t27+OKLL6BUKtGsWTNkZ2dj7ty5Rl+EiKhyYX0hIrnYQBFRpXD27Fnk5uYiPDxcmubu7o7Q0FBkZmYiJiYGmZmZ8PDwkL7cAEB4eDgcHBywf/9+vPjii8jMzETnzp2hVCqlMZGRkZg1axauXbuGmjVrFlu3VquFVquVHhcWFgIAdDoddDpdqTEb5qkcRMUTL2WZlmJYn5z1qhxNl6epGV4DU70Wln4dHlynNdZtKnJysEZ+rC/Gy7RFpqwvpq4HpmbLrwNg37VIbsxsoIioUsjNzQUAeHt7G0339vaW5uXm5sLLy8tofrVq1eDp6Wk0JiAgoNgyDPNK+oKTnJyMxMTEYtPT09Ph6ur6yNhntNE/coxcGzduNNmyykOj0TxyzOx2FgjkMZnqtbDW6wDIey1sXVk53Lp1y4KR3Mf6cp8139ePYo76YsptZ0q2/Do8yB5rkdz6wgaKiOgxTZ48GePHj5ceFxYWws/PDxEREVCr1aU+T6fTQaPRYOohB2j1CpPEciwh0iTLkcuQQ/fu3eHk5FTm2OYJmy0UVfmpHARmtNGb7LWw9OsAlO+1sFVycjDsgakqqnJ9KQ9T1hdT1wNTs+XXAbDvWiS3vrCBIqJKwcfHBwCQl5eHunXrStPz8vLQqlUracylS5eMnnfv3j1cvXpVer6Pjw/y8vKMxhgeG8Y8TKVSQaVSFZvu5OQk64+HVq+Atsg0f6St9cdKTq6mytGcTPVaWPNLg9z3nS0rKwdr5Mb68n/rtFXmqC+m3HamZMuvw4PssRbJjZdX4SOiSiEgIAA+Pj7YunWrNK2wsBD79+9HWFgYACAsLAz5+fnIysqSxmzbtg16vR6hoaHSmJ07dxodB63RaNC4ceMSD68hosqP9YWIHsQGiojsxo0bN5CdnY3s7GwA90/szs7OxoULF6BQKDB27Fi8//77WLduHY4ePYohQ4bA19cXffr0AQA0bdoUPXr0wMiRI3HgwAHs2bMH8fHxiImJga+vLwBg4MCBUCqVGD58OHJycrBy5UosWLDA6BAaIqp8WF+ISC4ewkdEduPQoUN47rnnpMeGLx2xsbFISUnBxIkTcfPmTYwaNQr5+fno2LEjNm3aBGdnZ+k5qampiI+PR7du3eDg4IB+/fph4cKF0nx3d3ekp6cjLi4OISEhqF27NqZNm8ZLDBNVcqwvRCQXGygishtdunSBEKVfVlahUCApKQlJSUmljvH09ERaWlqZ62nRogV27dpV4TiJyP6wvhCRXDyEj4iIiIiISCarNFAJCQlQKBRG/5o0aSLNv3PnDuLi4lCrVi1Ur14d/fr1K3bVmgsXLiA6Ohqurq7w8vLChAkTcO/ePUunQkREREREVYjVDuFr1qwZtmzZ8n+BVPu/UMaNG4cNGzZg9erVcHd3R3x8PPr27Ys9e/YAAIqKihAdHQ0fHx/s3bsXFy9exJAhQ+Dk5IQPP/zQ4rkQEREREVHVYLUGqlq1aiXe86CgoACff/450tLS0LVrVwDA8uXL0bRpU+zbtw/t27dHeno6jh8/ji1btsDb2xutWrXCjBkzMGnSJCQkJECpVFo6HSIiIiIiqgKsdg7UqVOn4Ovri4YNG2LQoEG4cOECACArKws6nQ7h4eHS2CZNmqB+/frIzMwEAGRmZiI4OBje3t7SmMjISBQWFiInJ8eyiRARERERUZVhlT1QoaGhSElJQePGjXHx4kUkJiaiU6dOOHbsGHJzc6FUKuHh4WH0HG9vb+Tm5gIAcnNzjZonw3zDvNJotVpotVrpcWFhIQBAp9MZ3dTuYSrH0q/KY0oqB2H0X3tgbzHbW7yAaWIu6/1tapZcFxEREZGlWaWBioqKkv6/RYsWCA0Nhb+/P1atWgUXFxezrTc5ORmJiYnFpqenp8PV1bXU581uZ7aQSjSjjd6yKzQBe4vZ3uIFHi/mjRs3mjASIiIioqrLJu4D5eHhgaeeegqnT59G9+7dcffuXeTn5xvthcrLy5POmfLx8cGBAweMlmG4Sl9J51UZTJ482ehu34WFhfDz80NERATUanWpz2uesLkiaZWbykFgRhs9ph5ygFavsMg6H5e9xWxv8QKmiflYQqSJoyqdTqfDjz/+aLH1EREREVmSTTRQN27cwJkzZzB48GCEhITAyckJW7duRb9+/QAAJ0+exIULFxAWFgYACAsLwwcffIBLly7By8sLAKDRaKBWqxEUFFTqelQqFVQqVbHpTk5OcHJyKvV52iLLftHW6hUWX+fjsreY7S1e4PFiLuv9TURERETyWaWBevvtt9GrVy/4+/vj77//xvTp0+Ho6IgBAwbA3d0dw4cPx/jx4+Hp6Qm1Wo0333wTYWFhaN++PQAgIiICQUFBGDx4MGbPno3c3FxMmTIFcXFxJTZIRERVRYN3NphsWedmRptsWURk/1hfiO6zSgP1559/YsCAAbhy5Qrq1KmDjh07Yt++fahTpw4AYN68eXBwcEC/fv2g1WoRGRmJJUuWSM93dHTE+vXrMWbMGISFhcHNzQ2xsbFISkqyRjpERERERFRFWKWBWrFiRZnznZ2dsXjxYixevLjUMf7+/jwxnoiIiIiILMpq94EiIiIiIiKyNzZxEQkiIrI9cs53UDkKzG53/2ql9nZhFiKyHlOeT0VkaWygiKoAnvhLREREZBo8hI+IiIiIiEgmNlBEREREREQysYEiIiIiIiKSiedAERERmRjPOyQic2F9sT7ugSIiIiIiIpKJDRQREREREZFMbKCIiIiIiIhkYgNFREREREQkExsoIqpUEhISoFAojP41adJEmn/nzh3ExcWhVq1aqF69Ovr164e8vDyjZVy4cAHR0dFwdXWFl5cXJkyYgHv37lk6FSKyIawtRGTAq/ARUaXTrFkzbNmyRXpcrdr/lbpx48Zhw4YNWL16Ndzd3REfH4++fftiz549AICioiJER0fDx8cHe/fuxcWLFzFkyBA4OTnhww8/tHguRGQ7WFuICGADRUSVULVq1eDj41NsekFBAT7//HOkpaWha9euAIDly5ejadOm2LdvH9q3b4/09HQcP34cW7Zsgbe3N1q1aoUZM2Zg0qRJSEhIgFKptHQ6RGQjWFuICGADRUSV0KlTp+Dr6wtnZ2eEhYUhOTkZ9evXR1ZWFnQ6HcLDw6WxTZo0Qf369ZGZmYn27dsjMzMTwcHB8Pb2lsZERkZizJgxyMnJQevWra2RElVhcu/5onIUmN0OaJ6wGdoiRanjeN+XimNtocrGlPeUAqpOfWEDRUSVSmhoKFJSUtC4cWNcvHgRiYmJ6NSpE44dO4bc3FwolUp4eHgYPcfb2xu5ubkAgNzcXKMvOIb5hnkl0Wq10Gq10uPCwkIAgE6ng06nKzVWwzyVgyhfkjbEELs95wBUjjzk5lDWe9LaDLHJ+dxYmjVqC1C164u1VIZ6YC0Pvi9tudaURm7MbKCIqFKJioqS/r9FixYIDQ2Fv78/Vq1aBRcXF7OsMzk5GYmJicWmp6enw9XV9ZHPn9FGb46wLKoy5ABUjjwelcPGjRstFEnFaTSaUufdunXLgpH8H2vUFoD1xZq47crvwfpS1ufYVsmtL2ygiKhS8/DwwFNPPYXTp0+je/fuuHv3LvLz841+Kc7Ly5POa/Dx8cGBAweMlmG4klZJ5z4AwOTJkzF+/HjpcWFhIfz8/BAREQG1Wl1qbDqdDhqNBlMPOUCrL/2QK1umchCY0UZv1zkAlSMPuTkcS4i0YFTlY/hMdO/eHU5OTiWOMeyBsTZL1BagatcXa6kM9cBajiVEyvoc2yq59YUNFBFVajdu3MCZM2cwePBghISEwMnJCVu3bkW/fv0AACdPnsSFCxcQFhYGAAgLC8MHH3yAS5cuwcvLC8D9X9HUajWCgoJKXIdKpYJKpSo23cnJSdYfD61eUeY5K/agMuQAVI48HpWDPXyhKeuzYyvxW6K2AKwv1sRtV34Pviflvkdtidx42UARUaXy9ttvo1evXvD398fff/+N6dOnw9HREQMGDIC7uzuGDx+O8ePHw9PTE2q1Gm+++SbCwsLQvn17AEBERASCgoIwePBgzJ49G7m5uZgyZQri4uJK/BJDRFUDawsRGbCBIqJK5c8//8SAAQNw5coV1KlTBx07dsS+fftQp04dAMC8efPg4OCAfv36QavVIjIyEkuWLJGe7+joiPXr12PMmDEICwuDm5sbYmNjkZSUZK2UiMgGsLYQkQEbKCKqVFasWFHmfGdnZyxevBiLFy8udYy/v79dnGhPVBGmvGxxVblkMcDaQiRHg3c2yL6lwqPYcn1xsHYARERERERE9oINFBERERERkUxsoIiIiIiIiGRiA0VERERERCQTGygiIiIiIiKZ2EARERERERHJxAaKiIiIiIhIJjZQREREREREMrGBIiIiIiIikokNFBERERERkUxsoIiIiIiIiGRiA0VERERERCQTGygiIiIiIiKZ2EARERERERHJxAaKiIiIiIhIJjZQREREREREMrGBIiIiIiIikokNFBERERERkUxsoIiIiIiIiGRiA0VERERERCQTGygiIiIiIiKZqlk7ACIiIrJPDd7ZYNLlnZoRYdLlEZH9MnV9OTcz2mTL4h4oIiIiIiIimdhAERERERERyWT3DdTixYvRoEEDODs7IzQ0FAcOHLB2SERUSbC+EJG5sL4Q2S+7bqBWrlyJ8ePHY/r06fjll1/QsmVLREZG4tKlS9YOjYjsHOsLEZkL6wuRfbPrBmru3LkYOXIkXnvtNQQFBWHZsmVwdXXFF198Ye3QiMjOsb4QkbmwvhDZN7u9Ct/du3eRlZWFyZMnS9McHBwQHh6OzMzMEp+j1Wqh1WqlxwUFBQCAq1evQqfTlbquavdumijqslXTC9y6pUc1nQOK9AqLrPNx2VvM9hYvYHsxX7lypcz5Op0Ot27dAgAIISwRksmVt75UtLYYtpWtvLYVYWvvz4qqDHlUhhyuXLmCW7du4cqVK3BycipxzPXr1wGwvlSF+mItleGzZE22uv0e9f0FkF9f7LaBunz5MoqKiuDt7W003dvbG7/99luJz0lOTkZiYmKx6QEBAWaJsSIGWjuACrC3mO0tXsC2Yq49R/7Y69evw93d3XzBmEl564s91BZzsqX35+OoDHnYew51WV+Kja/q9cVa7P2zZG22uP1M+f3Fbhuoipg8eTLGjx8vPdbr9bh69Spq1aoFhcL6HXJhYSH8/Pzwv//9D2q12trhyGJvMdtbvID9xWyI9/jx4/D19bV2OBZR0dpib69tSSpDDkDlyKOq5CCEwPXr11lfqkB9sRZuu8djz9tPbn2x2waqdu3acHR0RF5entH0vLw8+Pj4lPgclUoFlUplNM3Dw8NcIVaYWq22uzecvcVsb/EC9hfzE088AQcH+zzNsrz15XFri729tiWpDDkAlSOPqpCDPe55MmB9sR/cdo/HXrefnPpin99uACiVSoSEhGDr1q3SNL1ej61btyIsLMyKkRGRvWN9ISJzYX0hsn92uwcKAMaPH4/Y2Fi0adMG7dq1w/z583Hz5k289tpr1g6NiOwc6wsRmQvrC5F9s+sG6pVXXsE///yDadOmITc3F61atcKmTZuKnZhpL1QqFaZPn15sV70ts7eY7S1ewP5itrd4S2OJ+lIZtlVlyAGoHHkwB/vB+mLbuO0eT1XYfgphr9cBJSIiIiIisjC7PQeKiIiIiIjI0thAERERERERycQGioiIiIiISCY2UERERERERDKxgTKz5ORktG3bFjVq1ICXlxf69OmDkydPGo3p0qULFAqF0b/Ro0cbjblw4QKio6Ph6uoKLy8vTJgwAffu3TNLzAkJCcXiadKkiTT/zp07iIuLQ61atVC9enX069ev2A0BLRlvgwYNisWrUCgQFxcHwDa2786dO9GrVy/4+vpCoVBg7dq1RvOFEJg2bRrq1q0LFxcXhIeH49SpU0Zjrl69ikGDBkGtVsPDwwPDhw/HjRs3jMYcOXIEnTp1grOzM/z8/DB79myTx6vT6TBp0iQEBwfDzc0Nvr6+GDJkCP7++2+jZZT0usycOdMs8dqrxYsXo0GDBnB2dkZoaCgOHDhglTgs9ZnPyMjA008/DZVKhUaNGiElJaXCMdvSZ2r16tVo0qQJnJ2dERwcjI0bN5osj6FDhxZ7bXr06GEzecj5G2fJ94+tfKZsQVXfFvZY16ylstRTixJkVpGRkWL58uXi2LFjIjs7W/Ts2VPUr19f3LhxQxrz7LPPipEjR4qLFy9K/woKCqT59+7dE82bNxfh4eHi8OHDYuPGjaJ27dpi8uTJZol5+vTpolmzZkbx/PPPP9L80aNHCz8/P7F161Zx6NAh0b59e/HMM89YLd5Lly4ZxarRaAQAsX37diGEbWzfjRs3ivfee0+sWbNGABA//PCD0fyZM2cKd3d3sXbtWvHrr7+KF154QQQEBIjbt29LY3r06CFatmwp9u3bJ3bt2iUaNWokBgwYIM0vKCgQ3t7eYtCgQeLYsWPi22+/FS4uLuI///mPSePNz88X4eHhYuXKleK3334TmZmZol27diIkJMRoGf7+/iIpKclouz/4vjdlvPZoxYoVQqlUii+++ELk5OSIkSNHCg8PD5GXl2fxWCzxmf/jjz+Eq6urGD9+vDh+/LhYtGiRcHR0FJs2bapQzLbymdqzZ49wdHQUs2fPFsePHxdTpkwRTk5O4ujRoybJIzY2VvTo0cPotbl69arRGGvmIedvnKXeP7b0mbI2bgv7rGvWUlnqqSWxgbKwS5cuCQBix44d0rRnn31W/Otf/yr1ORs3bhQODg4iNzdXmrZ06VKhVquFVqs1eYzTp08XLVu2LHFefn6+cHJyEqtXr5amnThxQgAQmZmZVon3Yf/6179EYGCg0Ov1Qgjb274PFye9Xi98fHzERx99JE3Lz88XKpVKfPvtt0IIIY4fPy4AiIMHD0pjfv75Z6FQKMRff/0lhBBiyZIlombNmkYxT5o0STRu3Nik8ZbkwIEDAoA4f/68NM3f31/Mmzev1OeYK1570a5dOxEXFyc9LioqEr6+viI5OdnisVjiMz9x4kTRrFkzo2W/8sorIjIy8rHjt+Znqn///iI6OtoontDQUPH6668/dh5C3G+gevfuXepzbC2Ph//GWfL9Y0ufKWvjtrD/umYtlaWemhsP4bOwgoICAICnp6fR9NTUVNSuXRvNmzfH5MmTcevWLWleZmYmgoODjW6wFxkZicLCQuTk5JglzlOnTsHX1xcNGzbEoEGDcOHCBQBAVlYWdDodwsPDpbFNmjRB/fr1kZmZabV4De7evYtvvvkGw4YNg0KhkKbb2vZ90NmzZ5Gbm2u0Td3d3REaGmq0TT08PNCmTRtpTHh4OBwcHLB//35pTOfOnaFUKo3yOHnyJK5du2bWHAoKCqBQKODh4WE0febMmahVqxZat26Njz76yOjQB2vGa213795FVlaW0Wvu4OCA8PBw6TW3NHN/5jMzM42WYRhjjnwt+ZmyRF4ZGRnw8vJC48aNMWbMGFy5ckWaZ2t5PPw3zlLvH1v8TFkLt8X/qUx1zVoqWz01lWrWDqAq0ev1GDt2LDp06IDmzZtL0wcOHAh/f3/4+vriyJEjmDRpEk6ePIk1a9YAAHJzc4vdndzwODc31+RxhoaGIiUlBY0bN8bFixeRmJiITp064dixY8jNzYVSqSz2Rdnb21uKxdLxPmjt2rXIz8/H0KFDpWm2tn0fZlhHSTE8uE29vLyM5lerVg2enp5GYwICAootwzCvZs2aZon/zp07mDRpEgYMGAC1Wi1Nf+utt/D000/D09MTe/fuxeTJk3Hx4kXMnTvXqvHagsuXL6OoqKjE1/y3336zeDyW+MyXNqawsBC3b9+Gi4uLyfKx5GeqtLxMVTt69OiBvn37IiAgAGfOnMG7776LqKgoZGZmwtHR0abyKOlvnKXeP9euXbOpz5Q12Vp9sZbKVtespTLVU1NiA2VBcXFxOHbsGHbv3m00fdSoUdL/BwcHo27duujWrRvOnDmDwMBAS4eJqKgo6f9btGiB0NBQ+Pv7Y9WqVTZfDD7//HNERUXB19dXmmZr27cy0el06N+/P4QQWLp0qdG88ePHS//fokULKJVKvP7660hOToZKpbJ0qFQGe/7MV3YxMTHS/wcHB6NFixYIDAxERkYGunXrZsXIiivtbxyRNbCukTnxED4LiY+Px/r167F9+3bUq1evzLGhoaEAgNOnTwMAfHx8il0ZxvDYx8fHDNEa8/DwwFNPPYXTp0/Dx8cHd+/eRX5+frF4DLFYK97z589jy5YtGDFiRJnjbG37GtZRUgwPbtNLly4Zzb937x6uXr1qte1uaJ7Onz8PjUZjtPepJKGhobh37x7OnTtnlXhtSe3ateHo6Fjma25N5vjMlzZGrVab/MuMJT9TpY0x1+vYsGFD1K5d26h+2UIepf2Ns9T7x9Y/U5bEbVEye69r1lKZ6+njYANlZkIIxMfH44cffsC2bduK7b4sSXZ2NgCgbt26AICwsDAcPXrU6M1p+MIaFBRklrgfdOPGDZw5cwZ169ZFSEgInJycsHXrVmn+yZMnceHCBYSFhVk13uXLl8PLywvR0dFljrO17RsQEAAfHx+jbVpYWIj9+/cbbdP8/HxkZWVJY7Zt2wa9Xi81hGFhYdi5cyd0Op1RHo0bNzb54XCG5unUqVPYsmULatWq9cjnZGdnw8HBQdrNb8l4bY1SqURISIjRa67X67F161bpNbcmc3zmw8LCjJZhGGOOfC35mbJkXgDw559/4sqVK0b1y5p5POpvnKXeP7b+mbIkbouS2Xtds5bKXE8fi5UvYlHpjRkzRri7u4uMjAyjS2neunVLCCHE6dOnRVJSkjh06JA4e/as+PHHH0XDhg1F586dpWUYLqUZEREhsrOzxaZNm0SdOnXMdlnwf//73yIjI0OcPXtW7NmzR4SHh4vatWuLS5cuCSHuX/qzfv36Ytu2beLQoUMiLCxMhIWFWS1eIe5fYah+/fpi0qRJRtNtZftev35dHD58WBw+fFgAEHPnzhWHDx+Wrlo3c+ZM4eHhIX788Udx5MgR0bt37xIvEdq6dWuxf/9+sXv3bvHkk08aXSI0Pz9feHt7i8GDB4tjx46JFStWCFdX1wpdFryseO/evSteeOEFUa9ePZGdnW30vjZcXWfv3r1i3rx5Ijs7W5w5c0Z88803ok6dOmLIkCFmidcerVixQqhUKpGSkiKOHz8uRo0aJTw8PIyu+GQplvjMGy73O2HCBHHixAmxePHix7rcr618pvbs2SOqVasmPv74Y3HixAkxffr0cl12t6w8rl+/Lt5++22RmZkpzp49K7Zs2SKefvpp8eSTT4o7d+7YRB6P+hsnhOXeP7b0mbI2bgv7rGvWUlnqqSWxgTIzACX+W758uRBCiAsXLojOnTsLT09PoVKpRKNGjcSECROM7lMkhBDnzp0TUVFRwsXFRdSuXVv8+9//Fjqdziwxv/LKK6Ju3bpCqVSKJ554Qrzyyivi9OnT0vzbt2+LN954Q9SsWVO4urqKF198UVy8eNFq8QohxObNmwUAcfLkSaPptrJ9t2/fXuL7IDY2Vghx/zKhU6dOFd7e3kKlUolu3boVy+XKlStiwIABonr16kKtVovXXntNXL9+3WjMr7/+Kjp27ChUKpV44oknxMyZM00e79mzZ0t9XxvuvZWVlSVCQ0OFu7u7cHZ2Fk2bNhUffvih0Zc+U8ZrrxYtWiTq168vlEqlaNeundi3b59V4rDUZ3779u2iVatWQqlUioYNG0p1sCJs6TO1atUq8dRTTwmlUimaNWsmNmzYYJI8bt26JSIiIkSdOnWEk5OT8Pf3FyNHjiz2JdiaeTzqb5wQln3/2MpnyhZU9W1hj3XNWipLPbUkhRBCmHy3FhERERERUSXEc6CIiIiIiIhkYgNFREREREQkExsoIiIiIiIimdhAERERERERycQGioiIiIiISCY2UERERERERDKxgSIiIiIiIpKJDRQREREREZFMbKCIiIiIiIhkYgNFREREREQkExsoIiIiIiIimdhAERERERERycQGioiIiIiISCY2UERERERERDKxgSIiIiIiIpKJDRQREREREZFMbKCIiIiIiIhkYgNFREREREQkExsoIiIiIiIimdhAERERERERycQGqpJr0KABhg4dKj3OyMiAQqFARkZGuZdleO53331nugBNTKFQICEhwdphlMiWYyMqD3utKykpKVAoFDh37pzZ10VEpsOaY1kPb28qjg2UHTN8MEv6984771g1trS0NMyfP7/Y9HPnzhnF6eTkhNq1a+OZZ57Bu+++iwsXLlg+2HJ4cJvv3r272HwhBPz8/KBQKPD8889bIUKix2NvdaVLly6lxvvgP2v/ePGoL21Dhw5F9erVLRwVkfWx5piHoeYoFAp88803JY7p0KEDFAoFmjdvbuHo7F81awdAjy8pKQkBAQFG00r7MHTu3Bm3b9+GUqk0a0xpaWk4duwYxo4dW+L8AQMGoGfPntDr9bh27RoOHjyI+fPnY8GCBfj8888RExNj1vgel7OzM9LS0tCxY0ej6Tt27MCff/4JlUpV7Dm3b99GtWr8yJF9sJe68t5772HEiBHS44MHD2LhwoV499130bRpU2l6ixYt0KxZM8TExJT4+SQi62LNMQ/D95VXX33VaPq5c+ewd+9eODs7F3vOyZMn4eDAfSxl4be5SiAqKgpt2rSRNdbBwaHED4ulPf3008U+zOfPn0dERARiY2PRtGlTtGzZ0krRPVrPnj2xevVqLFy40KgpSktLQ0hICC5fvlzsObaw3Ynkspe60r17d6PHzs7OWLhwIbp3744uXboUG+/o6GihyOzDnTt3oFQq+WWJrI41xzx69uyJdevW4fLly6hdu7Y0PS0tDd7e3njyySdx7do1o+fwR6ZHY8WsYko7bnjx4sVo2LAhXFxc0K5dO+zatQtdunQpsRjo9Xp88MEHqFevHpydndGtWzecPn1amt+lSxds2LAB58+fl3YfN2jQ4JGx+fv7IyUlBXfv3sXs2bON5uXn52Ps2LHw8/ODSqVCo0aNMGvWLOj1+jKXef78ebzxxhto3LgxXFxcUKtWLbz88stGxyP/8ccfUCgUmDdvXrHn7927FwqFAt9++63R9AEDBuDKlSvQaDTStLt37+K7777DwIEDS4zl4V36CQkJUCgUOH36NIYOHQoPDw+4u7vjtddew61bt8rMi8iW2HJdeVBJ5yM0aNAAzz//PDIyMtCmTRu4uLggODhYymXNmjUIDg6Gs7MzQkJCcPjw4WLL/e233/DSSy/B09MTzs7OaNOmDdatW1eu2EqzZMkSNGvWDCqVCr6+voiLi0N+fr7RmNLOV3h4WxtepxUrVmDKlCl44okn4OrqisLCQpPESmQprDnya07v3r2hUqmwevVqo+lpaWno379/iQ3ewzXFkMeePXswfvx41KlTB25ubnjxxRfxzz//lGubVBbcA1UJFBQUFNvj8eCvDI+ydOlSxMfHo1OnThg3bhzOnTuHPn36oGbNmqhXr16x8TNnzoSDgwPefvttFBQUYPbs2Rg0aBD2798P4P7u7YKCAvz5559SUyL32P6wsDAEBgYaNSa3bt3Cs88+i7/++guvv/466tevj71792Ly5Mm4ePFiiedaGRw8eBB79+5FTEwM6tWrh3PnzmHp0qXo0qULjh8/DldXVzRs2BAdOnRAamoqxo0bZ/T81NRU1KhRA7179zaa3qBBA4SFheHbb79FVFQUAODnn39GQUEBYmJisHDhQln5AkD//v0REBCA5ORk/PLLL/jss8/g5eWFWbNmyV4GkalVprryKKdPn8bAgQPx+uuv49VXX8XHH3+MXr16YdmyZXj33XfxxhtvAACSk5PRv39/o8NbcnJy0KFDBzzxxBN455134ObmhlWrVqFPnz74/vvv8eKLLxqt6/r16yXuodZqtcWmJSQkIDExEeHh4RgzZgxOnjyJpUuX4uDBg9izZw+cnJwqlO+MGTOgVCrx9ttvQ6vVmv0wKCI5WHPMU3NcXV3Ru3dvfPvttxgzZgwA4Ndff0VOTg4+++wzHDlyRHbcb775JmrWrInp06fj3LlzmD9/PuLj47Fy5UqTbBe7IshuLV++XAAo8Z+Bv7+/iI2NlR5v375dABDbt28XQgih1WpFrVq1RNu2bYVOp5PGpaSkCADi2WefLfbcpk2bCq1WK01fsGCBACCOHj0qTYuOjhb+/v7FYj579qwAID766KNS8+rdu7cAIAoKCoQQQsyYMUO4ubmJ33//3WjcO++8IxwdHcWFCxekaQDE9OnTpce3bt0qtvzMzEwBQHz11VfStP/85z8CgDhx4oQ07e7du6J27dpG28+wzQ8ePCg++eQTUaNGDWkdL7/8snjuueeEEPe3e3R0tNF6H45t+vTpAoAYNmyY0bgXX3xR1KpVq9TtQ2RO9lhXHrR69WqjWErK7ezZs0a5ABB79+6Vpm3evFkAEC4uLuL8+fPSdEOdeHDZ3bp1E8HBweLOnTvSNL1eL5555hnx5JNPFsuzrH9ubm7S+EuXLgmlUikiIiJEUVGRNP2TTz4RAMQXX3xhlMODr4fBs88+W+K2btiwYYm1kcgaWHPMW3NWr14t1q9fLxQKhfR9acKECaJhw4ZCiPt1olmzZkZxP7y9DXmEh4cLvV4vTR83bpxwdHQU+fn5ZW6jyoiH8FUCixcvhkajMfon16FDh3DlyhWMHDnS6FyeQYMGoWbNmiU+57XXXjP6xbJTp04A7h8KZwqGX3iuX78OAFi9ejU6deqEmjVr4vLly9K/8PBwFBUVYefOnaUuy8XFRfp/nU6HK1euoFGjRvDw8MAvv/wizevfvz+cnZ2RmpoqTdu8eTMuX75c7FytB59z+/ZtrF+/HtevX8f69etLPXyvLKNHjzZ63KlTJ1y5coWH1ZBVVba6UpagoCCEhYVJj0NDQwEAXbt2Rf369YtNN8R09epVbNu2Df3795f2LF2+fBlXrlxBZGQkTp06hb/++stoXdOmTSu2XTUaDSIiIozGbdmyBXfv3sXYsWONzk8aOXIk1Go1NmzYUOF8Y2NjjWojkS1gzTFPzQGAiIgIeHp6YsWKFRBCYMWKFRgwYEC54x41ahQUCoX0uFOnTigqKsL58+fLvSx7x0P4KoF27drJPvHyYYY3faNGjYymV6tWrdRjfR/8cAOQitPDJyFW1I0bNwAANWrUAACcOnUKR44cQZ06dUocf+nSpVKXdfv2bSQnJ2P58uX466+/IISQ5hUUFEj/7+HhgV69eiEtLQ0zZswAcP/wvSeeeAJdu3Ytcdl16tRBeHg40tLScOvWLRQVFeGll14qX7Ioe3uq1epyL4/IFCpbXSnLw+t2d3cHAPj5+ZU43RDT6dOnIYTA1KlTMXXq1BKXfenSJTzxxBPS4+DgYISHhxcb9/Blhg3bsHHjxkbTlUolGjZs+FhfWB6+0hmRLWDNMU/NAQAnJye8/PLLSEtLQ7t27fC///2vQj/4WnOb2Ro2UFRupV1R5sHm5HEcO3YMXl5eUvOg1+vRvXt3TJw4scTxTz31VKnLevPNN7F8+XKMHTsWYWFhcHd3h0KhQExMTLELUAwZMgSrV6/G3r17ERwcjHXr1uGNN94o8+pUAwcOxMiRI5Gbm4uoqCh4eHiUO19zb08ie2DNz0Fp635UTIYa8vbbbyMyMrLEsQ9/oTOHB38RflBRUVGJOXDvE1HVqzkDBw7EsmXLkJCQgJYtWyIoKKi8YfP7ygPYQFVx/v7+AO7/qvHcc89J0+/du4dz586hRYsWFVpuaX/QHyUzMxNnzpwxOmwuMDAQN27cKPFX20f57rvvEBsbizlz5kjT7ty5U+wqVgDQo0cP1KlTB6mpqQgNDcWtW7cwePDgMpf/4osv4vXXX8e+ffuq5kmURCWwtbpiLg0bNgRw/9fditSnshi24cmTJ6X1APev9nn27Fmj9dWsWbPEmnb+/Hmj5xJVVqw5j9axY0fUr18fGRkZvEiVCfAcqCquTZs2qFWrFv773//i3r170vTU1NTH2iXr5uZmdIicHOfPn8fQoUOhVCoxYcIEaXr//v2RmZmJzZs3F3tOfn6+UdwPc3R0LPbLyKJFi1BUVFRsbLVq1TBgwACsWrUKKSkpCA4OfmTRrV69OpYuXYqEhAT06tXrUSkSVQm2VFfMycvLC126dMF//vMfXLx4sdj8x7m8b3h4OJRKJRYuXGhUwz7//HMUFBQgOjpamhYYGIh9+/bh7t270rT169fjf//7X4XXT2RPWHPuK6vmKBQKLFy4ENOnT3/kj8P0aNwDVcUplUokJCTgzTffRNeuXdG/f3+cO3cOKSkpCAwMrPCvLyEhIVi5ciXGjx+Ptm3bonr16kYNxi+//IJvvvkGer0e+fn5OHjwIL7//nsoFAp8/fXXRo3LhAkTsG7dOjz//PMYOnQoQkJCcPPmTRw9ehTfffcdzp07V+qlTp9//nl8/fXXcHd3R1BQEDIzM7FlyxbUqlWrxPFDhgzBwoULsX37dtm/0MTGxpZjyxBVftaqK9awePFidOzYEcHBwRg5ciQaNmyIvLw8ZGZm4s8//8Svv/5aoeXWqVMHkydPRmJiInr06IEXXngBJ0+exJIlS9C2bVujvfQjRozAd999hx49eqB///44c+YMvvnmGwQGBpoqTSKbxpojr+b07t272G1ZqGLYQBHi4+MhhMCcOXPw9ttvo2XLlli3bh3eeuutCt/p+4033kB2djaWL1+OefPmwd/f36jofPvtt/j2229RrVo1qNVqPPnkkxg7dixGjx5d7CRFV1dX7NixAx9++CFWr16Nr776Cmq1Gk899RQSExOlkyxLsmDBAjg6OiI1NRV37txBhw4dsGXLllKPHQ4JCUGzZs1w4sQJDBo0qEK5E5F16oo1BAUF4dChQ0hMTERKSgquXLkCLy8vtG7dGtOmTXusZSckJKBOnTr45JNPMG7cOHh6emLUqFH48MMPje4BFRkZiTlz5mDu3LkYO3Ys2rRpg/Xr1+Pf//7346ZHZDdYcx6/5pB8ClEVz/yiR9Lr9ahTpw769u2L//73v9YOx6Jat24NT09PbN261dqhEFUqVbmuEJHlseaQufAcKMKdO3eKnSf01Vdf4erVq+jSpYt1grKSQ4cOITs7G0OGDLF2KER2jXWFiCyJNYcsiXugCBkZGRg3bhxefvll1KpVC7/88gs+//xzNG3aFFlZWUY3mqusjh07hqysLMyZMweXL1/GH3/8UeFd/kTEukJElsWaQ5bEc6AIDRo0gJ+fHxYuXIirV6/C09MTQ4YMwcyZM6tMwfnuu++QlJSExo0b49tvv2XzRPSYWFeIyJJYc8iSuAeKiIiIiIhIJp4DRUREREREJBMbKCIiIiIiIpmq9DlQer0ef//9N2rUqFHhm6wRUXFCCFy/fh2+vr5wcKh6v9OwthCZD+sL6wuRucitL1W6gfr777/h5+dn7TCIKq3//e9/qFevnrXDsDjWFiLzY30hInN5VH2p0g1UjRo1ANzfSGq1usQxOp0O6enpiIiIMLrze2VQWXNjXtZXWFgIPz8/6TNW1cipLYB9vaamxLyrTt7myJn1pWrWl8qUD3OxXXLrS5VuoAy7vtVqdZkNlKurK9RqdaV4YzyosubGvGxHVT28RE5tAezzNTUF5l118jZnzqwvVau+VKZ8mIvte1R9qXoHDxMREREREVUQGygiIiIiIiKZ2EARERERERHJxAaKiIiIiIhIpnI3UDt37kSvXr3g6+sLhUKBtWvXGs0XQmDatGmoW7cuXFxcEB4ejlOnThmNuXr1KgYNGgS1Wg0PDw8MHz4cN27cMBpz5MgRdOrUCc7OzvDz88Ps2bOLxbJ69Wo0adIEzs7OCA4OxsaNG8ubDhERERERkWzlbqBu3ryJli1bYvHixSXOnz17NhYuXIhly5Zh//79cHNzQ2RkJO7cuSONGTRoEHJycqDRaLB+/Xrs3LkTo0aNkuYXFhYiIiIC/v7+yMrKwkcffYSEhAR8+umn0pi9e/diwIABGD58OA4fPow+ffqgT58+OHbsWHlTIiIiIiIikqXclzGPiopCVFRUifOEEJg/fz6mTJmC3r17AwC++uoreHt7Y+3atYiJicGJEyewadMmHDx4EG3atAEALFq0CD179sTHH38MX19fpKam4u7du/jiiy+gVCrRrFkzZGdnY+7cuVKjtWDBAvTo0QMTJkwAAMyYMQMajQaffPIJli1bVqGNQUREREREVBaTngN19uxZ5ObmIjw8XJrm7u6O0NBQZGZmAgAyMzPh4eEhNU8AEB4eDgcHB+zfv18a07lzZyiVSmlMZGQkTp48iWvXrkljHlyPYYxhPURERERERKZm0hvp5ubmAgC8vb2Npnt7e0vzcnNz4eXlZRxEtWrw9PQ0GhMQEFBsGYZ5NWvWRG5ubpnrKYlWq4VWq5UeFxYWArh/EzCdTlficwzTQ5I2Qas3zU37jiVEmmQ5j8uQW2m52yvmZX32ECM9WoN3Nph0eedmRpt0eURkv8pbX1SOArPbAc0TNkNbVPz7GOsLWZJJGyhbl5ycjMTExGLT09PT4erqWuZzZ7TRmywOW7vYhUajsXYIZsG8rOfWrVvWDoGIiIjILEzaQPn4+AAA8vLyULduXWl6Xl4eWrVqJY25dOmS0fPu3buHq1evSs/38fFBXl6e0RjD40eNMcwvyeTJkzF+/HjpcWFhIfz8/BAREQG1Wl3ic3Q6HTQaDaYecqiUe6A0Gg26d+8OJycna4djMszL+gx7d4mIiIgqG5M2UAEBAfDx8cHWrVulhqmwsBD79+/HmDFjAABhYWHIz89HVlYWQkJCAADbtm2DXq9HaGioNOa9996DTqeTvihqNBo0btwYNWvWlMZs3boVY8eOldav0WgQFhZWanwqlQoqlarYdCcnp0d+IdXqFSXuMq4IW/vyKyd/e8S8rMfW4yMiIiKqqHJfROLGjRvIzs5GdnY2gPsXjsjOzsaFCxegUCgwduxYvP/++1i3bh2OHj2KIUOGwNfXF3369AEANG3aFD169MDIkSNx4MAB7NmzB/Hx8YiJiYGvry8AYODAgVAqlRg+fDhycnKwcuVKLFiwwGjv0b/+9S9s2rQJc+bMwW+//YaEhAQcOnQI8fHxj79ViIiIiIiISlDuPVCHDh3Cc889Jz02NDWxsbFISUnBxIkTcfPmTYwaNQr5+fno2LEjNm3aBGdnZ+k5qampiI+PR7du3eDg4IB+/fph4cKF0nx3d3ekp6cjLi4OISEhqF27NqZNm2Z0r6hnnnkGaWlpmDJlCt599108+eSTWLt2LZo3b16hDUFERERERPQo5W6gunTpAiFEqfMVCgWSkpKQlJRU6hhPT0+kpaWVuZ4WLVpg165dZY55+eWX8fLLL5cdMBERERERkYmY9D5QRERERERElRkbKCIiIiIiIpnYQBGR3Vi6dClatGgBtVoNtVqNsLAw/Pzzz9L8O3fuIC4uDrVq1UL16tXRr1+/Yrc7uHDhAqKjo+Hq6govLy9MmDAB9+7dMxqTkZGBp59+GiqVCo0aNUJKSool0iMiK2J9ISK52EARkd2oV68eZs6ciaysLBw6dAhdu3ZF7969kZOTAwAYN24cfvrpJ6xevRo7duzA33//jb59+0rPLyoqQnR0NO7evYu9e/fiyy+/REpKCqZNmyaNOXv2LKKjo/Hcc88hOzsbY8eOxYgRI7B582aL50tElsP6QkRymfQ+UERE5tSrVy+jxx988AGWLl2Kffv2oV69evj888+RlpaGrl27AgCWL1+Opk2bYt++fWjfvj3S09Nx/PhxbNmyBd7e3mjVqhVmzJiBSZMmISEhAUqlEsuWLUNAQADmzJkD4P6tF3bv3o158+YhMtI2boJNRKbH+kJEcrGBIiK7VFRUhNWrV+PmzZsICwtDVlYWdDodwsPDpTFNmjRB/fr1kZmZifbt2yMzMxPBwcHw9vaWxkRGRmLMmDHIyclB69atkZmZabQMw5gHb9r9MK1WC61WKz0uLCwEAOh0Ouh0ulKfZ5hX1hhrUjmWfsXVing4X1vN21yqYt7myNkS24/1xfzKW19UDsLovw+z1TxLYuuvTXlUplwA+XmwgSIiu3L06FGEhYXhzp07qF69On744QcEBQUhOzsbSqUSHh4eRuO9vb2Rm5sLAMjNzTX6cmOYb5hX1pjCwkLcvn0bLi4uxWJKTk5GYmJisenp6elwdXV9ZE4ajeaRY6xhdjvTLm/jxo1Gj201b3OrinmbMudbt26ZbFkPY32xnIrWlxlt9CVOf7i+2ANbfW0qorLkIre+sIEiIrvSuHFjZGdno6CgAN999x1iY2OxY8cOq8Y0efJk6abiwP1fiP38/BAREQG1Wl3q83Q6HTQaDbp37w4nJydLhFouzRNMe17GsYT7hyjZet7mUhXzNkfOhj0w5sD6YjnlrS8qB4EZbfSYesgBWr2i2HxDfbEHtv7alEdlygWQX1/YQBGRXVEqlWjUqBEAICQkBAcPHsSCBQvwyiuv4O7du8jPzzf6lTgvLw8+Pj4AAB8fHxw4cMBoeYaraD045uEra+Xl5UGtVpf46zAAqFQqqFSqYtOdnJxk/UGRO87StEXFv6Q8jodztNW8za0q5m3KnM257VhfLKei9UWrV5T4XFvM8VFs9bWpiMqSi9wceBU+IrJrer0eWq0WISEhcHJywtatW6V5J0+exIULFxAWFgYACAsLw9GjR3Hp0iVpjEajgVqtRlBQkDTmwWUYxhiWQURVB+sLEZWEe6CIyG5MnjwZUVFRqF+/Pq5fv460tDRkZGRg8+bNcHd3x/DhwzF+/Hh4enpCrVbjzTffRFhYGNq3bw8AiIiIQFBQEAYPHozZs2cjNzcXU6ZMQVxcnPQL7+jRo/HJJ59g4sSJGDZsGLZt24ZVq1Zhw4YN1kydiMyM9YWI5GIDRUR249KlSxgyZAguXrwId3d3tGjRAps3b0b37t0BAPPmzYODgwP69esHrVaLyMhILFmyRHq+o6Mj1q9fjzFjxiAsLAxubm6IjY1FUlKSNCYgIAAbNmzAuHHjsGDBAtSrVw+fffYZLzFMVMmxvhCRXGygiMhufP7552XOd3Z2xuLFi7F48eJSx/j7+z/yak1dunTB4cOHKxQjEdkn1hcikovnQBEREREREcnEBoqIiIiIiEgmNlBEREREREQy8RwoIiIra56w2WT3XDo3M9okyyGiyoH1hcj0uAeKiIiIiIhIJjZQREREREREMrGBIiIiIiIikokNFBERERERkUxsoIiIiIiIiGRiA0VERERERCQTGygiIiIiIiKZ2EARERERERHJxAaKiIiIiIhIJjZQREREREREMrGBIiIiIiIikokNFBERERERkUxsoIiIiIiIiGQyeQNVVFSEqVOnIiAgAC4uLggMDMSMGTMghJDGCCEwbdo01K1bFy4uLggPD8epU6eMlnP16lUMGjQIarUaHh4eGD58OG7cuGE05siRI+jUqROcnZ3h5+eH2bNnmzodIiIiIiIiickbqFmzZmHp0qX45JNPcOLECcyaNQuzZ8/GokWLpDGzZ8/GwoULsWzZMuzfvx9ubm6IjIzEnTt3pDGDBg1CTk4ONBoN1q9fj507d2LUqFHS/MLCQkRERMDf3x9ZWVn46KOPkJCQgE8//dTUKREREREREQEAqpl6gXv37kXv3r0RHR0NAGjQoAG+/fZbHDhwAMD9vU/z58/HlClT0Lt3bwDAV199BW9vb6xduxYxMTE4ceIENm3ahIMHD6JNmzYAgEWLFqFnz574+OOP4evri9TUVNy9exdffPEFlEolmjVrhuzsbMydO9eo0SIiIiIiIjIVkzdQzzzzDD799FP8/vvveOqpp/Drr79i9+7dmDt3LgDg7NmzyM3NRXh4uPQcd3d3hIaGIjMzEzExMcjMzISHh4fUPAFAeHg4HBwcsH//frz44ovIzMxE586doVQqpTGRkZGYNWsWrl27hpo1axaLTavVQqvVSo8LCwsBADqdDjqdrsR8DNNVDqLE+RVR2roszRCHrcRjKszL+uwhRiIiIqKKMHkD9c4776CwsBBNmjSBo6MjioqK8MEHH2DQoEEAgNzcXACAt7e30fO8vb2lebm5ufDy8jIOtFo1eHp6Go0JCAgotgzDvJIaqOTkZCQmJhabnp6eDldX1zLzmtFGX+b88ti4caPJlmUKGo3G2iGYBfOynlu3bpllucnJyVizZg1+++03uLi44JlnnsGsWbPQuHFjaUyXLl2wY8cOo+e9/vrrWLZsmfT4woULGDNmDLZv347q1asjNjYWycnJqFbt/0piRkYGxo8fj5ycHPj5+WHKlCkYOnSoWfKqKhq8swEAoHIUmN0OaJ6wGdoiRYWXd25mtKlCI2J9sXOG+mIKrC30KCZvoFatWoXU1FSkpaVJh9WNHTsWvr6+iI2NNfXqymXy5MkYP3689LiwsBB+fn6IiIiAWq0u8Tk6nQ4ajQZTDzlAq6/4H/oHHUuINMlyHpcht+7du8PJycna4ZgM87I+w95dU9uxYwfi4uLQtm1b3Lt3D++++y4iIiJw/PhxuLm5SeNGjhyJpKQk6fGDP5AUFRUhOjoaPj4+2Lt3Ly5evIghQ4bAyckJH374IYD7e8qjo6MxevRopKamYuvWrRgxYgTq1q2LyEjb+PwSkWmxvhCRXCZvoCZMmIB33nkHMTExAIDg4GCcP38eycnJiI2NhY+PDwAgLy8PdevWlZ6Xl5eHVq1aAQB8fHxw6dIlo+Xeu3cPV69elZ7v4+ODvLw8ozGGx4YxD1OpVFCpVMWmOzk5PfILqVaveKxfSh9eny2Rk789Yl7WY674Nm3aZPQ4JSUFXl5eyMrKQufOnaXprq6updaB9PR0HD9+HFu2bIG3tzdatWqFGTNmYNKkSUhISIBSqcSyZcsQEBCAOXPmAACaNm2K3bt3Y968efyCQ1RJsb4QkVwmb6Bu3boFBwfji/s5OjpCr79/CFxAQAB8fHywdetWqWEqLCzE/v37MWbMGABAWFgY8vPzkZWVhZCQEADAtm3boNfrERoaKo157733oNPppC9rGo0GjRs3LvHwPSKqfAoKCgAAnp6eRtNTU1PxzTffwMfHB7169cLUqVOlX4kzMzMRHBxsdBhxZGQkxowZg5ycHLRu3RqZmZlG52kaxowdO7bEOCpyfqVhPmC751iqHE0Xl9Fy/3++j5u3vZ1rZ0/nMZqKOXK21PZjfSl9maZQ3vpiqrohh7nfY5WpFlSmXAD5eZi8gerVqxc++OAD1K9fH82aNcPhw4cxd+5cDBs2DACgUCgwduxYvP/++3jyyScREBCAqVOnwtfXF3369AFw/9eYHj16YOTIkVi2bBl0Oh3i4+MRExMDX19fAMDAgQORmJiI4cOHY9KkSTh27BgWLFiAefPmmTolIrJBer0eY8eORYcOHdC8eXNp+sCBA+Hv7w9fX18cOXIEkyZNwsmTJ7FmzRoA98+RLOkcTMO8ssYUFhbi9u3bcHFxMZr3OOdXArZ7juXsdiZbVIkeN29bO59ULns4j9HUTJmzuc6xfBDrS8lsob6YMp/SWKq2VKZaUFlykVtfTN5ALVq0CFOnTsUbb7yBS5cuwdfXF6+//jqmTZsmjZk4cSJu3ryJUaNGIT8/Hx07dsSmTZvg7OwsjUlNTUV8fDy6desGBwcH9OvXDwsXLpTmu7u7Iz09HXFxcQgJCUHt2rUxbdo0XsKcqIqIi4vDsWPHsHv3bqPpD9aA4OBg1K1bF926dcOZM2cQGBhollgqcn4lYPvnWDZP2GyyZT1I5SAwo43+sfO2lfNJ5bKn8xhNxRw5m+scywexvpTMmvXFVHVDDnPXlspUCypTLoD8+mLyBqpGjRqYP38+5s+fX+oYhUKBpKQko5MwH+bp6Ym0tLQy19WiRQvs2rWroqESkZ2Kj4+XbrBdr169MscaDvs9ffo0AgMD4ePjI92XzuDh8ydLO8dSrVYX+3UYeLzzKwHbPcfSVDGVuvzHzNte/1jbw3mMpmbKnM297VhfSmcL9cWU+ZTGUp/PylQLKksucnNwePQQIiLbIIRAfHw8fvjhB2zbtq3YrQxKkp2dDQDSRWvCwsJw9OhRowvVaDQaqNVqBAUFSWO2bt1qtByNRoOwsDATZUJEtob1hYjkYgNFRHYjLi4O33zzDdLS0lCjRg3k5uYiNzcXt2/fBgCcOXMGM2bMQFZWFs6dO4d169ZhyJAh6Ny5M1q0aAEAiIiIQFBQEAYPHoxff/0VmzdvxpQpUxAXFyf9yjt69Gj88ccfmDhxIn777TcsWbIEq1atwrhx46yWOxGZF+sLEcnFBoqI7MbSpUtRUFCALl26oG7dutK/lStXAgCUSiW2bNmCiIgINGnSBP/+97/Rr18//PTTT9IyHB0dsX79ejg6OiIsLAyvvvoqhgwZYnRIcUBAADZs2ACNRoOWLVtizpw5+Oyzz3iJYaJKjPWFiOQy+TlQRETmIkTZl6/18/PDjh07Hrkcf3//R15lqUuXLjh8+HC54iMi+8X6QkRycQ8UERERERGRTGygiIiIiIiIZGIDRUREREREJBMbKCIiIiIiIpnYQBEREREREcnEBoqIiIiIiEgmNlBEREREREQysYEiIiIiIiKSiQ0UERERERGRTGygiIiIiIiIZGIDRUREREREJBMbKCIiIiIiIpnYQBEREREREcnEBoqIiIiIiEgmNlBEREREREQysYEiIiIiIiKSiQ0UERERERGRTGygiIiIiIiIZGIDRUREREREJBMbKCIiIiIiIpnYQBGR3UhOTkbbtm1Ro0YNeHl5oU+fPjh58qTRmDt37iAuLg61atVC9erV0a9fP+Tl5RmNuXDhAqKjo+Hq6govLy9MmDAB9+7dMxqTkZGBp59+GiqVCo0aNUJKSoq50yMiK2J9ISK52EARkd3YsWMH4uLisG/fPmg0Guh0OkRERODmzZvSmHHjxuGnn37C6tWrsWPHDvz999/o27evNL+oqAjR0dG4e/cu9u7diy+//BIpKSmYNm2aNObs2bOIjo7Gc889h+zsbIwdOxYjRozA5s2bLZovEVkO6wsRyVXN2gEQEcm1adMmo8cpKSnw8vJCVlYWOnfujIKCAnz++edIS0tD165dAQDLly9H06ZNsW/fPrRv3x7p6ek4fvw4tmzZAm9vb7Rq1QozZszApEmTkJCQAKVSiWXLliEgIABz5swBADRt2hS7d+/GvHnzEBkZafG8icj8WF+ISC7ugSIiu1VQUAAA8PT0BABkZWVBp9MhPDxcGtOkSRPUr18fmZmZAIDMzEwEBwfD29tbGhMZGYnCwkLk5ORIYx5chmGMYRlEVPmxvhBRabgHiojskl6vx9ixY9GhQwc0b94cAJCbmwulUgkPDw+jsd7e3sjNzZXGPPjlxjDfMK+sMYWFhbh9+zZcXFyM5mm1Wmi1WulxYWEhAECn00Gn05Wag2GeykHIylmOstZXXipH08VltNz/n+/j5m3KXC3BEK+9xf04zJGzJbYf60vZyzSF8tYXU9UNOcz9HqtMtaAy5QLIz8MsDdRff/2FSZMm4eeff8atW7fQqFEjLF++HG3atAEACCEwffp0/Pe//0V+fj46dOiApUuX4sknn5SWcfXqVbz55pv46aef4ODggH79+mHBggWoXr26NObIkSOIi4vDwYMHUadOHbz55puYOHGiOVIiIhsTFxeHY8eOYffu3dYOBcnJyUhMTCw2PT09Ha6uro98/ow2epPFsnHjRpMta3Y7ky2qRI+btylztSSNRmPtECzOlDnfunXLZMsqDetLyWyhvpgyn9JYqrZUplpQWXKRW19M3kBdu3YNHTp0wHPPPYeff/4ZderUwalTp1CzZk1pzOzZs7Fw4UJ8+eWXCAgIwNSpUxEZGYnjx4/D2dkZADBo0CBcvHhROpHztddew6hRo5CWlgbg/i8wERERCA8Px7Jly3D06FEMGzYMHh4eGDVqlKnTIiIbEh8fj/Xr12Pnzp2oV6+eNN3Hxwd3795Ffn6+0a/EeXl58PHxkcYcOHDAaHmGq2g9OObhK2vl5eVBrVYX+3UYACZPnozx48dLjwsLC+Hn54eIiAio1epS89DpdNBoNJh6yAFavUJm9mU7lmC6cyiaJ5jnpHaVg8CMNvrHztuUuVqC4fXu3r07nJycrB2ORZgjZ8MeGHNhfSmdNeuLqeqGHOauLZWpFlSmXAD59cXkDdSsWbPg5+eH5cuXS9MCAgKk/xdCYP78+ZgyZQp69+4NAPjqq6/g7e2NtWvXIiYmBidOnMCmTZtw8OBBaa/VokWL0LNnT3z88cfw9fVFamoq7t69iy+++AJKpRLNmjVDdnY25s6dywaKqJISQuDNN9/EDz/8gIyMDKPaAgAhISFwcnLC1q1b0a9fPwDAyZMnceHCBYSFhQEAwsLC8MEHH+DSpUvw8vICcP+XM7VajaCgIGnMw79AajQaaRkPU6lUUKlUxaY7OTnJ+oOi1SugLTLNFwJT/gEzVUylLv8x87bXP9Zy3xeViSlzNte2Y315NFuoL6bMpzSW+nxWplpQWXKRm4PJLyKxbt06tGnTBi+//DK8vLzQunVr/Pe//5Xmnz17Frm5uUYnULq7uyM0NNToJEwPDw+peQKA8PBwODg4YP/+/dKYzp07Q6lUSmMiIyNx8uRJXLt2zdRpEZENiIuLwzfffIO0tDTUqFEDubm5yM3Nxe3btwHcryXDhw/H+PHjsX37dmRlZeG1115DWFgY2rdvDwCIiIhAUFAQBg8ejF9//RWbN2/GlClTEBcXJ31JGT16NP744w9MnDgRv/32G5YsWYJVq1Zh3LhxVsudiMyL9YWI5DL5Hqg//vgDS5cuxfjx4/Huu+/i4MGDeOutt6BUKhEbGyudRFnSCZQPnmBp+OVGCrRaNXh6ehqNefjXoQdP1HzwkEGDipyIaesnYT6OynbinwHzsj5zxbh06VIAQJcuXYymL1++HEOHDgUAzJs3TzpvUqvVIjIyEkuWLJHGOjo6Yv369RgzZgzCwsLg5uaG2NhYJCUlSWMCAgKwYcMGjBs3DgsWLEC9evXw2Wef8RLDRJUY6wsRyWXyBkqv16NNmzb48MMPAQCtW7fGsWPHsGzZMsTGxpp6deXyOCdi2upJmKZQWU78exjzsh5zneQtxKN/yHB2dsbixYuxePHiUsf4+/s/8nPYpUsXHD58uNwxEpF9Yn0hIrlM3kDVrVtXOs7XoGnTpvj+++8B/N9JlHl5eahbt640Ji8vD61atZLGXLp0yWgZ9+7dw9WrVx95EuaD63hYRU7EtPWTMB9HZTvxz4B5WZ+5T/ImIiIishaTN1AdOnTAyZMnjab9/vvv8Pf3B3B/17WPjw+2bt0qNUyFhYXYv38/xowZA+D+CZb5+fnIyspCSEgIAGDbtm3Q6/UIDQ2Vxrz33nvQ6XTSl0mNRoPGjRuXePge8HgnYtrqSZimUFlO/HsY87IeW4+PiIiIqKJMfhGJcePGYd++ffjwww9x+vRppKWl4dNPP0VcXBwAQKFQYOzYsXj//fexbt06HD16FEOGDIGvry/69OkD4P4eqx49emDkyJE4cOAA9uzZg/j4eMTExMDX1xcAMHDgQCiVSgwfPhw5OTlYuXIlFixYYLSHiYiIiIiIyJRMvgeqbdu2+OGHHzB58mQkJSUhICAA8+fPx6BBg6QxEydOxM2bNzFq1Cjk5+ejY8eO2LRpk3QPKABITU1FfHw8unXrJp2wuXDhQmm+u7s70tPTERcXh5CQENSuXRvTpk3jJcyJiIiIiMhsTN5AAcDzzz+P559/vtT5CoUCSUlJRleleZinp6d009zStGjRArt27apwnEREREREROVh8kP4iIiIiIiIKis2UERERERERDKxgSIiIiIiIpKJDRQREREREZFMbKCIiIiIiIhkYgNFREREREQkExsoIiIiIiIimdhAERERERERycQGioiIiIiISCY2UERERERERDKxgSIiIiIiIpKJDRQREREREZFM1awdABERmU6DdzZYOwQiqqRYX4ju4x4oIiIiIiIimdhAERERERERycQGioiIiIiISCY2UERkN3bu3IlevXrB19cXCoUCa9euNZo/dOhQKBQKo389evQwGnP16lUMGjQIarUaHh4eGD58OG7cuGE05siRI+jUqROcnZ3h5+eH2bNnmzs1IrIy1hcikosNFBHZjZs3b6Jly5ZYvHhxqWN69OiBixcvSv++/fZbo/mDBg1CTk4ONBoN1q9fj507d2LUqFHS/MLCQkRERMDf3x9ZWVn46KOPkJCQgE8//dRseRGR9bG+EJFcvAofEdmNqKgoREVFlTlGpVLBx8enxHknTpzApk2bcPDgQbRp0wYAsGjRIvTs2RMff/wxfH19kZqairt37+KLL76AUqlEs2bNkJ2djblz5xp9ESLrM+UVwc7NjDbZssg+sb6QgamvNsj6UvmwgSKiSiUjIwNeXl6oWbMmunbtivfffx+1atUCAGRmZsLDw0P6cgMA4eHhcHBwwP79+/Hiiy8iMzMTnTt3hlKplMZERkZi1qxZuHbtGmrWrFlsnVqtFlqtVnpcWFgIANDpdNDpdKXGapinchCPl7SdMeRrS3mX9TqZeh2WWJetMEfO1tx+rC/WY4t1Q66HX6fKVAsqUy6A/DzYQBFRpdGjRw/07dsXAQEBOHPmDN59911ERUUhMzMTjo6OyM3NhZeXl9FzqlWrBk9PT+Tm5gIAcnNzERAQYDTG29tbmlfSF5zk5GQkJiYWm56eng5XV9dHxj2jjV52jpWJLeW9ceNGi61Lo9FYbF22wpQ537p1y2TLKg/WF9tgj/mUVl8qUy2oLLnIrS9soIio0oiJiZH+Pzg4GC1atEBgYCAyMjLQrVs3s6138uTJGD9+vPS4sLAQfn5+iIiIgFqtLvV5Op0OGo0GUw85QKtXmC0+W6NyEJjRRm9TeR9LiDT7Ogyvd/fu3eHk5GT29dkCc+Rs2ANjaawv1mWLdUOuh+tLZaoFlSkXQH59YQNF/6+9e4+Oor7/P/7a3DYESMItCSkBgygX5WaCYbkVJSRgtFJpFaWAluJXGvwWU7XSn+UitlEUUDSKVgVtpaA9gggUEoNcDSCRlIuWguI3UkkQkISAJJtkfn94MnXNhQE2u9nN83FOzmFnPjv7fk+ST/bF7MwAfqtr165q3769Dh8+rBEjRigmJkbHjx93GVNZWalTp06Z5zXExMSouLjYZUzN4/rOfbDb7bLb7bWWBwcHW/qDUl5tU3mVb70hcIem1Lcn//Bb/bnwJ+7suansO+YX7/DFfur7PvnTXOAvvVjtgavwAfBbR48e1cmTJ9WxY0dJksPh0OnTp5Wfn2+O2bhxo6qrq5WUlGSO2bJli8vnoHNyctS9e/c6P14DoHlifgGaLwIUAJ9RVlamgoICFRQUSJKOHDmigoICFRYWqqysTA899JB27NihL774Qrm5ubr11lvVrVs3paZ+9/GJnj17atSoUZoyZYp27dql7du3a9q0aRo3bpxiY2MlSXfddZdCQkI0efJkHThwQCtWrNCzzz7r8hEaAP6H+QWAVQQoAD5j9+7d6t+/v/r37y9JysjIUP/+/TVz5kwFBgZq7969+slPfqKrr75akydPVkJCgrZu3ery8Zc333xTPXr00IgRI3TTTTdpyJAhLvdgiYiIUHZ2to4cOaKEhAT99re/1cyZM7nEMODnmF8AWMU5UAB8xvDhw2UY9V/CdsOGDRfcRtu2bbVs2bIGx/Tp00dbt2696PoA+C7mFwBWcQQKAAAAACwiQAEAAACARQQoAAAAALCo0QPUE088IZvNpunTp5vLzp8/r/T0dLVr106tWrXS2LFja90XobCwUGlpaQoLC1NUVJQeeughVVZWuozZtGmTrrvuOtntdnXr1k1Lly5t7HYAAAAANGONGqA++ugjvfTSS+rTp4/L8gceeEDvvfee3n77bW3evFlfffWVbrvtNnN9VVWV0tLSVFFRoQ8//FCvv/66li5dqpkzZ5pjjhw5orS0NN1www0qKCjQ9OnT9atf/crSSZ4AAAAAcCkaLUCVlZVp/Pjx+vOf/+xyc7iSkhK9+uqrWrBggW688UYlJCRoyZIl+vDDD7Vjxw5JUnZ2tj755BP99a9/Vb9+/TR69GjNnTtXWVlZqqiokCQtXrxY8fHxmj9/vnr27Klp06bpZz/7mRYuXNhYLQEAAABo5hrtMubp6elKS0tTcnKyHn/8cXN5fn6+nE6nkpOTzWU9evRQ586dlZeXp4EDByovL0+9e/dWdHS0OSY1NVVTp07VgQMH1L9/f+Xl5blso2bM9z8q+EPl5eUqLy83H5eWlkqSnE6ny13Bv69muT2g/kubXqz6XsvTaupoKvW4C315ny/UCAAAcCkaJUAtX75cH3/8sT766KNa64qKihQSEqLIyEiX5dHR0SoqKjLHfD881ayvWdfQmNLSUn377bdq0aJFrdfOzMzUnDlzai3Pzs5WWFhYgz3NTaxucP3FWLdundu25Q45OTneLqFR0Jf3nDt3ztslAAAANAq3B6gvv/xSv/nNb5STk6PQ0FB3b/6yzJgxQxkZGebj0tJSxcXFKSUlReHh4XU+x+l0KicnR3/YHaDyaptb6tg/O9Ut27lcNb2NHDlSwcHB3i7HbejL+2qO7gIAAPgbtweo/Px8HT9+XNddd525rKqqSlu2bNHzzz+vDRs2qKKiQqdPn3Y5ClVcXKyYmBhJUkxMjHbt2uWy3Zqr9H1/zA+v3FdcXKzw8PA6jz5Jkt1ul91ur7U8ODj4gm9Iy6ttKq9yT4Bqam9+rfTvi+jLe5p6fQAAAJfK7ReRGDFihPbt26eCggLzKzExUePHjzf/HRwcrNzcXPM5Bw8eVGFhoRwOhyTJ4XBo3759On78uDkmJydH4eHh6tWrlznm+9uoGVOzDQAAAABwN7cfgWrdurWuvfZal2UtW7ZUu3btzOWTJ09WRkaG2rZtq/DwcN1///1yOBwaOHCgJCklJUW9evXShAkTNG/ePBUVFenRRx9Venq6eQTpvvvu0/PPP6+HH35Yv/zlL7Vx40a99dZbWrt2rbtbAgAAAABJjXgVvoYsXLhQAQEBGjt2rMrLy5WamqoXXnjBXB8YGKg1a9Zo6tSpcjgcatmypSZNmqTHHnvMHBMfH6+1a9fqgQce0LPPPqtOnTrplVdeUWpq0zi/CAAAAID/8UiA2rRpk8vj0NBQZWVlKSsrq97ndOnS5YJXqxs+fLj27NnjjhIBAAAA4IIa7Ua6AAAAAOBvCFAAAAAAYBEBCgAAAAAsIkABAAAAgEUEKAAAAACwiAAFAAAAABYRoAAAAADAIgIUAJ+xZcsW3XLLLYqNjZXNZtOqVatc1huGoZkzZ6pjx45q0aKFkpOTdejQIZcxp06d0vjx4xUeHq7IyEhNnjxZZWVlLmP27t2roUOHKjQ0VHFxcZo3b15jtwbAy5hfAFhFgALgM86ePau+ffvWexPuefPmadGiRVq8eLF27typli1bKjU1VefPnzfHjB8/XgcOHFBOTo7WrFmjLVu26N577zXXl5aWKiUlRV26dFF+fr6eeuopzZ49Wy+//HKj9wfAe5hfAFgV5O0CAMCq0aNHa/To0XWuMwxDzzzzjB599FHdeuutkqQ33nhD0dHRWrVqlcaNG6dPP/1U69ev10cffaTExERJ0nPPPaebbrpJTz/9tGJjY/Xmm2+qoqJCr732mkJCQnTNNdeooKBACxYscHkjBMC/ML8AsIoABcAvHDlyREVFRUpOTjaXRUREKCkpSXl5eRo3bpzy8vIUGRlpvrmRpOTkZAUEBGjnzp366U9/qry8PA0bNkwhISHmmNTUVD355JP65ptv1KZNm1qvXV5ervLycvNxaWmpJMnpdMrpdNZbc806e4Bx6Y37oJp+m1LfDX2f3P0annitpqIxevbG/mN+8b6mOG9Y9cPvkz/NBf7Ui2S9DwIUAL9QVFQkSYqOjnZZHh0dba4rKipSVFSUy/qgoCC1bdvWZUx8fHytbdSsq+sNTmZmpubMmVNreXZ2tsLCwi5Y+9zE6guO8UdNqe9169Z57LVycnI89lpNhTt7PnfunNu2ZRXzS9Phi/3UN7/401zgL71YnV8IUABwmWbMmKGMjAzzcWlpqeLi4pSSkqLw8PB6n+d0OpWTk6M/7A5QebXNE6U2CfYAQ3MTq5tU3/tnpzb6a9R8v0eOHKng4OBGf72moDF6rjkC01wwv3ynKc4bVv1wfvGnucCfepGszy8EKAB+ISYmRpJUXFysjh07msuLi4vVr18/c8zx48ddnldZWalTp06Zz4+JiVFxcbHLmJrHNWN+yG63y26311oeHBxs6Q9KebVN5VW+9YbAHZpS3578w2/158KfuLNnb+w75pemwxf7qe/75E9zgb/0YrUHrsIHwC/Ex8crJiZGubm55rLS0lLt3LlTDodDkuRwOHT69Gnl5+ebYzZu3Kjq6molJSWZY7Zs2eLyOeicnBx17969zo/XAPB/zC8Avo8ABcBnlJWVqaCgQAUFBZK+O7G7oKBAhYWFstlsmj59uh5//HGtXr1a+/bt08SJExUbG6sxY8ZIknr27KlRo0ZpypQp2rVrl7Zv365p06Zp3Lhxio2NlSTdddddCgkJ0eTJk3XgwAGtWLFCzz77rMtHaAD4H+YXAFbxET4APmP37t264YYbzMc1bzomTZqkpUuX6uGHH9bZs2d177336vTp0xoyZIjWr1+v0NBQ8zlvvvmmpk2bphEjRiggIEBjx47VokWLzPURERHKzs5Wenq6EhIS1L59e82cOZNLDAN+jvkFgFUEKAA+Y/jw4TKM+i9ha7PZ9Nhjj+mxxx6rd0zbtm21bNmyBl+nT58+2rp16yXXCcD3ML8AsIqP8AEAAACARQQoAAAAALCIAAUAAAAAFhGgAAAAAMAiAhQAAAAAWESAAgAAAACLCFAAAAAAYBEBCgAAAAAsIkABAAAAgEUEKAAAAACwKMjbBQAA4G1XPLLWrdv74ok0t24PgO/64fxiDzQ073rp2tkbVF5lu+jtMb94n9uPQGVmZmrAgAFq3bq1oqKiNGbMGB08eNBlzPnz55Wenq527dqpVatWGjt2rIqLi13GFBYWKi0tTWFhYYqKitJDDz2kyspKlzGbNm3SddddJ7vdrm7dumnp0qXubgcAAAAATG4PUJs3b1Z6erp27NihnJwcOZ1OpaSk6OzZs+aYBx54QO+9957efvttbd68WV999ZVuu+02c31VVZXS0tJUUVGhDz/8UK+//rqWLl2qmTNnmmOOHDmitLQ03XDDDSooKND06dP1q1/9Shs2bHB3SwAAAAAgqRE+wrd+/XqXx0uXLlVUVJTy8/M1bNgwlZSU6NVXX9WyZct04403SpKWLFminj17aseOHRo4cKCys7P1ySef6P3331d0dLT69eunuXPn6ne/+51mz56tkJAQLV68WPHx8Zo/f74kqWfPntq2bZsWLlyo1NRUd7cFAAAAAI1/EYmSkhJJUtu2bSVJ+fn5cjqdSk5ONsf06NFDnTt3Vl5eniQpLy9PvXv3VnR0tDkmNTVVpaWlOnDggDnm+9uoGVOzDQAAAABwt0a9iER1dbWmT5+uwYMH69prr5UkFRUVKSQkRJGRkS5jo6OjVVRUZI75fniqWV+zrqExpaWl+vbbb9WiRYta9ZSXl6u8vNx8XFpaKklyOp1yOp119lCz3B5gWOrZivpey9Nq6mgq9bgLfXmfL9QIAABwKRo1QKWnp2v//v3atm1bY76MZZmZmZozZ06t5dnZ2QoLC2vwuXMTq91Wx7p169y2LXfIycnxdgmNgr6859y5c94uAQAAoFE0WoCaNm2a1qxZoy1btqhTp07m8piYGFVUVOj06dMuR6GKi4sVExNjjtm1a5fL9mqu0vf9MT+8cl9xcbHCw8PrPPokSTNmzFBGRob5uLS0VHFxcUpJSVF4eHidz3E6ncrJydEfdgeovPriLzVZl/2zm8Y5WjW9jRw5UsHBwd4ux23oy/tqju4CAAD4G7cHKMMwdP/992vlypXatGmT4uPjXdYnJCQoODhYubm5Gjt2rCTp4MGDKiwslMPhkCQ5HA798Y9/1PHjxxUVFSXpu/91Dw8PV69evcwxPzySk5OTY26jLna7XXa7vdby4ODgC74hLa+2XdK1+uvS1N78WunfF9GX9zT1+gAAAC6V2wNUenq6li1bpnfffVetW7c2z1mKiIhQixYtFBERocmTJysjI0Nt27ZVeHi47r//fjkcDg0cOFCSlJKSol69emnChAmaN2+eioqK9Oijjyo9Pd0MQPfdd5+ef/55Pfzww/rlL3+pjRs36q233tLate69GSIAAAAA1HD7VfhefPFFlZSUaPjw4erYsaP5tWLFCnPMwoULdfPNN2vs2LEaNmyYYmJi9M4775jrAwMDtWbNGgUGBsrhcOgXv/iFJk6cqMcee8wcEx8fr7Vr1yonJ0d9+/bV/Pnz9corr3AJc6CZmz17tmw2m8tXjx49zPXuupE3gOaFuQVAjUb5CN+FhIaGKisrS1lZWfWO6dKlywUvtjB8+HDt2bPnomsE4N+uueYavf/+++bjoKD/TnUPPPCA1q5dq7ffflsRERGaNm2abrvtNm3fvl3Sf2/kHRMTow8//FDHjh3TxIkTFRwcrD/96U8e7wVA08HcAkBq5KvwAYA3BAUFmRec+T533cgbQPPE3AJA8sCNdAHA0w4dOqTY2Fh17dpV48ePV2FhoST33cgbQPPE3AJA4ggUAD+TlJSkpUuXqnv37jp27JjmzJmjoUOHav/+/W67kfcPXcpNumvWS+69UbcvqOnXn/uu6/vuSzfDdpfG6Nlb+88bc4vE/FLDn+aNy+2lKc0h/javWe2DAAXAr4wePdr8d58+fZSUlKQuXbrorbfeqvcecZfrcm7SLbn3Rt2+xJ/7bugcXl+4Gba7ubNnb92o2xtzi8T88kP+1M+l9nKhawR4g7/Ma1bnFwIUAL8WGRmpq6++WocPH9bIkSPdciPvH7qUm3RLjXOjbl9gDzA0N7Har/uu64bpvnQzbHdpjJ6byo26PTG3SMwvNfxp3rjcXuqaX7zF3+Y1q/MLAQqAXysrK9Nnn32mCRMmuO1G3j90OTfpltx7o25f4s99N/R994WbYbubO3tuKvvOE3OLxPzyQ/7Uz6X20lR+B77PX+Y1qz0QoAD4lQcffFC33HKLunTpoq+++kqzZs1SYGCg7rzzTrfdyBtA88PcAqAGAQqAXzl69KjuvPNOnTx5Uh06dNCQIUO0Y8cOdejQQdJ3N/IOCAjQ2LFjVV5ertTUVL3wwgvm82tu5D116lQ5HA61bNlSkyZNcrmRN4Dmh7kFQA0CFAC/snz58gbXu+tG3gCaF+YWADW4DxQAAAAAWESAAgAAAACLCFAAAAAAYBEBCgAAAAAsIkABAAAAgEUEKAAAAACwiMuYAwDgZlc8srbWMnugoXnXS9fO3qDyKpvlbX3xRJo7SwPg4+qaXy4V88ul4QgUAAAAAFhEgAIAAAAAiwhQAAAAAGARAQoAAAAALCJAAQAAAIBFBCgAAAAAsIgABQAAAAAWEaAAAAAAwCJupAsAQBPmzptmStw4E8B/Xe788sMbhDeX+YUABbgBb3AAAACaBwKUH7jUN+8//F8DqWm/cbfaZ1191aUp9+pu7gx4zWm/AQAA/BDnQAEAAACARRyBQrPl7o/dAQAAwP8RoLygKb9xb8q1NSd1fR+sfjQRAAAAjcfnP8KXlZWlK664QqGhoUpKStKuXbu8XRIAP8H8AqCxML8Avsunj0CtWLFCGRkZWrx4sZKSkvTMM88oNTVVBw8eVFRUlLfLA+DDmF/gr7iojPcxv8BfNZf5xaePQC1YsEBTpkzRPffco169emnx4sUKCwvTa6+95u3SAPg45hcAjYX5BfBtPnsEqqKiQvn5+ZoxY4a5LCAgQMnJycrLy6vzOeXl5SovLzcfl5SUSJJOnTolp9NZ53OcTqfOnTunIGeAqqr967yToGpD585V+11v9NW4Tp48ecExZ86ckSQZhtHY5TSKi51fLmVukfx7fmlIU/lZ9jR/7PtC80HNz/jJkycVHBzsltdkfmme84s//f7QizVW3m+4m9X5xWcD1IkTJ1RVVaXo6GiX5dHR0frXv/5V53MyMzM1Z86cWsvj4+MbpUZfcJe3C2gk9NV42s+3PvbMmTOKiIhovGIaycXOL8wtF68p/Cx7g7/1fTHzgbsxvzS/+cWffn/o5cKa8vziswHqUsyYMUMZGRnm4+rqap06dUrt2rWTzVZ3ai4tLVVcXJy+/PJLhYeHe6pUj/DX3ujL+wzD0JkzZxQbG+vtUjziUuYWybe+p+5E382n78bomfmlec4v/tQPvTRdVucXnw1Q7du3V2BgoIqLi12WFxcXKyYmps7n2O122e12l2WRkZGWXi88PNwvfjDq4q+90Zd3+eL/DNe42PnlcuYWyXe+p+5G382Hu3tmfom0/Hr+9vPmT/3QS9NkZX7x2YtIhISEKCEhQbm5ueay6upq5ebmyuFweLEyAL6O+QVAY2F+AXyfzx6BkqSMjAxNmjRJiYmJuv766/XMM8/o7Nmzuueee7xdGgAfx/wCoLEwvwC+zacD1B133KGvv/5aM2fOVFFRkfr166f169fXOjHzctjtds2aNavW4XN/4K+90Rfcgfml8dB38+m7OfZsBfPLxfOnfujF99kMX70OKAAAAAB4mM+eAwUAAAAAnkaAAgAAAACLCFAAAAAAYBEBCgAAAAAsIkBdQFZWlq644gqFhoYqKSlJu3bt8nZJDdqyZYtuueUWxcbGymazadWqVS7rDcPQzJkz1bFjR7Vo0ULJyck6dOiQy5hTp05p/PjxCg8PV2RkpCZPnqyysjIPdlFbZmamBgwYoNatWysqKkpjxozRwYMHXcacP39e6enpateunVq1aqWxY8fWulFhYWGh0tLSFBYWpqioKD300EOqrKz0ZCsuXnzxRfXp08e8AZ3D4dA//vEPc70v9gTrfG1+uVjumI98jbvmKl/jjrkM7tXU55fZs2fLZrO5fPXo0cNc39T//nnq/dbevXs1dOhQhYaGKi4uTvPmzfN4L3fffXet79WoUaOaZC8eY6Bey5cvN0JCQozXXnvNOHDggDFlyhQjMjLSKC4u9nZp9Vq3bp3x//7f/zPeeecdQ5KxcuVKl/VPPPGEERERYaxatcr45z//afzkJz8x4uPjjW+//dYcM2rUKKNv377Gjh07jK1btxrdunUz7rzzTg934io1NdVYsmSJsX//fqOgoMC46aabjM6dOxtlZWXmmPvuu8+Ii4szcnNzjd27dxsDBw40Bg0aZK6vrKw0rr32WiM5OdnYs2ePsW7dOqN9+/bGjBkzvNGSYRiGsXr1amPt2rXGv//9b+PgwYPG73//eyM4ONjYv3+/YRi+2ROs8cX55WK5Yz7yNe6Yq3zR5c5lcC9fmF9mzZplXHPNNcaxY8fMr6+//tpc39T//nni/VZJSYkRHR1tjB8/3ti/f7/xt7/9zWjRooXx0ksvebSXSZMmGaNGjXL5Xp06dcplTFPpxVMIUA24/vrrjfT0dPNxVVWVERsba2RmZnqxKut++EtQXV1txMTEGE899ZS57PTp04bdbjf+9re/GYZhGJ988okhyfjoo4/MMf/4xz8Mm81m/Oc///FY7Rdy/PhxQ5KxefNmwzC+6yM4ONh4++23zTGffvqpIcnIy8szDOO7CSIgIMAoKioyx7z44otGeHi4UV5e7tkGGtCmTRvjlVde8aueUJuvzy8X61LmI39wKXOVv7iYuQzu5Qvzy6xZs4y+ffvWuc7X/v411vutF154wWjTpo1LP7/73e+M7t27e6wXw/guQN166631Pqep9tKY+AhfPSoqKpSfn6/k5GRzWUBAgJKTk5WXl+fFyi7dkSNHVFRU5NJTRESEkpKSzJ7y8vIUGRmpxMREc0xycrICAgK0c+dOj9dcn5KSEklS27ZtJUn5+flyOp0uvfXo0UOdO3d26a13794uNypMTU1VaWmpDhw44MHq61ZVVaXly5fr7NmzcjgcftET6uaP88vFsjIf+YNLmat83aXMZXAfX5pfDh06pNjYWHXt2lXjx49XYWGhJN//m+6u91t5eXkaNmyYQkJCzDGpqak6ePCgvvnmGw91851NmzYpKipK3bt319SpU3Xy5Elzna/14g4EqHqcOHFCVVVVte4KHh0draKiIi9VdXlq6m6op6KiIkVFRbmsDwoKUtu2bZtM39XV1Zo+fboGDx6sa6+9VtJ3dYeEhCgyMtJl7A97q6v3mnXesm/fPrVq1Up2u1333XefVq5cqV69evl0T2iYP84vF8vKfOTrLnWu8lWXM5fBfXxlfklKStLSpUu1fv16vfjiizpy5IiGDh2qM2fO+PzfP3e932oqPY4aNUpvvPGGcnNz9eSTT2rz5s0aPXq0qqqqzFp8pRd3CfJ2AcDFSk9P1/79+7Vt2zZvl+IW3bt3V0FBgUpKSvT3v/9dkyZN0ubNm71dFoDL5G9z1YUwl+FijB492vx3nz59lJSUpC5duuitt95SixYtvFgZfmjcuHHmv3v37q0+ffroyiuv1KZNmzRixAgvVuY9HIGqR/v27RUYGFjrii/FxcWKiYnxUlWXp6buhnqKiYnR8ePHXdZXVlbq1KlTTaLvadOmac2aNfrggw/UqVMnc3lMTIwqKip0+vRpl/E/7K2u3mvWeUtISIi6deumhIQEZWZmqm/fvnr22Wd9uic0zB/nl4tlZT7yZZczV/mqy5nL4D6+Or9ERkbq6quv1uHDh33+75+73m811R67du2q9u3b6/Dhw2YtvtrLpSJA1SMkJEQJCQnKzc01l1VXVys3N1cOh8OLlV26+Ph4xcTEuPRUWlqqnTt3mj05HA6dPn1a+fn55piNGzequrpaSUlJHq+5hmEYmjZtmlauXKmNGzcqPj7eZX1CQoKCg4Ndejt48KAKCwtdetu3b5/LL3lOTo7Cw8PVq1cvzzRiQXV1tcrLy/2qJ7jyx/nlYlmZj3yRO+Yqf3Excxncx1fnl7KyMn322Wfq2LGjz//9c9f7LYfDoS1btsjpdJpjcnJy1L17d7Vp08ZD3dR29OhRnTx5Uh07dpTk271cMm9fxaIpW758uWG3242lS5can3zyiXHvvfcakZGRLld8aWrOnDlj7Nmzx9izZ48hyViwYIGxZ88e4//+7/8Mw/juspqRkZHGu+++a+zdu9e49dZb67ysZv/+/Y2dO3ca27ZtM6666iqvX8Z86tSpRkREhLFp0yaXy2ieO3fOHHPfffcZnTt3NjZu3Gjs3r3bcDgchsPhMNfXXPI0JSXFKCgoMNavX2906NDBq5f8fuSRR4zNmzcbR44cMfbu3Ws88sgjhs1mM7Kzsw3D8M2eYI0vzi8Xyx3zka9xx1zliy53LoN7+cL88tvf/tbYtGmTceTIEWP79u1GcnKy0b59e+P48eOGYTT9v3+eeL91+vRpIzo62pgwYYKxf/9+Y/ny5UZYWJjbL/3dUC9nzpwxHnzwQSMvL884cuSI8f777xvXXXedcdVVVxnnz59vcr14CgHqAp577jmjc+fORkhIiHH99dcbO3bs8HZJDfrggw8MSbW+Jk2aZBjGd5fW/MMf/mBER0cbdrvdGDFihHHw4EGXbZw8edK48847jVatWhnh4eHGPffcY5w5c8YL3fxXXT1JMpYsWWKO+fbbb41f//rXRps2bYywsDDjpz/9qXHs2DGX7XzxxRfG6NGjjRYtWhjt27c3fvvb3xpOp9PD3fzXL3/5S6NLly5GSEiI0aFDB2PEiBHmGw7D8M2eYJ2vzS8Xyx3zka9x11zla9wxl8G9mvr8cscddxgdO3Y0QkJCjB/96EfGHXfcYRw+fNhc39T//nnq/dY///lPY8iQIYbdbjd+9KMfGU888YRHezl37pyRkpJidOjQwQgODja6dOliTJkypVYYbyq9eIrNMAyjcY9xAQAAAIB/4BwoAAAAALCIAAUAAAAAFhGgAAAAAMAiAhQAAAAAWESAAgAAAACLCFAAAAAAYBEBCgAAAAAsIkABAAAAgEUEKAAAAACwiAAFAAAAABYRoAAAAADAIgIUAAAAAFhEgAIAAAAAiwhQAAAAAGARAQoAAAAALCJAAQAAAIBFBCgAAAAAsIgABQAAAAAWEaAAAAAAwCICFAAAAABYRICCi9mzZ8tms3m7DBeVlZV6+OGHFRcXp4CAAI0ZM8bbJdXyxRdfyGaz6emnn/Z2KQAAAGhEBCh4nNPp1KJFizRgwAC1bt1arVq10oABA7Ro0SI5nc5a41977TU99dRT+tnPfqbXX39dDzzwgMLDw3XrrbfWGrtw4ULZbDZNmjSp1rqZM2fKZrPp3//+d6P0BQAAAP8X5O0C0LycPXtWaWlp2rx5s26++WbdfffdCggI0Pr16/Wb3/xG77zzjtauXauWLVuaz9m4caN+9KMfaeHCheaygQMH6sMPP6y1/e3btysoKEjbt2+vc11UVJSuvvrqxmkOAAAAfo8jUPCojIwMbd68Wc8995zee+89paena+rUqXr33Xf1/PPPa/PmzXrwwQddnnP8+HFFRka6LBsyZIhOnDihTz/91GX59u3bdfvtt+uzzz5TUVGRubyyslI7d+7U4MGDG603AAAA+D8CVDO2bds2DRgwQKGhobryyiv10ksv1RqzZMkS3XjjjYqKipLdblevXr304osvuoyZNGmS2rdvX+fH71JSUtS9e3dJ0tGjR/Xqq6/qxhtv1LRp02qNTU9P1w033KBXXnlFR48eNc8r+uCDD3TgwAHZbDbZbDZt2rRJQ4YMkSSXI02ff/65ioqKNG3aNIWGhrqsKygo0NmzZ83nSdK//vUv/exnP1Pbtm0VGhqqxMRErV69ulZdp0+f1vTp0xUXFye73a5u3brpySefVHV1dYP71zAM3XvvvQoJCdE777zT4FgAAAD4BgJUM7Vv3z6lpKTo+PHjmj17tu655x7NmjVLK1eudBn34osvqkuXLvr973+v+fPnKy4uTr/+9a+VlZVljpkwYYJOnjypDRs2uDy3qKhIGzdu1C9+8QtJ0j/+8Q9VVVVp4sSJ9dY1ceJEVVZWav369erQoYP+8pe/qEePHurUqZP+8pe/6C9/+Yt69uypgQMHKigoSNu2bTOfu337drVs2VIDBgxQYmKiS4Cq+XdNgDpw4IAGDhyoTz/9VI888ojmz5+vli1basyYMS774Ny5c/rxj3+sv/71r5o4caIWLVqkwYMHa8aMGcrIyKi3j6qqKt1999164403tHLlSt122231jgUAAIAPMdAsjRkzxggNDTX+7//+z1z2ySefGIGBgcb3fyzOnTtX67mpqalG165dzcdVVVVGp06djDvuuMNl3IIFCwybzWZ8/vnnhmEYxvTp0w1Jxp49e+qt6+OPPzYkGRkZGeayH//4x8Y111xTa+yAAQOMK6+80nz8P//zP8YNN9xgGIZhPPzww8aAAQPMdT/72c+MsLAww+l0GoZhGCNGjDB69+5tnD9/3hxTXV1tDBo0yLjqqqvMZXPnzjVatmxp/Pvf/3Z57UceecQIDAw0CgsLDcMwjCNHjhiSjKeeespwOp3GHXfcYbRo0cLYsGFDvb0CAADA93AEqhmqqqrShg0bNGbMGHXu3Nlc3rNnT6WmprqMbdGihfnvkpISnThxQj/+8Y/1+eefq6SkRJIUEBCg8ePHa/Xq1Tpz5ow5/s0339SgQYMUHx8vSea61q1b11tbzbrS0tIL9jFkyBCXc522b9+uQYMGSZIGDx6sPXv26Ny5c+a6pKQkBQUF6dSpU9q4caNuv/12nTlzRidOnNCJEyd08uRJpaam6tChQ/rPf/4jSXr77bc1dOhQtWnTxhx34sQJJScnq6qqSlu2bHGpqaKiQj//+c+1Zs0arVu3TikpKRfsAwAAAL6DANUMff311/r222911VVX1VpXc75Sje3btys5OVktW7ZUZGSkOnTooN///veSZAYo6buP3n377bfmx98OHjyo/Px8TZgwwRxTE46+H7J+yErIqvH986BOnz6tAwcOmBeJGDRokCorK7Vr1y4dOXJEx44dM8cfPnxYhmHoD3/4gzp06ODyNWvWLEnfXbhCkg4dOmR+nPD7X8nJyS7jamRmZmrVqlX6+9//ruHDh1+wBwAAAPgWLmOOen322WcaMWKEevTooQULFiguLk4hISFat26dFi5c6HIRhV69eikhIcE8V+ivf/2rQkJCdPvtt5tjevbsKUnau3ev+vXrV+dr7t2719zehdQEom3btiksLEyS5HA4JEnt27fXVVddpW3btunLL790GV9T94MPPljriFuNbt26mWNHjhyphx9+uM5xP7wkempqqtavX6958+Zp+PDhCg0NvWAfAAAA8B0EqGaoQ4cOatGihQ4dOlRr3cGDB81/v/feeyovL9fq1atdPur3wQcf1LndiRMnKiMjQ8eOHdOyZcuUlpamNm3amOtHjx6twMBA/eUvf6n3QhJvvPGGgoKCNGrUqAv2ERUVZYakli1bqlevXi6XOx80aJC2b9+uo0ePKjAw0AxXXbt2lSQFBwebR5Lqc+WVV6qsrOyC42oMHDhQ9913n26++Wb9/Oc/18qVKxUUxK8ZAACAv+AjfM1QYGCgUlNTtWrVKhUWFprLP/30U5cr6QUGBkr67nLcNUpKSrRkyZI6t3vnnXfKZrPpN7/5jT7//HPz6ns14uLidM899+j999+vdSl0SVq8eLE2btyoyZMnq1OnTpZ6GTJkiAoKCpSdnW2e/1Rj0KBBysvL09atW9WnTx/zY4FRUVEaPny4XnrpJR07dqzWNr/++mvz37fffrvy8vJqXWFQ+u7y5pWVlbWWJycna/ny5Vq/fr0mTJhwwcudAwAAwHfwX+PN1Jw5c7R+/XoNHTpUv/71r1VZWannnntO11xzjfkxupSUFIWEhOiWW27R//zP/6isrEx//vOfFRUVVWfw6NChg0aNGqW3335bkZGRSktLqzVm4cKF+te//qVf//rXWr9+vXmkacOGDXr33Xf14x//WPPnz7fcx5AhQ7RkyRJ99NFHSk9Pd1k3aNAglZSUqKSkRPfff7/LuqysLA0ZMkS9e/fWlClT1LVrVxUXFysvL09Hjx7VP//5T0nSQw89pNWrV+vmm2/W3XffrYSEBJ09e1b79u3T3//+d33xxRdq3759rbrGjBmjJUuWaOLEiQoPD6/zHlsAAADwQd6+DCC8Z/PmzUZCQoIREhJidO3a1Vi8eLExa9Ysl8uYr1692ujTp48RGhpqXHHFFcaTTz5pvPbaa4Yk48iRI7W2+dZbbxmSjHvvvbfe1y0vLzcWLlxoJCQkGC1btjTCwsKM6667znjmmWeMioqKWuPru4y5YRjGwYMHDUmGpFqXGq+urjYiIyMNScaKFStqPfezzz4zJk6caMTExBjBwcHGj370I+Pmm282/v73v7uMO3PmjDFjxgyjW7duRkhIiNG+fXtj0KBBxtNPP23W+/3LmH/fCy+8YEgyHnzwwXr3BwAAAHyHzTC+9/ks4DK9++67GjNmjLZs2aKhQ4d6uxwAAADArQhQcKubb75Zn376qQ4fPiybzebtcgAAAAC34hwouMXy5cu1d+9erV27Vs8++yzhCQAAAH6JI1BwC5vNplatWumOO+7Q4sWLuXQ3AAAA/BLvcuEW5HAAAAA0B9wHCgAAAAAsIkABAAAAgEXN+iN81dXV+uqrr9S6dWsuegC4kWEYOnPmjGJjYxUQwP/TAAAA/9GsA9RXX32luLg4b5cB+K0vv/xSnTp18nYZAAAAbtOsA1Tr1q0lffcmLzw8vM4xTqdT2dnZSklJUXBwsCfLa1LYD+wDyfo+KC0tVVxcnPk7BgAA4C+adYCq+dheeHh4gwEqLCxM4eHhzfZNs8R+kNgH0sXvAz4aCwAA/A0nJwAAAACARQQoAAAAALCIAAUAAAAAFhGgAAAAAMAiAhQAAAAAWESAAgAAAACL3B6gMjMzNWDAALVu3VpRUVEaM2aMDh486DLm/PnzSk9PV7t27dSqVSuNHTtWxcXFLmMKCwuVlpamsLAwRUVF6aGHHlJlZaXLmE2bNum6666T3W5Xt27dtHTpUne3AwAAAAAmtweozZs3Kz09XTt27FBOTo6cTqdSUlJ09uxZc8wDDzyg9957T2+//bY2b96sr776Srfddpu5vqqqSmlpaaqoqNCHH36o119/XUuXLtXMmTPNMUeOHFFaWppuuOEGFRQUaPr06frVr36lDRs2uLslAAAAAJDUCDfSXb9+vcvjpUuXKioqSvn5+Ro2bJhKSkr06quvatmyZbrxxhslSUuWLFHPnj21Y8cODRw4UNnZ2frkk0/0/vvvKzo6Wv369dPcuXP1u9/9TrNnz1ZISIgWL16s+Ph4zZ8/X5LUs2dPbdu2TQsXLlRqaqq729K1szeovMo9NwX94ok0t2wHAAAAgGc1+jlQJSUlkqS2bdtKkvLz8+V0OpWcnGyO6dGjhzp37qy8vDxJUl5ennr37q3o6GhzTGpqqkpLS3XgwAFzzPe3UTOmZhsAAAAA4G5uPwL1fdXV1Zo+fboGDx6sa6+9VpJUVFSkkJAQRUZGuoyNjo5WUVGROeb74almfc26hsaUlpbq22+/VYsWLWrVU15ervLycvNxaWmpJMnpdMrpdNbZQ81ye4BhqWcr6nutpqymZl+s3V3YB9b3QXPeRwAAwL81aoBKT0/X/v37tW3btsZ8GcsyMzM1Z86cWsuzs7MVFhbW4HPnJla7rY5169a5bVuelpOT4+0SvI59cOF9cO7cOQ9VAgAA4FmNFqCmTZumNWvWaMuWLerUqZO5PCYmRhUVFTp9+rTLUaji4mLFxMSYY3bt2uWyvZqr9H1/zA+v3FdcXKzw8PA6jz5J0owZM5SRkWE+Li0tVVxcnFJSUhQeHl7nc5xOp3JycvSH3QEqr3bPOVD7Z7v/HK3GVrMfRo4cqeDgYG+X4xbXzr64C47YAwzNTayu82fBF7+nl8Lqz0HN0V0AAAB/4/YAZRiG7r//fq1cuVKbNm1SfHy8y/qEhAQFBwcrNzdXY8eOlSQdPHhQhYWFcjgckiSHw6E//vGPOn78uKKioiR99z/e4eHh6tWrlznmh0dycnJyzG3UxW63y26311oeHBx8wVBQXm1z20UkfDmAWNlXvuJSv591/Sz4yz6x6kI/B81tfwAAgObD7QEqPT1dy5Yt07vvvqvWrVub5yxFRESoRYsWioiI0OTJk5WRkaG2bdsqPDxc999/vxwOhwYOHChJSklJUa9evTRhwgTNmzdPRUVFevTRR5Wenm4GoPvuu0/PP/+8Hn74Yf3yl7/Uxo0b9dZbb2nt2rXubgkAAAAAJDXCVfhefPFFlZSUaPjw4erYsaP5tWLFCnPMwoULdfPNN2vs2LEaNmyYYmJi9M4775jrAwMDtWbNGgUGBsrhcOgXv/iFJk6cqMcee8wcEx8fr7Vr1yonJ0d9+/bV/Pnz9corrzTKJcwBAAAAQGqkj/BdSGhoqLKyspSVlVXvmC5dulzwYgvDhw/Xnj17LrpG1O+KR+o+gmcPNDTv+ou/Hxb3vAIAAIA/adSr8KFu9YWUS0VIAQAAADyj0W+kCwAAAAD+giNQ8BnuPnLXlHGUEgAAoGniCBQAAAAAWESAAgAAAACLCFAAAAAAYBEBCgAAAAAsIkABAAAAgEUEKAAAAACwiAAFAAAAABYRoAAAAADAIgIUAAAAAFhEgAIAAAAAiwhQAAAAAGARAQoAAAAALCJAAQAAAIBFBCgAAAAAsIgABQAAAAAWEaAAAAAAwCICFAAAAABYRIACAAAAAIsIUAAAAABgEQEKAAAAACwiQAEAAACARQQoAAAAALCIAAUAAAAAFhGgAAAAAMAiAhQAAAAAWESAAgAAAACLCFAAAAAAYBEBCgAAAAAsIkABAAAAgEUEKAAAAACwiAAFAAAAABYRoAAAAADAIgIUAAAAAFhEgAIAAAAAiwhQAAAAAGARAQoAAAAALCJAAQAAAIBFbg9QW7Zs0S233KLY2FjZbDatWrXKZf3dd98tm83m8jVq1CiXMadOndL48eMVHh6uyMhITZ48WWVlZS5j9u7dq6FDhyo0NFRxcXGaN2+eu1sBAAAAABduD1Bnz55V3759lZWVVe+YUaNG6dixY+bX3/72N5f148eP14EDB5STk6M1a9Zoy5Ytuvfee831paWlSklJUZcuXZSfn6+nnnpKs2fP1ssvv+zudgAAAADAFOTuDY4ePVqjR49ucIzdbldMTEyd6z799FOtX79eH330kRITEyVJzz33nG666SY9/fTTio2N1ZtvvqmKigq99tprCgkJ0TXXXKOCggItWLDAJWgBAAAAgDu5PUBZsWnTJkVFRalNmza68cYb9fjjj6tdu3aSpLy8PEVGRprhSZKSk5MVEBCgnTt36qc//any8vI0bNgwhYSEmGNSU1P15JNP6ptvvlGbNm3qfN3y8nKVl5ebj0tLSyVJTqdTTqezzufULLcHGJfXdCOqr/ZLYQ+su8+a/i92P3iiNk9paB+4s0/J/b26q76a7Vxoe+7eHwAAAE2FxwPUqFGjdNtttyk+Pl6fffaZfv/732v06NHKy8tTYGCgioqKFBUV5VpkUJDatm2roqIiSVJRUZHi4+NdxkRHR5vr6gtQmZmZmjNnTq3l2dnZCgsLa7DuuYnVlnv0tHXr1rltW/Oub3j9xe4HT9bmKXXtA3f2Kbm/V3fXl5OT0+D6c+fOufX1AAAAmgqPB6hx48aZ/+7du7f69OmjK6+8Ups2bdKIESMa9bVnzJihjIwM83Fpaani4uKUkpKi8PDwOp/jdDqVk5OjP+wOUHm1rVHru1T7Z6e6bVvXzt5Q53J7gKG5idUXvR88UZunNLQP3Nmn5P5e3VVfze/DyJEjFRwcXO+4mqO7AAAA/sYrH+H7vq5du6p9+/Y6fPiwRowYoZiYGB0/ftxlTGVlpU6dOmWeNxUTE6Pi4mKXMTWP6zu3Svru3Cu73V5reXBwcINvBiWpvNqm8qqmGaAuVPvFuFCPF7sfPFmbp9S1D9zZp+T+Xt1d34V+Z9z9egAAAE2F1+8DdfToUZ08eVIdO3aUJDkcDp0+fVr5+fnmmI0bN6q6ulpJSUnmmC1btricZ5GTk6Pu3bvX+/E9AAAAALhcbg9QZWVlKigoUEFBgSTpyJEjKigoUGFhocrKyvTQQw9px44d+uKLL5Sbm6tbb71V3bp1U2rqdx8x6tmzp0aNGqUpU6Zo165d2r59u6ZNm6Zx48YpNjZWknTXXXcpJCREkydP1oEDB7RixQo9++yzLh/PAwAAAAB3c3uA2r17t/r376/+/ftLkjIyMtS/f3/NnDlTgYGB2rt3r37yk5/o6quv1uTJk5WQkKCtW7e6fLTuzTffVI8ePTRixAjddNNNGjJkiMs9niIiIpSdna0jR44oISFBv/3tbzVz5kwuYQ4AAACgUbn9HKjhw4fLMOq/BPOGDRc+Ob5t27ZatmxZg2P69OmjrVu3XnR9AAAAAHCpvH4OFAAAAAD4CgIUAAAAAFhEgAIAAAAAiwhQAAAAAGARAQoAAAAALCJAAQAAAIBFBCgAAAAAsIgABQAAAAAWEaAAAAAAwCICFAAAAABYRIACAAAAAIsIUAAAAABgUZC3CwDQ+K54ZK1btmMPNDTverdsCgAAwCdxBAoAAAAALCJAAQAAAIBFBCgAAAAAsIgABQAAAAAWEaAAAAAAwCICFAAAAABYRIACAAAAAIsIUAAAAABgEQEKAAAAACwiQAEAAACARQQoAAAAALCIAAUAAAAAFhGgAAAAAMAiAhQAAAAAWESAAgAAAACLCFAAAAAAYBEBCgAAAAAsIkABAAAAgEUEKAAAAACwiAAFAAAAABYRoAAAAADAIgIUAAAAAFhEgAIAAAAAiwhQAAAAAGARAQoAAAAALCJAAQAAAIBFbg9QW7Zs0S233KLY2FjZbDatWrXKZb1hGJo5c6Y6duyoFi1aKDk5WYcOHXIZc+rUKY0fP17h4eGKjIzU5MmTVVZW5jJm7969Gjp0qEJDQxUXF6d58+a5uxUAAAAAcOH2AHX27Fn17dtXWVlZda6fN2+eFi1apMWLF2vnzp1q2bKlUlNTdf78eXPM+PHjdeDAAeXk5GjNmjXasmWL7r33XnN9aWmpUlJS1KVLF+Xn5+upp57S7Nmz9fLLL7u7HQAAAAAwBbl7g6NHj9bo0aPrXGcYhp555hk9+uijuvXWWyVJb7zxhqKjo7Vq1SqNGzdOn376qdavX6+PPvpIiYmJkqTnnntON910k55++mnFxsbqzTffVEVFhV577TWFhITommuuUUFBgRYsWOAStAAAAADAndweoBpy5MgRFRUVKTk52VwWERGhpKQk5eXlady4ccrLy1NkZKQZniQpOTlZAQEB2rlzp376058qLy9Pw4YNU0hIiDkmNTVVTz75pL755hu1adOmztcvLy9XeXm5+bi0tFSS5HQ65XQ663xOzXJ7gHHpjTey+mq/FPbAuvus6f9i94MnavOUhvaBO/uUvN9rfWp6v1C/7t4fAAAATYVHA1RRUZEkKTo62mV5dHS0ua6oqEhRUVEu64OCgtS2bVuXMfHx8bW2UbOuvgCVmZmpOXPm1FqenZ2tsLCwBmufm1jd4HpvWrdundu2Ne/6htdf7H7wZG2eUtc+cGefUtPptT45OTkNrj937pyHKgEAAPAsjwYob5sxY4YyMjLMx6WlpYqLi1NKSorCw8PrfI7T6VROTo7+sDtA5dU2T5V6UfbPTnXbtq6dvaHO5fYAQ3MTqy96P3iiNk9paB+4s0/J+73Wp2YfjBw5UsHBwfWOqzm6CwAA4G88GqBiYmIkScXFxerYsaO5vLi4WP369TPHHD9+3OV5lZWVOnXqlPn8mJgYFRcXu4ypeVwzpi52u112u73W8uDg4AbfDEpSebVN5VVNM0BdqPaLcaEeL3Y/eLI2T6lrH7izT6np9FqfC/3OuHt/AAAANBUevQ9UfHy8YmJilJubay4rLS3Vzp075XA4JEkOh0OnT59Wfn6+OWbjxo2qrq5WUlKSOWbLli0u51nk5OSoe/fu9X58DwAAAAAul9sDVFlZmQoKClRQUCDpuwtHFBQUqLCwUDabTdOnT9fjjz+u1atXa9++fZo4caJiY2M1ZswYSVLPnj01atQoTZkyRbt27dL27ds1bdo0jRs3TrGxsZKku+66SyEhIZo8ebIOHDigFStW6Nlnn3X5eB4AAAAAuJvbP8K3e/du3XDDDebjmlAzadIkLV26VA8//LDOnj2re++9V6dPn9aQIUO0fv16hYaGms958803NW3aNI0YMUIBAQEaO3asFi1aZK6PiIhQdna20tPTlZCQoPbt22vmzJlcwhwAAABAo3J7gBo+fLgMo/5LMNtsNj322GN67LHH6h3Ttm1bLVu2rMHX6dOnj7Zu3XrJdQIAAADAxfLoOVAAAAAA4MsIUAAAAABgEQEKAAAAACwiQAEAAACARQQoAAAAALCIAAUAAAAAFhGgAAAAAMAiAhQAAAAAWESAAgAAAACLCFAAAAAAYBEBCgAAAAAsIkABAAAAgEUEKAAAAACwiAAFAAAAABYRoAAAAADAIgIUAAAAAFhEgAIAAAAAiwhQAAAAAGARAQoAAAAALCJAAQAAAIBFBCgAAAAAsIgABQAAAAAWEaAAAAAAwCICFAAAAABYRIACAAAAAIsIUAAAAABgEQEKAAAAACwiQAEAAACARQQoAAAAALCIAAUAAAAAFhGgAAAAAMAiAhQAAAAAWESAAgAAAACLCFAAAAAAYBEBCgAAAAAsIkABAAAAgEUEKAAAAACwiAAFAAAAABYRoAAAAADAIq8EqNmzZ8tms7l89ejRw1x//vx5paenq127dmrVqpXGjh2r4uJil20UFhYqLS1NYWFhioqK0kMPPaTKykpPtwIAAACgGQny1gtfc801ev/99/9bSNB/S3nggQe0du1avf3224qIiNC0adN02223afv27ZKkqqoqpaWlKSYmRh9++KGOHTumiRMnKjg4WH/605883gsAAACA5sFrASooKEgxMTG1lpeUlOjVV1/VsmXLdOONN0qSlixZop49e2rHjh0aOHCgsrOz9cknn+j9999XdHS0+vXrp7lz5+p3v/udZs+erZCQEE+3AwAAAKAZ8FqAOnTokGJjYxUaGiqHw6HMzEx17txZ+fn5cjqdSk5ONsf26NFDnTt3Vl5engYOHKi8vDz17t1b0dHR5pjU1FRNnTpVBw4cUP/+/et8zfLycpWXl5uPS0tLJUlOp1NOp7PO59QstwcYl91zY6mv9kthD6y7z5r+L3Y/eKI2T2loH7izT8n7vdanpvcL9evu/QEAANBUeCVAJSUlaenSperevbuOHTumOXPmaOjQodq/f7+KiooUEhKiyMhIl+dER0erqKhIklRUVOQSnmrW16yrT2ZmpubMmVNreXZ2tsLCwhqseW5itZXWvGLdunVu29a86xtef7H7wZO1eUpd+8CdfUpNp9f65OTkNLj+3LlzHqoEAADAs7wSoEaPHm3+u0+fPkpKSlKXLl301ltvqUWLFo32ujNmzFBGRob5uLS0VHFxcUpJSVF4eHidz3E6ncrJydEfdgeovNrWaLVdjv2zU922rWtnb6hzuT3A0NzE6oveD56ozVMa2gfu7FPyfq/1qdkHI0eOVHBwcL3jao7uAgAA+BuvfYTv+yIjI3X11Vfr8OHDGjlypCoqKnT69GmXo1DFxcXmOVMxMTHatWuXyzZqrtJX13lVNex2u+x2e63lwcHBDb4ZlKTyapvKq5pmgLpQ7RfjQj1e7H7wZG2eUtc+cGefUtPptT4X+p1x9/4AAABoKprEfaDKysr02WefqWPHjkpISFBwcLByc3PN9QcPHlRhYaEcDockyeFwaN++fTp+/Lg5JicnR+Hh4erVq5fH6wcAAADQPHjlCNSDDz6oW265RV26dNFXX32lWbNmKTAwUHfeeaciIiI0efJkZWRkqG3btgoPD9f9998vh8OhgQMHSpJSUlLUq1cvTZgwQfPmzVNRUZEeffRRpaen13mECQAAAADcwSsB6ujRo7rzzjt18uRJdejQQUOGDNGOHTvUoUMHSdLChQsVEBCgsWPHqry8XKmpqXrhhRfM5wcGBmrNmjWaOnWqHA6HWrZsqUmTJumxxx7zRjsAAAAAmgmvBKjly5c3uD40NFRZWVnKysqqd0yXLl3cfuUzAAAAAGhIkzgHCgAAAAB8AQEKAAAAACwiQAEAAACARQQoAAAAALCIAAUAAAAAFhGgAAAAAMAiAhQAAAAAWESAAgAAAACLCFAAAAAAYBEBCgAAAAAsIkABAAAAgEUEKAAAAACwiAAFAAAAABYRoAAAAADAIgIUAAAAAFhEgAIAAAAAiwhQAAAAAGARAQoAAAAALCJAAQAAAIBFBCgAAAAAsIgABQAAAAAWEaAAAAAAwCICFAAAAABYRIACAAAAAIsIUAAAAABgEQEKAAAAACwiQAEAAACARQQoAAAAALCIAAUAAAAAFhGgAAAAAMAiAhQAAAAAWESAAgAAAACLCFAAAAAAYBEBCgAAAAAsIkABAAAAgEUEKAAAAACwiAAFAAAAABYRoAAAAADAIgIUAAAAAFjk8wEqKytLV1xxhUJDQ5WUlKRdu3Z5uyQAAAAAfsqnA9SKFSuUkZGhWbNm6eOPP1bfvn2Vmpqq48ePe7s0AAAAAH7IpwPUggULNGXKFN1zzz3q1auXFi9erLCwML322mveLg0AAACAHwrydgGXqqKiQvn5+ZoxY4a5LCAgQMnJycrLy6vzOeXl5SovLzcfl5SUSJJOnTolp9NZ53OcTqfOnTunIGeAqqptbuzAfU6ePOm2bQVVnq17ebWhc+eqL3o/eKI2T2loH7izT8n7vdanZh+cPHlSwcHB9Y47c+aMJMkwDE+VBgAA4BE+G6BOnDihqqoqRUdHuyyPjo7Wv/71rzqfk5mZqTlz5tRaHh8f3yg1ekr7+Z55nbsu4Tmeqs1T6tsH/tZnQy7m5+DMmTOKiIhotFoAAAA8zWcD1KWYMWOGMjIyzMfV1dU6deqU2rVrJ5ut7qMqpaWliouL05dffqnw8HBPldrksB/YB5L1fWAYhs6cOaPY2FgPVgcAAND4fDZAtW/fXoGBgSouLnZZXlxcrJiYmDqfY7fbZbfbXZZFRkZaer3w8PBm+6b5+9gP7APJ2j7gyBMAAPBHPnsRiZCQECUkJCg3N9dcVl1drdzcXDkcDi9WBgAAAMBf+ewRKEnKyMjQpEmTlJiYqOuvv17PPPOMzp49q3vuucfbpQEAAADwQz4doO644w59/fXXmjlzpoqKitSvXz+tX7++1oUlLofdbtesWbNqffSvuWE/sA8k9gEAAIDN4DrDAAAAAGCJz54DBQAAAACeRoACAAAAAIsIUAAAAABgEQEKAAAAACwiQF1AVlaWrrjiCoWGhiopKUm7du3ydkkek5mZqQEDBqh169aKiorSmDFjdPDgQW+X5VVPPPGEbDabpk+f7u1SPO4///mPfvGLX6hdu3Zq0aKFevfurd27d3u7LAAAAI8iQDVgxYoVysjI0KxZs/Txxx+rb9++Sk1N1fHjx71dmkds3rxZ6enp2rFjh3JycuR0OpWSkqKzZ896uzSv+Oijj/TSSy+pT58+3i7F47755hsNHjxYwcHB+sc//qFPPvlE8+fPV5s2bbxdGgAAgEdxGfMGJCUlacCAAXr++eclSdXV1YqLi9P999+vRx55xMvVed7XX3+tqKgobd68WcOGDfN2OR5VVlam6667Ti+88IIef/xx9evXT88884y3y/KYRx55RNu3b9fWrVu9XQoAAIBXcQSqHhUVFcrPz1dycrK5LCAgQMnJycrLy/NiZd5TUlIiSWrbtq2XK/G89PR0paWlufw8NCerV69WYmKifv7znysqKkr9+/fXn//8Z2+XBQAA4HEEqHqcOHFCVVVVio6OdlkeHR2toqIiL1XlPdXV1Zo+fboGDx6sa6+91tvleNTy5cv18ccfKzMz09uleM3nn3+uF198UVdddZU2bNigqVOn6n//93/1+uuve7s0AAAAjwrydgHwDenp6dq/f7+2bdvm7VI86ssvv9RvfvMb5eTkKDQ01NvleE11dbUSExP1pz/9SZLUv39/7d+/X4sXL9akSZO8XB0AAIDncASqHu3bt1dgYKCKi4tdlhcXFysmJsZLVXnHtGnTtGbNGn3wwQfq1KmTt8vxqPz8fB0/flzXXXedgoKCFBQUpM2bN2vRokUKCgpSVVWVt0v0iI4dO6pXr14uy3r27KnCwkIvVQQAAOAdBKh6hISEKCEhQbm5ueay6upq5ebmyuFweLEyzzEMQ9OmTdPKlSu1ceNGxcfHe7skjxsxYoT27dungoIC8ysxMVHjx49XQUGBAgMDvV2iRwwePLjWJez//e9/q0uXLl6qCAAAwDv4CF8DMjIyNGnSJCUmJur666/XM888o7Nnz+qee+7xdmkekZ6ermXLlundd99V69atzXO/IiIi1KJFCy9X5xmtW7eudc5Xy5Yt1a5du2Z1LtgDDzygQYMG6U9/+pNuv/127dq1Sy+//LJefvllb5cGAADgUVzG/AKef/55PfXUUyoqKlK/fv20aNEiJSUlebssj7DZbHUuX7Jkie6++27PFtOEDB8+vNldxlyS1qxZoxkzZujQoUOKj49XRkaGpkyZ4u2yAAAAPIoABQAAAAAWcQ4UAAAAAFhEgAIAAAAAiwhQAAAAAGARAQoAAAAALCJAAQAAAIBFBCgAAAAAsIgABQAAAAAWEaAAAAAAwCICFAAAAABYRIACAAAAAIsIUAAAAABgEQEKAAAAACz6/3iTn/BEFYojAAAAAElFTkSuQmCC\n"
-          },
-          "metadata": {}
-        }
-      ],
-      "source": [
-        "ed_flights.select_dtypes(include=np.number).hist(figsize=[10,10])\n",
-        "plt.show()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "dCy_h-vONRFq"
-      },
-      "source": [
-        "### Elasticsearch utilities"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 59,
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2021-12-15T20:25:02.211768Z",
-          "iopub.status.busy": "2021-12-15T20:25:02.211404Z",
-          "iopub.status.idle": "2021-12-15T20:25:02.297769Z",
-          "shell.execute_reply": "2021-12-15T20:25:02.295526Z"
-        },
-        "pycharm": {
-          "is_executing": false
-        },
-        "id": "IYKn-Uz2NRFr"
-      },
-      "outputs": [],
-      "source": [
-        "ed_flights2 = ed_flights[(ed_flights.OriginAirportID == 'AMS') & (ed_flights.FlightDelayMin > 60)]\n",
-        "ed_flights2 = ed_flights2[['timestamp', 'OriginAirportID', 'DestAirportID', 'FlightDelayMin']]\n",
-        "ed_flights2 = ed_flights2.tail()"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 60,
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2021-12-15T20:25:02.319861Z",
-          "iopub.status.busy": "2021-12-15T20:25:02.305735Z",
-          "iopub.status.idle": "2021-12-15T20:25:02.325635Z",
-          "shell.execute_reply": "2021-12-15T20:25:02.326869Z"
-        },
-        "pycharm": {
-          "is_executing": false
-        },
-        "id": "hks1CjV0NRFr",
-        "outputId": "523c74c6-334a-4b50-87a2-3060b456c3ef",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        }
-      },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "es_index_pattern: flights\n",
-            "Index:\n",
-            " es_index_field: _id\n",
-            " is_source_field: False\n",
-            "Mappings:\n",
-            " capabilities:\n",
-            "                   es_field_name  is_source es_dtype                  es_date_format        pd_dtype  is_searchable  is_aggregatable  is_scripted aggregatable_es_field_name\n",
-            "timestamp              timestamp       True     date  strict_date_hour_minute_second  datetime64[ns]           True             True        False                  timestamp\n",
-            "OriginAirportID  OriginAirportID       True  keyword                            None          object           True             True        False            OriginAirportID\n",
-            "DestAirportID      DestAirportID       True  keyword                            None          object           True             True        False              DestAirportID\n",
-            "FlightDelayMin    FlightDelayMin       True  integer                            None           int64           True             True        False             FlightDelayMin\n",
-            "Operations:\n",
-            " tasks: [('boolean_filter': ('boolean_filter': {'bool': {'must': [{'term': {'OriginAirportID': 'AMS'}}, {'range': {'FlightDelayMin': {'gt': 60}}}]}})), ('tail': ('sort_field': '_doc', 'count': 5))]\n",
-            " size: 5\n",
-            " sort_params: {'_doc': 'desc'}\n",
-            " _source: ['timestamp', 'OriginAirportID', 'DestAirportID', 'FlightDelayMin']\n",
-            " body: {'query': {'bool': {'must': [{'term': {'OriginAirportID': 'AMS'}}, {'range': {'FlightDelayMin': {'gt': 60}}}]}}}\n",
-            " post_processing: [('sort_index')]\n",
-            "\n"
-          ]
-        }
-      ],
-      "source": [
-        "print(ed_flights2.es_info())"
-      ]
-    }
-  ],
-  "metadata": {
-    "kernelspec": {
-      "display_name": "Python 3",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.8.6"
-    },
-    "pycharm": {
-      "stem_cell": {
-        "cell_type": "raw",
-        "metadata": {
-          "collapsed": false
-        },
-        "source": []
-      }
-    },
-    "colab": {
-      "provenance": []
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "GTid11BRNRFA"
+   },
+   "source": [
+    "# Eland Demo Notebook\n",
+    "\n",
+    "<a target=\"_blank\" href=\"https://colab.research.google.com/github/elastic/eland/blob/main/docs/sphinx/examples/demo_notebook.ipynb\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
+    "\n",
+    "In this notebook we'll show you how to explore and analyze data in Elasticsearch using the familiar Pandas-compatible API."
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 0
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Rkdq0gUBOPJn"
+   },
+   "source": [
+    "## Requirements 🧰\n",
+    "\n",
+    "For this example, you will need:\n",
+    "\n",
+    "- Python 3.8 or later\n",
+    "- An Elastic deployment\n",
+    "  - We'll be using [Elastic Cloud](https://www.elastic.co/guide/en/cloud/current/ec-getting-started.html) for this example (available with a [free trial](https://cloud.elastic.co/registration))\n",
+    "\n",
+    "### Create Elastic Cloud deployment\n",
+    "\n",
+    "If you don't have an Elastic Cloud deployment, follow these steps to create one.\n",
+    "\n",
+    "1. Go to https://cloud.elastic.co/registration and sign up for a free trial\n",
+    "2. Select **Create Deployment** and follow the instructions\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "8EzcP9SpOYsc"
+   },
+   "source": [
+    "## Install packages 📦\n",
+    "\n",
+    "First we `pip install` and import the packages we need for this example.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "execution": {
+     "iopub.execute_input": "2023-09-20T14:01:46.419913Z",
+     "iopub.status.busy": "2023-09-20T14:01:46.419725Z",
+     "iopub.status.idle": "2023-09-20T14:01:59.374939Z",
+     "shell.execute_reply": "2023-09-20T14:01:59.373253Z"
+    },
+    "id": "YTm5ABvjOaSb",
+    "outputId": "02a2a2f6-38af-4d8c-9817-0ebd9a90032c"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Collecting git+https://github.com/pquentin/eland.git@demo-notebook-colab\r\n",
+      "  Cloning https://github.com/pquentin/eland.git (to revision demo-notebook-colab) to /tmp/pip-req-build-llaufivk\r\n",
+      "  Running command git clone --filter=blob:none --quiet https://github.com/pquentin/eland.git /tmp/pip-req-build-llaufivk\r\n",
+      "  Running command git checkout -b demo-notebook-colab --track origin/demo-notebook-colab\r\n",
+      "  Switched to a new branch 'demo-notebook-colab'\r\n",
+      "  branch 'demo-notebook-colab' set up to track 'origin/demo-notebook-colab'.\r\n",
+      "  Resolved https://github.com/pquentin/eland.git to commit a85c8debaf44833ea1e8eb0041cd654dc2029709\r\n",
+      "  Preparing metadata (setup.py) ... \u001b[?25l-\b \bdone\r\n",
+      "\u001b[?25hRequirement already satisfied: elasticsearch<9,>=8.3 in /home/q/src/eland/.nox/docs/lib/python3.10/site-packages (from eland==8.9.0) (8.9.0)\r\n",
+      "Requirement already satisfied: pandas<2,>=1.5 in /home/q/src/eland/.nox/docs/lib64/python3.10/site-packages (from eland==8.9.0) (1.5.3)\r\n",
+      "Requirement already satisfied: matplotlib>=3.6 in /home/q/src/eland/.nox/docs/lib64/python3.10/site-packages (from eland==8.9.0) (3.8.0)\r\n",
+      "Requirement already satisfied: numpy<1.24,>=1.2.0 in /home/q/src/eland/.nox/docs/lib64/python3.10/site-packages (from eland==8.9.0) (1.23.5)\r\n",
+      "Requirement already satisfied: elastic-transport<9,>=8 in /home/q/src/eland/.nox/docs/lib/python3.10/site-packages (from elasticsearch<9,>=8.3->eland==8.9.0) (8.4.0)\r\n",
+      "Requirement already satisfied: contourpy>=1.0.1 in /home/q/src/eland/.nox/docs/lib64/python3.10/site-packages (from matplotlib>=3.6->eland==8.9.0) (1.1.1)\r\n",
+      "Requirement already satisfied: cycler>=0.10 in /home/q/src/eland/.nox/docs/lib/python3.10/site-packages (from matplotlib>=3.6->eland==8.9.0) (0.11.0)\r\n",
+      "Requirement already satisfied: fonttools>=4.22.0 in /home/q/src/eland/.nox/docs/lib64/python3.10/site-packages (from matplotlib>=3.6->eland==8.9.0) (4.42.1)\r\n",
+      "Requirement already satisfied: kiwisolver>=1.0.1 in /home/q/src/eland/.nox/docs/lib64/python3.10/site-packages (from matplotlib>=3.6->eland==8.9.0) (1.4.5)\r\n",
+      "Requirement already satisfied: packaging>=20.0 in /home/q/src/eland/.nox/docs/lib/python3.10/site-packages (from matplotlib>=3.6->eland==8.9.0) (23.1)\r\n",
+      "Requirement already satisfied: pillow>=6.2.0 in /home/q/src/eland/.nox/docs/lib64/python3.10/site-packages (from matplotlib>=3.6->eland==8.9.0) (10.0.1)\r\n",
+      "Requirement already satisfied: pyparsing>=2.3.1 in /home/q/src/eland/.nox/docs/lib/python3.10/site-packages (from matplotlib>=3.6->eland==8.9.0) (3.1.1)\r\n",
+      "Requirement already satisfied: python-dateutil>=2.7 in /home/q/src/eland/.nox/docs/lib/python3.10/site-packages (from matplotlib>=3.6->eland==8.9.0) (2.8.2)\r\n",
+      "Requirement already satisfied: pytz>=2020.1 in /home/q/src/eland/.nox/docs/lib/python3.10/site-packages (from pandas<2,>=1.5->eland==8.9.0) (2023.3.post1)\r\n",
+      "Requirement already satisfied: urllib3<2,>=1.26.2 in /home/q/src/eland/.nox/docs/lib/python3.10/site-packages (from elastic-transport<9,>=8->elasticsearch<9,>=8.3->eland==8.9.0) (1.26.16)\r\n",
+      "Requirement already satisfied: certifi in /home/q/src/eland/.nox/docs/lib/python3.10/site-packages (from elastic-transport<9,>=8->elasticsearch<9,>=8.3->eland==8.9.0) (2023.7.22)\r\n",
+      "Requirement already satisfied: six>=1.5 in /home/q/src/eland/.nox/docs/lib/python3.10/site-packages (from python-dateutil>=2.7->matplotlib>=3.6->eland==8.9.0) (1.16.0)\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "# TODO switch to !pip install eland before merging\n",
+    "!pip install git+https://github.com/pquentin/eland.git@demo-notebook-colab\n",
+    "\n",
+    "import os\n",
+    "\n",
+    "import eland as ed\n",
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "import requests\n",
+    "\n",
+    "from elasticsearch import Elasticsearch\n",
+    "\n",
+    "# Import standard test settings for consistent results\n",
+    "from eland.conftest import *"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-12-15T20:24:28.813370Z",
+     "iopub.status.busy": "2021-12-15T20:24:28.802670Z",
+     "iopub.status.idle": "2021-12-15T20:24:30.192643Z",
+     "shell.execute_reply": "2021-12-15T20:24:30.192931Z"
+    },
+    "id": "64Wm8FvSNRFD",
+    "pycharm": {
+     "is_executing": false
+    }
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "J9YR-d7OOk0-"
+   },
+   "source": [
+    "## Initialize client 🔌\n",
+    "\n",
+    "Next we input credentials with `getpass`. `getpass` is part of the Python standard library and is used to securely prompt for credentials."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "execution": {
+     "iopub.execute_input": "2023-09-20T14:01:59.380866Z",
+     "iopub.status.busy": "2023-09-20T14:01:59.380551Z",
+     "iopub.status.idle": "2023-09-20T14:01:59.397932Z",
+     "shell.execute_reply": "2023-09-20T14:01:59.397250Z"
+    },
+    "id": "DARo7JpKOsdW",
+    "outputId": "ccefe4c6-04ee-4119-db3e-a1e14613d856"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Connected to cluster named 'docker-cluster' (version: 8.10.1)\n"
+     ]
+    }
+   ],
+   "source": [
+    "from getpass import getpass\n",
+    "\n",
+    "if os.environ.get(\"DOCS_BUILD\"):\n",
+    "  # Building the docs relies on a local cluster\n",
+    "  es_kwargs = {\"hosts\": \"http://localhost:9200\"}\n",
+    "else:\n",
+    "  cloud_id = getpass(\"Elastic Cloud ID: \")\n",
+    "  username = getpass(\"Elastic username: \")\n",
+    "  password = getpass(\"Elastic password: \")\n",
+    "  es_kwargs = {\n",
+    "      \"cloud_id\": cloud_id,\n",
+    "      \"basic_auth\": (username, password)\n",
+    "  }\n",
+    "\n",
+    "es = Elasticsearch(**es_kwargs)\n",
+    "es_info = es.info()\n",
+    "print(f\"Connected to cluster named '{es_info['cluster_name']}' (version: {es_info['version']['number']})\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "4m9amNr6OxKr"
+   },
+   "source": [
+    "## Load and process documents 📄\n",
+    "\n",
+    "Time to load some data! We'll be using the Eland test data, which is a fake flights dataset."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "execution": {
+     "iopub.execute_input": "2023-09-20T14:01:59.401801Z",
+     "iopub.status.busy": "2023-09-20T14:01:59.401349Z",
+     "iopub.status.idle": "2023-09-20T14:01:59.406495Z",
+     "shell.execute_reply": "2023-09-20T14:01:59.405603Z"
+    },
+    "id": "UXLIpuFTO8pq",
+    "outputId": "07b273cc-fed1-4705-eb5a-c66bcd68a266"
+   },
+   "outputs": [],
+   "source": [
+    "import tempfile\n",
+    "\n",
+    "from eland import pandas_to_es\n",
+    "from eland import dataload\n",
+    "\n",
+    "if not os.environ.get(\"DOCS_BUILD\"):\n",
+    "  with tempfile.TemporaryDirectory() as tmpdir:\n",
+    "    r = requests.get(\"https://github.com/elastic/eland/raw/main/tests/flights.json.gz\")\n",
+    "    path = os.path.join(tmpdir, \"flights.json.gz\")\n",
+    "    with open(path, \"wb\") as f:\n",
+    "      f.write(r.content)\n",
+    "\n",
+    "    df = pd.read_json(path, lines=True)\n",
+    "    pandas_to_es(df, es, dataload.FLIGHTS_INDEX_NAME, dataload.FLIGHTS_MAPPING)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "c3Af_LIiNRFE"
+   },
+   "source": [
+    "## Compare Eland DataFrame vs pandas DataFrame"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "bNs9FbAgNRFE"
+   },
+   "source": [
+    "Create an eland.DataFrame from a `flights` index"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-09-20T14:01:59.411859Z",
+     "iopub.status.busy": "2023-09-20T14:01:59.411377Z",
+     "iopub.status.idle": "2023-09-20T14:01:59.444878Z",
+     "shell.execute_reply": "2023-09-20T14:01:59.444057Z"
+    },
+    "id": "7_rgLmsLNRFF",
+    "pycharm": {
+     "is_executing": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "ed_flights = ed.DataFrame(es, 'flights')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "execution": {
+     "iopub.execute_input": "2023-09-20T14:01:59.450189Z",
+     "iopub.status.busy": "2023-09-20T14:01:59.448553Z",
+     "iopub.status.idle": "2023-09-20T14:01:59.462517Z",
+     "shell.execute_reply": "2023-09-20T14:01:59.461836Z"
+    },
+    "id": "ickl9aGUNRFH",
+    "outputId": "0e458e62-44ef-41cd-cad3-70db542a8748",
+    "pycharm": {
+     "is_executing": false
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "eland.dataframe.DataFrame"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "type(ed_flights)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "8Y39fj7rNRFI"
+   },
+   "source": [
+    "Compare to pandas DataFrame (created from the same data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-09-20T14:01:59.465886Z",
+     "iopub.status.busy": "2023-09-20T14:01:59.465420Z",
+     "iopub.status.idle": "2023-09-20T14:02:02.585850Z",
+     "shell.execute_reply": "2023-09-20T14:02:02.584124Z"
+    },
+    "id": "Qxz7lZ7zNRFI",
+    "pycharm": {
+     "is_executing": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "pd_flights = ed.eland_to_pandas(ed_flights)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "execution": {
+     "iopub.execute_input": "2023-09-20T14:02:02.591812Z",
+     "iopub.status.busy": "2023-09-20T14:02:02.591594Z",
+     "iopub.status.idle": "2023-09-20T14:02:02.596770Z",
+     "shell.execute_reply": "2023-09-20T14:02:02.596036Z"
+    },
+    "id": "0f9qCkT3NRFJ",
+    "outputId": "1fa758e8-b5c9-4015-fbe8-95062e667ebd",
+    "pycharm": {
+     "is_executing": false
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "pandas.core.frame.DataFrame"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "type(pd_flights)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "idu_eqdsNRFK"
+   },
+   "source": [
+    "## Attributes and underlying data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "bltr_0r-NRFL"
+   },
+   "source": [
+    "### DataFrame.columns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "execution": {
+     "iopub.execute_input": "2023-09-20T14:02:02.601035Z",
+     "iopub.status.busy": "2023-09-20T14:02:02.600287Z",
+     "iopub.status.idle": "2023-09-20T14:02:02.608615Z",
+     "shell.execute_reply": "2023-09-20T14:02:02.607941Z"
+    },
+    "id": "ZLVUimn_NRFL",
+    "outputId": "5ca55025-05e4-474f-9aed-6e9148492a12",
+    "pycharm": {
+     "is_executing": false
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Index(['AvgTicketPrice', 'Cancelled', 'Carrier', 'Dest', 'DestAirportID', 'DestCityName',\n",
+       "       'DestCountry', 'DestLocation', 'DestRegion', 'DestWeather', 'DistanceKilometers',\n",
+       "       'DistanceMiles', 'FlightDelay', 'FlightDelayMin', 'FlightDelayType', 'FlightNum',\n",
+       "       'FlightTimeHour', 'FlightTimeMin', 'Origin', 'OriginAirportID', 'OriginCityName',\n",
+       "       'OriginCountry', 'OriginLocation', 'OriginRegion', 'OriginWeather', 'dayOfWeek',\n",
+       "       'timestamp'],\n",
+       "      dtype='object')"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pd_flights.columns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "execution": {
+     "iopub.execute_input": "2023-09-20T14:02:02.611587Z",
+     "iopub.status.busy": "2023-09-20T14:02:02.611332Z",
+     "iopub.status.idle": "2023-09-20T14:02:02.617698Z",
+     "shell.execute_reply": "2023-09-20T14:02:02.616584Z"
+    },
+    "id": "UcFhMhhFNRFM",
+    "outputId": "5c2c2e40-8d1a-4f2f-b960-66cc50310802",
+    "pycharm": {
+     "is_executing": false
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Index(['AvgTicketPrice', 'Cancelled', 'Carrier', 'Dest', 'DestAirportID', 'DestCityName',\n",
+       "       'DestCountry', 'DestLocation', 'DestRegion', 'DestWeather', 'DistanceKilometers',\n",
+       "       'DistanceMiles', 'FlightDelay', 'FlightDelayMin', 'FlightDelayType', 'FlightNum',\n",
+       "       'FlightTimeHour', 'FlightTimeMin', 'Origin', 'OriginAirportID', 'OriginCityName',\n",
+       "       'OriginCountry', 'OriginLocation', 'OriginRegion', 'OriginWeather', 'dayOfWeek',\n",
+       "       'timestamp'],\n",
+       "      dtype='object')"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ed_flights.columns"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "NPoDKfjYNRFM"
+   },
+   "source": [
+    "### DataFrame.dtypes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "execution": {
+     "iopub.execute_input": "2023-09-20T14:02:02.623836Z",
+     "iopub.status.busy": "2023-09-20T14:02:02.623573Z",
+     "iopub.status.idle": "2023-09-20T14:02:02.630161Z",
+     "shell.execute_reply": "2023-09-20T14:02:02.629490Z"
+    },
+    "id": "b0Xh8p_nNRFN",
+    "outputId": "6650ded2-9c3c-4072-e8c0-a7304723d3c2",
+    "pycharm": {
+     "is_executing": false
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "AvgTicketPrice           float64\n",
+       "Cancelled                   bool\n",
+       "Carrier                   object\n",
+       "Dest                      object\n",
+       "DestAirportID             object\n",
+       "                       ...      \n",
+       "OriginLocation            object\n",
+       "OriginRegion              object\n",
+       "OriginWeather             object\n",
+       "dayOfWeek                  int64\n",
+       "timestamp         datetime64[ns]\n",
+       "Length: 27, dtype: object"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pd_flights.dtypes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "execution": {
+     "iopub.execute_input": "2023-09-20T14:02:02.633854Z",
+     "iopub.status.busy": "2023-09-20T14:02:02.633244Z",
+     "iopub.status.idle": "2023-09-20T14:02:02.643532Z",
+     "shell.execute_reply": "2023-09-20T14:02:02.642885Z"
+    },
+    "id": "IrDE-STnNRFN",
+    "outputId": "8b892450-e29e-483d-fd81-5dd07dcd6e33",
+    "pycharm": {
+     "is_executing": false
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "AvgTicketPrice           float64\n",
+       "Cancelled                   bool\n",
+       "Carrier                   object\n",
+       "Dest                      object\n",
+       "DestAirportID             object\n",
+       "                       ...      \n",
+       "OriginLocation            object\n",
+       "OriginRegion              object\n",
+       "OriginWeather             object\n",
+       "dayOfWeek                  int64\n",
+       "timestamp         datetime64[ns]\n",
+       "Length: 27, dtype: object"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ed_flights.dtypes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "b4KBN1iQNRFN"
+   },
+   "source": [
+    "### DataFrame.select_dtypes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 424
+    },
+    "execution": {
+     "iopub.execute_input": "2023-09-20T14:02:02.647340Z",
+     "iopub.status.busy": "2023-09-20T14:02:02.646872Z",
+     "iopub.status.idle": "2023-09-20T14:02:02.688102Z",
+     "shell.execute_reply": "2023-09-20T14:02:02.686306Z"
+    },
+    "id": "MOAMAU4DNRFO",
+    "outputId": "e3f4f29b-e53f-454c-cc98-c80af327a66c",
+    "pycharm": {
+     "is_executing": false
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>AvgTicketPrice</th>\n",
+       "      <th>DistanceKilometers</th>\n",
+       "      <th>...</th>\n",
+       "      <th>FlightTimeMin</th>\n",
+       "      <th>dayOfWeek</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>841.265642</td>\n",
+       "      <td>16492.326654</td>\n",
+       "      <td>...</td>\n",
+       "      <td>1030.770416</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>882.982662</td>\n",
+       "      <td>8823.400140</td>\n",
+       "      <td>...</td>\n",
+       "      <td>464.389481</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>190.636904</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>181.694216</td>\n",
+       "      <td>555.737767</td>\n",
+       "      <td>...</td>\n",
+       "      <td>222.749059</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>730.041778</td>\n",
+       "      <td>13358.244200</td>\n",
+       "      <td>...</td>\n",
+       "      <td>785.779071</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>13054</th>\n",
+       "      <td>1080.446279</td>\n",
+       "      <td>8058.581753</td>\n",
+       "      <td>...</td>\n",
+       "      <td>402.929088</td>\n",
+       "      <td>6</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>13055</th>\n",
+       "      <td>646.612941</td>\n",
+       "      <td>7088.598322</td>\n",
+       "      <td>...</td>\n",
+       "      <td>644.418029</td>\n",
+       "      <td>6</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>13056</th>\n",
+       "      <td>997.751876</td>\n",
+       "      <td>10920.652972</td>\n",
+       "      <td>...</td>\n",
+       "      <td>937.540811</td>\n",
+       "      <td>6</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>13057</th>\n",
+       "      <td>1102.814465</td>\n",
+       "      <td>18748.859647</td>\n",
+       "      <td>...</td>\n",
+       "      <td>1697.404971</td>\n",
+       "      <td>6</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>13058</th>\n",
+       "      <td>858.144337</td>\n",
+       "      <td>16809.141923</td>\n",
+       "      <td>...</td>\n",
+       "      <td>1610.761827</td>\n",
+       "      <td>6</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>13059 rows × 7 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "       AvgTicketPrice  DistanceKilometers  ...  FlightTimeMin  dayOfWeek\n",
+       "0          841.265642        16492.326654  ...    1030.770416          0\n",
+       "1          882.982662         8823.400140  ...     464.389481          0\n",
+       "2          190.636904            0.000000  ...       0.000000          0\n",
+       "3          181.694216          555.737767  ...     222.749059          0\n",
+       "4          730.041778        13358.244200  ...     785.779071          0\n",
+       "...               ...                 ...  ...            ...        ...\n",
+       "13054     1080.446279         8058.581753  ...     402.929088          6\n",
+       "13055      646.612941         7088.598322  ...     644.418029          6\n",
+       "13056      997.751876        10920.652972  ...     937.540811          6\n",
+       "13057     1102.814465        18748.859647  ...    1697.404971          6\n",
+       "13058      858.144337        16809.141923  ...    1610.761827          6\n",
+       "\n",
+       "[13059 rows x 7 columns]"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pd_flights.select_dtypes(include=np.number)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 424
+    },
+    "execution": {
+     "iopub.execute_input": "2023-09-20T14:02:02.691981Z",
+     "iopub.status.busy": "2023-09-20T14:02:02.691560Z",
+     "iopub.status.idle": "2023-09-20T14:02:03.529026Z",
+     "shell.execute_reply": "2023-09-20T14:02:03.528234Z"
+    },
+    "id": "QyaBzEf-NRFO",
+    "outputId": "89f85e32-b4ec-47d3-9c9d-77354c3bdfb9",
+    "pycharm": {
+     "is_executing": false
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>AvgTicketPrice</th>\n",
+       "      <th>DistanceKilometers</th>\n",
+       "      <th>...</th>\n",
+       "      <th>FlightTimeMin</th>\n",
+       "      <th>dayOfWeek</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>841.265642</td>\n",
+       "      <td>16492.326654</td>\n",
+       "      <td>...</td>\n",
+       "      <td>1030.770416</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>882.982662</td>\n",
+       "      <td>8823.400140</td>\n",
+       "      <td>...</td>\n",
+       "      <td>464.389481</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>190.636904</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>181.694216</td>\n",
+       "      <td>555.737767</td>\n",
+       "      <td>...</td>\n",
+       "      <td>222.749059</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>730.041778</td>\n",
+       "      <td>13358.244200</td>\n",
+       "      <td>...</td>\n",
+       "      <td>785.779071</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>13054</th>\n",
+       "      <td>1080.446279</td>\n",
+       "      <td>8058.581753</td>\n",
+       "      <td>...</td>\n",
+       "      <td>402.929088</td>\n",
+       "      <td>6</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>13055</th>\n",
+       "      <td>646.612941</td>\n",
+       "      <td>7088.598322</td>\n",
+       "      <td>...</td>\n",
+       "      <td>644.418029</td>\n",
+       "      <td>6</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>13056</th>\n",
+       "      <td>997.751876</td>\n",
+       "      <td>10920.652972</td>\n",
+       "      <td>...</td>\n",
+       "      <td>937.540811</td>\n",
+       "      <td>6</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>13057</th>\n",
+       "      <td>1102.814465</td>\n",
+       "      <td>18748.859647</td>\n",
+       "      <td>...</td>\n",
+       "      <td>1697.404971</td>\n",
+       "      <td>6</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>13058</th>\n",
+       "      <td>858.144337</td>\n",
+       "      <td>16809.141923</td>\n",
+       "      <td>...</td>\n",
+       "      <td>1610.761827</td>\n",
+       "      <td>6</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>\n",
+       "<p>13059 rows × 7 columns</p>"
+      ],
+      "text/plain": [
+       "       AvgTicketPrice  DistanceKilometers  ...  FlightTimeMin  dayOfWeek\n",
+       "0          841.265642        16492.326654  ...    1030.770416          0\n",
+       "1          882.982662         8823.400140  ...     464.389481          0\n",
+       "2          190.636904            0.000000  ...       0.000000          0\n",
+       "3          181.694216          555.737767  ...     222.749059          0\n",
+       "4          730.041778        13358.244200  ...     785.779071          0\n",
+       "...               ...                 ...  ...            ...        ...\n",
+       "13054     1080.446279         8058.581753  ...     402.929088          6\n",
+       "13055      646.612941         7088.598322  ...     644.418029          6\n",
+       "13056      997.751876        10920.652972  ...     937.540811          6\n",
+       "13057     1102.814465        18748.859647  ...    1697.404971          6\n",
+       "13058      858.144337        16809.141923  ...    1610.761827          6\n",
+       "\n",
+       "[13059 rows x 7 columns]"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ed_flights.select_dtypes(include=np.number)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "E9hPiMkPNRFP"
+   },
+   "source": [
+    "### DataFrame.empty"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "execution": {
+     "iopub.execute_input": "2023-09-20T14:02:03.533203Z",
+     "iopub.status.busy": "2023-09-20T14:02:03.532903Z",
+     "iopub.status.idle": "2023-09-20T14:02:03.540881Z",
+     "shell.execute_reply": "2023-09-20T14:02:03.540332Z"
+    },
+    "id": "fLMm3FGpNRFP",
+    "outputId": "c626a9cf-abfa-47a3-da75-c51a974d289e",
+    "pycharm": {
+     "is_executing": false
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "False"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pd_flights.empty"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "execution": {
+     "iopub.execute_input": "2023-09-20T14:02:03.543691Z",
+     "iopub.status.busy": "2023-09-20T14:02:03.543514Z",
+     "iopub.status.idle": "2023-09-20T14:02:03.557762Z",
+     "shell.execute_reply": "2023-09-20T14:02:03.557172Z"
+    },
+    "id": "cdaA4nkdNRFP",
+    "outputId": "10e9f655-c5a5-400b-9bdd-cbc697f8f325",
+    "pycharm": {
+     "is_executing": false
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "False"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ed_flights.empty"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "oV6j_h4INRFR"
+   },
+   "source": [
+    "### DataFrame.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "execution": {
+     "iopub.execute_input": "2023-09-20T14:02:03.560857Z",
+     "iopub.status.busy": "2023-09-20T14:02:03.560679Z",
+     "iopub.status.idle": "2023-09-20T14:02:03.565569Z",
+     "shell.execute_reply": "2023-09-20T14:02:03.564918Z"
+    },
+    "id": "HSlyhmmwNRFR",
+    "outputId": "a8fb77b7-2d4a-4769-e0e9-038b75dd0d26",
+    "pycharm": {
+     "is_executing": false
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(13059, 27)"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pd_flights.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "execution": {
+     "iopub.execute_input": "2023-09-20T14:02:03.572423Z",
+     "iopub.status.busy": "2023-09-20T14:02:03.571564Z",
+     "iopub.status.idle": "2023-09-20T14:02:03.580744Z",
+     "shell.execute_reply": "2023-09-20T14:02:03.579987Z"
+    },
+    "id": "n7NFeQR6NRFR",
+    "outputId": "c8a521bb-778c-4860-f18e-fe5374df14a4",
+    "pycharm": {
+     "is_executing": false
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(13059, 27)"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ed_flights.shape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "ib-JYdwXNRFS"
+   },
+   "source": [
+    "### DataFrame.index\n",
+    "\n",
+    "Note, `eland.DataFrame.index` does not mirror `pandas.DataFrame.index`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "execution": {
+     "iopub.execute_input": "2023-09-20T14:02:03.585145Z",
+     "iopub.status.busy": "2023-09-20T14:02:03.584210Z",
+     "iopub.status.idle": "2023-09-20T14:02:03.593063Z",
+     "shell.execute_reply": "2023-09-20T14:02:03.592439Z"
+    },
+    "id": "mTSyzPSgNRFS",
+    "outputId": "d5387124-7c52-4dc8-9d7d-c9afcdcb5945",
+    "pycharm": {
+     "is_executing": false
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Index(['0', '1', '2', '3', '4', '5', '6', '7', '8', '9',\n",
+       "       ...\n",
+       "       '13049', '13050', '13051', '13052', '13053', '13054', '13055', '13056', '13057', '13058'],\n",
+       "      dtype='object', length=13059)"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pd_flights.index"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "execution": {
+     "iopub.execute_input": "2023-09-20T14:02:03.596514Z",
+     "iopub.status.busy": "2023-09-20T14:02:03.596040Z",
+     "iopub.status.idle": "2023-09-20T14:02:03.601113Z",
+     "shell.execute_reply": "2023-09-20T14:02:03.600301Z"
+    },
+    "id": "puus-Fk7NRFS",
+    "outputId": "171280c9-b968-45d5-b436-b391187de90f",
+    "pycharm": {
+     "is_executing": false
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<eland.index.Index at 0x7f1bfc2edab0>"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# NBVAL_IGNORE_OUTPUT\n",
+    "ed_flights.index"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 35
+    },
+    "execution": {
+     "iopub.execute_input": "2023-09-20T14:02:03.607724Z",
+     "iopub.status.busy": "2023-09-20T14:02:03.607226Z",
+     "iopub.status.idle": "2023-09-20T14:02:03.611475Z",
+     "shell.execute_reply": "2023-09-20T14:02:03.610947Z"
+    },
+    "id": "rvJ41P0BNRFT",
+    "outputId": "f38536f5-dd9e-4c4a-a34f-a23b2b0ac14e",
+    "pycharm": {
+     "is_executing": false
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'_id'"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ed_flights.index.es_index_field"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "5JA3HKJgNRFT"
+   },
+   "source": [
+    "### DataFrame.values\n",
+    "\n",
+    "Note, `eland.DataFrame.values` is not supported."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "execution": {
+     "iopub.execute_input": "2023-09-20T14:02:03.614715Z",
+     "iopub.status.busy": "2023-09-20T14:02:03.614529Z",
+     "iopub.status.idle": "2023-09-20T14:02:03.696405Z",
+     "shell.execute_reply": "2023-09-20T14:02:03.695516Z"
+    },
+    "id": "oZYSyigXNRFU",
+    "outputId": "e7f2295c-1b7c-4640-9b50-b12af290a15a",
+    "pycharm": {
+     "is_executing": false
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[841.2656419677076, False, 'Kibana Airlines', ..., 'Sunny', 0,\n",
+       "        Timestamp('2018-01-01 00:00:00')],\n",
+       "       [882.9826615595518, False, 'Logstash Airways', ..., 'Clear', 0,\n",
+       "        Timestamp('2018-01-01 18:27:00')],\n",
+       "       [190.6369038508356, False, 'Logstash Airways', ..., 'Rain', 0,\n",
+       "        Timestamp('2018-01-01 17:11:14')],\n",
+       "       ...,\n",
+       "       [997.7518761454494, False, 'Logstash Airways', ..., 'Sunny', 6,\n",
+       "        Timestamp('2018-02-11 04:09:27')],\n",
+       "       [1102.8144645388556, False, 'JetBeats', ..., 'Hail', 6,\n",
+       "        Timestamp('2018-02-11 08:28:21')],\n",
+       "       [858.1443369038839, False, 'JetBeats', ..., 'Rain', 6,\n",
+       "        Timestamp('2018-02-11 14:54:34')]], dtype=object)"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pd_flights.values"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "execution": {
+     "iopub.execute_input": "2023-09-20T14:02:03.701252Z",
+     "iopub.status.busy": "2023-09-20T14:02:03.700700Z",
+     "iopub.status.idle": "2023-09-20T14:02:03.709077Z",
+     "shell.execute_reply": "2023-09-20T14:02:03.708370Z"
+    },
+    "id": "gQTQLsmWNRFU",
+    "outputId": "aedd4d28-a8e8-4790-9cd5-8357742c94c6",
+    "pycharm": {
+     "is_executing": false
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "This method would scan/scroll the entire Elasticsearch index(s) into memory. If this is explicitly required, and there is sufficient memory, call `ed.eland_to_pandas(ed_df).values`\n"
+     ]
+    }
+   ],
+   "source": [
+    "try:\n",
+    "    ed_flights.values\n",
+    "except AttributeError as e:\n",
+    "    print(e)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "lKqYv_fTNRFV"
+   },
+   "source": [
+    "## Indexing, iteration"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "_RlN4vASNRFV"
+   },
+   "source": [
+    "### DataFrame.head"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 236
+    },
+    "execution": {
+     "iopub.execute_input": "2023-09-20T14:02:03.712534Z",
+     "iopub.status.busy": "2023-09-20T14:02:03.712189Z",
+     "iopub.status.idle": "2023-09-20T14:02:03.727828Z",
+     "shell.execute_reply": "2023-09-20T14:02:03.727260Z"
+    },
+    "id": "PnuvMIlMNRFV",
+    "outputId": "919432a7-678e-4f1f-dfed-9c56fa24b444",
+    "pycharm": {
+     "is_executing": false
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>AvgTicketPrice</th>\n",
+       "      <th>Cancelled</th>\n",
+       "      <th>...</th>\n",
+       "      <th>dayOfWeek</th>\n",
+       "      <th>timestamp</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>841.265642</td>\n",
+       "      <td>False</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0</td>\n",
+       "      <td>2018-01-01 00:00:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>882.982662</td>\n",
+       "      <td>False</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0</td>\n",
+       "      <td>2018-01-01 18:27:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>190.636904</td>\n",
+       "      <td>False</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0</td>\n",
+       "      <td>2018-01-01 17:11:14</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>181.694216</td>\n",
+       "      <td>True</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0</td>\n",
+       "      <td>2018-01-01 10:33:28</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>730.041778</td>\n",
+       "      <td>False</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0</td>\n",
+       "      <td>2018-01-01 05:13:00</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>5 rows × 27 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   AvgTicketPrice  Cancelled  ... dayOfWeek           timestamp\n",
+       "0      841.265642      False  ...         0 2018-01-01 00:00:00\n",
+       "1      882.982662      False  ...         0 2018-01-01 18:27:00\n",
+       "2      190.636904      False  ...         0 2018-01-01 17:11:14\n",
+       "3      181.694216       True  ...         0 2018-01-01 10:33:28\n",
+       "4      730.041778      False  ...         0 2018-01-01 05:13:00\n",
+       "\n",
+       "[5 rows x 27 columns]"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pd_flights.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 236
+    },
+    "execution": {
+     "iopub.execute_input": "2023-09-20T14:02:03.731415Z",
+     "iopub.status.busy": "2023-09-20T14:02:03.731018Z",
+     "iopub.status.idle": "2023-09-20T14:02:04.261989Z",
+     "shell.execute_reply": "2023-09-20T14:02:04.261400Z"
+    },
+    "id": "i1-efE1RNRFW",
+    "outputId": "e90121ea-e212-49b2-b985-9c966029a934",
+    "pycharm": {
+     "is_executing": false
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>AvgTicketPrice</th>\n",
+       "      <th>Cancelled</th>\n",
+       "      <th>...</th>\n",
+       "      <th>dayOfWeek</th>\n",
+       "      <th>timestamp</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>841.265642</td>\n",
+       "      <td>False</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0</td>\n",
+       "      <td>2018-01-01 00:00:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>882.982662</td>\n",
+       "      <td>False</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0</td>\n",
+       "      <td>2018-01-01 18:27:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>190.636904</td>\n",
+       "      <td>False</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0</td>\n",
+       "      <td>2018-01-01 17:11:14</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>181.694216</td>\n",
+       "      <td>True</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0</td>\n",
+       "      <td>2018-01-01 10:33:28</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>730.041778</td>\n",
+       "      <td>False</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0</td>\n",
+       "      <td>2018-01-01 05:13:00</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>\n",
+       "<p>5 rows × 27 columns</p>"
+      ],
+      "text/plain": [
+       "   AvgTicketPrice  Cancelled  ... dayOfWeek           timestamp\n",
+       "0      841.265642      False  ...         0 2018-01-01 00:00:00\n",
+       "1      882.982662      False  ...         0 2018-01-01 18:27:00\n",
+       "2      190.636904      False  ...         0 2018-01-01 17:11:14\n",
+       "3      181.694216       True  ...         0 2018-01-01 10:33:28\n",
+       "4      730.041778      False  ...         0 2018-01-01 05:13:00\n",
+       "\n",
+       "[5 rows x 27 columns]"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ed_flights.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "55T-dd4ENRFW"
+   },
+   "source": [
+    "### DataFrame.tail"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 236
+    },
+    "execution": {
+     "iopub.execute_input": "2023-09-20T14:02:04.264387Z",
+     "iopub.status.busy": "2023-09-20T14:02:04.264166Z",
+     "iopub.status.idle": "2023-09-20T14:02:04.272053Z",
+     "shell.execute_reply": "2023-09-20T14:02:04.271637Z"
+    },
+    "id": "MUKzwkRtNRFW",
+    "outputId": "bc4747c7-343a-4aad-b184-5fb05bf0c448",
+    "pycharm": {
+     "is_executing": false
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>AvgTicketPrice</th>\n",
+       "      <th>Cancelled</th>\n",
+       "      <th>...</th>\n",
+       "      <th>dayOfWeek</th>\n",
+       "      <th>timestamp</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>13054</th>\n",
+       "      <td>1080.446279</td>\n",
+       "      <td>False</td>\n",
+       "      <td>...</td>\n",
+       "      <td>6</td>\n",
+       "      <td>2018-02-11 20:42:25</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>13055</th>\n",
+       "      <td>646.612941</td>\n",
+       "      <td>False</td>\n",
+       "      <td>...</td>\n",
+       "      <td>6</td>\n",
+       "      <td>2018-02-11 01:41:57</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>13056</th>\n",
+       "      <td>997.751876</td>\n",
+       "      <td>False</td>\n",
+       "      <td>...</td>\n",
+       "      <td>6</td>\n",
+       "      <td>2018-02-11 04:09:27</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>13057</th>\n",
+       "      <td>1102.814465</td>\n",
+       "      <td>False</td>\n",
+       "      <td>...</td>\n",
+       "      <td>6</td>\n",
+       "      <td>2018-02-11 08:28:21</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>13058</th>\n",
+       "      <td>858.144337</td>\n",
+       "      <td>False</td>\n",
+       "      <td>...</td>\n",
+       "      <td>6</td>\n",
+       "      <td>2018-02-11 14:54:34</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>5 rows × 27 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "       AvgTicketPrice  Cancelled  ... dayOfWeek           timestamp\n",
+       "13054     1080.446279      False  ...         6 2018-02-11 20:42:25\n",
+       "13055      646.612941      False  ...         6 2018-02-11 01:41:57\n",
+       "13056      997.751876      False  ...         6 2018-02-11 04:09:27\n",
+       "13057     1102.814465      False  ...         6 2018-02-11 08:28:21\n",
+       "13058      858.144337      False  ...         6 2018-02-11 14:54:34\n",
+       "\n",
+       "[5 rows x 27 columns]"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pd_flights.tail()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 236
+    },
+    "execution": {
+     "iopub.execute_input": "2023-09-20T14:02:04.274163Z",
+     "iopub.status.busy": "2023-09-20T14:02:04.274029Z",
+     "iopub.status.idle": "2023-09-20T14:02:04.660375Z",
+     "shell.execute_reply": "2023-09-20T14:02:04.659943Z"
+    },
+    "id": "wnFnjtDGNRFW",
+    "outputId": "f98da49c-a6ac-46b0-9873-23d5400e8e14",
+    "pycharm": {
+     "is_executing": false
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>AvgTicketPrice</th>\n",
+       "      <th>Cancelled</th>\n",
+       "      <th>...</th>\n",
+       "      <th>dayOfWeek</th>\n",
+       "      <th>timestamp</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>13054</th>\n",
+       "      <td>1080.446279</td>\n",
+       "      <td>False</td>\n",
+       "      <td>...</td>\n",
+       "      <td>6</td>\n",
+       "      <td>2018-02-11 20:42:25</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>13055</th>\n",
+       "      <td>646.612941</td>\n",
+       "      <td>False</td>\n",
+       "      <td>...</td>\n",
+       "      <td>6</td>\n",
+       "      <td>2018-02-11 01:41:57</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>13056</th>\n",
+       "      <td>997.751876</td>\n",
+       "      <td>False</td>\n",
+       "      <td>...</td>\n",
+       "      <td>6</td>\n",
+       "      <td>2018-02-11 04:09:27</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>13057</th>\n",
+       "      <td>1102.814465</td>\n",
+       "      <td>False</td>\n",
+       "      <td>...</td>\n",
+       "      <td>6</td>\n",
+       "      <td>2018-02-11 08:28:21</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>13058</th>\n",
+       "      <td>858.144337</td>\n",
+       "      <td>False</td>\n",
+       "      <td>...</td>\n",
+       "      <td>6</td>\n",
+       "      <td>2018-02-11 14:54:34</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>\n",
+       "<p>5 rows × 27 columns</p>"
+      ],
+      "text/plain": [
+       "       AvgTicketPrice  Cancelled  ... dayOfWeek           timestamp\n",
+       "13054     1080.446279      False  ...         6 2018-02-11 20:42:25\n",
+       "13055      646.612941      False  ...         6 2018-02-11 01:41:57\n",
+       "13056      997.751876      False  ...         6 2018-02-11 04:09:27\n",
+       "13057     1102.814465      False  ...         6 2018-02-11 08:28:21\n",
+       "13058      858.144337      False  ...         6 2018-02-11 14:54:34\n",
+       "\n",
+       "[5 rows x 27 columns]"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ed_flights.tail()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "y8nBZkIPNRFX"
+   },
+   "source": [
+    "### DataFrame.keys"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "execution": {
+     "iopub.execute_input": "2023-09-20T14:02:04.662764Z",
+     "iopub.status.busy": "2023-09-20T14:02:04.662626Z",
+     "iopub.status.idle": "2023-09-20T14:02:04.666260Z",
+     "shell.execute_reply": "2023-09-20T14:02:04.665832Z"
+    },
+    "id": "NNt89qcvNRFX",
+    "outputId": "0ae0562b-ead8-450d-fc25-205e14d7cb30",
+    "pycharm": {
+     "is_executing": false
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Index(['AvgTicketPrice', 'Cancelled', 'Carrier', 'Dest', 'DestAirportID', 'DestCityName',\n",
+       "       'DestCountry', 'DestLocation', 'DestRegion', 'DestWeather', 'DistanceKilometers',\n",
+       "       'DistanceMiles', 'FlightDelay', 'FlightDelayMin', 'FlightDelayType', 'FlightNum',\n",
+       "       'FlightTimeHour', 'FlightTimeMin', 'Origin', 'OriginAirportID', 'OriginCityName',\n",
+       "       'OriginCountry', 'OriginLocation', 'OriginRegion', 'OriginWeather', 'dayOfWeek',\n",
+       "       'timestamp'],\n",
+       "      dtype='object')"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pd_flights.keys()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "execution": {
+     "iopub.execute_input": "2023-09-20T14:02:04.668345Z",
+     "iopub.status.busy": "2023-09-20T14:02:04.668214Z",
+     "iopub.status.idle": "2023-09-20T14:02:04.671795Z",
+     "shell.execute_reply": "2023-09-20T14:02:04.671388Z"
+    },
+    "id": "zsEuViUSNRFX",
+    "outputId": "84961258-b43c-44bb-8923-f59fd9d0ec0a",
+    "pycharm": {
+     "is_executing": false
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Index(['AvgTicketPrice', 'Cancelled', 'Carrier', 'Dest', 'DestAirportID', 'DestCityName',\n",
+       "       'DestCountry', 'DestLocation', 'DestRegion', 'DestWeather', 'DistanceKilometers',\n",
+       "       'DistanceMiles', 'FlightDelay', 'FlightDelayMin', 'FlightDelayType', 'FlightNum',\n",
+       "       'FlightTimeHour', 'FlightTimeMin', 'Origin', 'OriginAirportID', 'OriginCityName',\n",
+       "       'OriginCountry', 'OriginLocation', 'OriginRegion', 'OriginWeather', 'dayOfWeek',\n",
+       "       'timestamp'],\n",
+       "      dtype='object')"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ed_flights.keys()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "KtypOwLUNRFX"
+   },
+   "source": [
+    "### DataFrame.get"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "execution": {
+     "iopub.execute_input": "2023-09-20T14:02:04.674069Z",
+     "iopub.status.busy": "2023-09-20T14:02:04.673699Z",
+     "iopub.status.idle": "2023-09-20T14:02:04.679643Z",
+     "shell.execute_reply": "2023-09-20T14:02:04.679200Z"
+    },
+    "id": "kFa9r_yQNRFY",
+    "outputId": "8edbbfe1-a871-4cd8-d798-3b0df0fea5f4",
+    "pycharm": {
+     "is_executing": false
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0         Kibana Airlines\n",
+       "1        Logstash Airways\n",
+       "2        Logstash Airways\n",
+       "3         Kibana Airlines\n",
+       "4         Kibana Airlines\n",
+       "               ...       \n",
+       "13054    Logstash Airways\n",
+       "13055    Logstash Airways\n",
+       "13056    Logstash Airways\n",
+       "13057            JetBeats\n",
+       "13058            JetBeats\n",
+       "Name: Carrier, Length: 13059, dtype: object"
+      ]
+     },
+     "execution_count": 29,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pd_flights.get('Carrier')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "execution": {
+     "iopub.execute_input": "2023-09-20T14:02:04.681992Z",
+     "iopub.status.busy": "2023-09-20T14:02:04.681842Z",
+     "iopub.status.idle": "2023-09-20T14:02:05.005843Z",
+     "shell.execute_reply": "2023-09-20T14:02:05.005258Z"
+    },
+    "id": "Fp52TYwGNRFY",
+    "outputId": "544bd33d-aa74-4e8b-8fde-db84a7cdf667",
+    "pycharm": {
+     "is_executing": false
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0         Kibana Airlines\n",
+       "1        Logstash Airways\n",
+       "2        Logstash Airways\n",
+       "3         Kibana Airlines\n",
+       "4         Kibana Airlines\n",
+       "               ...       \n",
+       "13054    Logstash Airways\n",
+       "13055    Logstash Airways\n",
+       "13056    Logstash Airways\n",
+       "13057            JetBeats\n",
+       "13058            JetBeats\n",
+       "Name: Carrier, Length: 13059, dtype: object"
+      ]
+     },
+     "execution_count": 30,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ed_flights.get('Carrier')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 424
+    },
+    "execution": {
+     "iopub.execute_input": "2023-09-20T14:02:05.008218Z",
+     "iopub.status.busy": "2023-09-20T14:02:05.008073Z",
+     "iopub.status.idle": "2023-09-20T14:02:05.017103Z",
+     "shell.execute_reply": "2023-09-20T14:02:05.016544Z"
+    },
+    "id": "-1zPSsGHNRFY",
+    "outputId": "69aee818-d25c-451c-ade6-5eff984a6887",
+    "pycharm": {
+     "is_executing": false
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Carrier</th>\n",
+       "      <th>Origin</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>Kibana Airlines</td>\n",
+       "      <td>Frankfurt am Main Airport</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>Logstash Airways</td>\n",
+       "      <td>Cape Town International Airport</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>Logstash Airways</td>\n",
+       "      <td>Venice Marco Polo Airport</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>Kibana Airlines</td>\n",
+       "      <td>Naples International Airport</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>Kibana Airlines</td>\n",
+       "      <td>Licenciado Benito Juarez International Airport</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>13054</th>\n",
+       "      <td>Logstash Airways</td>\n",
+       "      <td>Pisa International Airport</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>13055</th>\n",
+       "      <td>Logstash Airways</td>\n",
+       "      <td>Winnipeg / James Armstrong Richardson Internat...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>13056</th>\n",
+       "      <td>Logstash Airways</td>\n",
+       "      <td>Licenciado Benito Juarez International Airport</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>13057</th>\n",
+       "      <td>JetBeats</td>\n",
+       "      <td>Itami Airport</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>13058</th>\n",
+       "      <td>JetBeats</td>\n",
+       "      <td>Adelaide International Airport</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>13059 rows × 2 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                Carrier                                             Origin\n",
+       "0       Kibana Airlines                          Frankfurt am Main Airport\n",
+       "1      Logstash Airways                    Cape Town International Airport\n",
+       "2      Logstash Airways                          Venice Marco Polo Airport\n",
+       "3       Kibana Airlines                       Naples International Airport\n",
+       "4       Kibana Airlines     Licenciado Benito Juarez International Airport\n",
+       "...                 ...                                                ...\n",
+       "13054  Logstash Airways                         Pisa International Airport\n",
+       "13055  Logstash Airways  Winnipeg / James Armstrong Richardson Internat...\n",
+       "13056  Logstash Airways     Licenciado Benito Juarez International Airport\n",
+       "13057          JetBeats                                      Itami Airport\n",
+       "13058          JetBeats                     Adelaide International Airport\n",
+       "\n",
+       "[13059 rows x 2 columns]"
+      ]
+     },
+     "execution_count": 31,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pd_flights.get(['Carrier', 'Origin'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Fk7pTfyGNRFZ"
+   },
+   "source": [
+    "List input not currently supported by `eland.DataFrame.get`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "execution": {
+     "iopub.execute_input": "2023-09-20T14:02:05.019349Z",
+     "iopub.status.busy": "2023-09-20T14:02:05.019210Z",
+     "iopub.status.idle": "2023-09-20T14:02:05.023012Z",
+     "shell.execute_reply": "2023-09-20T14:02:05.022437Z"
+    },
+    "id": "iIGNGv6NNRFZ",
+    "outputId": "de14302c-170b-4272-f8e2-f5f8d1bb642b",
+    "pycharm": {
+     "is_executing": false
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "unhashable type: 'list'\n"
+     ]
+    }
+   ],
+   "source": [
+    "try:\n",
+    "    ed_flights.get(['Carrier', 'Origin'])\n",
+    "except TypeError as e:\n",
+    "    print(e)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "jygQjxYRNRFa"
+   },
+   "source": [
+    "### DataFrame.query"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 424
+    },
+    "execution": {
+     "iopub.execute_input": "2023-09-20T14:02:05.025178Z",
+     "iopub.status.busy": "2023-09-20T14:02:05.025045Z",
+     "iopub.status.idle": "2023-09-20T14:02:05.043920Z",
+     "shell.execute_reply": "2023-09-20T14:02:05.043309Z"
+    },
+    "id": "fpKfuV-uNRFa",
+    "outputId": "95ab3f49-2723-43b6-bf40-ac0e40654697",
+    "pycharm": {
+     "is_executing": false
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>AvgTicketPrice</th>\n",
+       "      <th>Cancelled</th>\n",
+       "      <th>...</th>\n",
+       "      <th>dayOfWeek</th>\n",
+       "      <th>timestamp</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>960.869736</td>\n",
+       "      <td>True</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0</td>\n",
+       "      <td>2018-01-01 12:09:35</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>26</th>\n",
+       "      <td>975.812632</td>\n",
+       "      <td>True</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0</td>\n",
+       "      <td>2018-01-01 15:38:32</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>311</th>\n",
+       "      <td>946.358410</td>\n",
+       "      <td>True</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0</td>\n",
+       "      <td>2018-01-01 11:51:12</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>651</th>\n",
+       "      <td>975.383864</td>\n",
+       "      <td>True</td>\n",
+       "      <td>...</td>\n",
+       "      <td>2</td>\n",
+       "      <td>2018-01-03 21:13:17</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>950</th>\n",
+       "      <td>907.836523</td>\n",
+       "      <td>True</td>\n",
+       "      <td>...</td>\n",
+       "      <td>2</td>\n",
+       "      <td>2018-01-03 05:14:51</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>12820</th>\n",
+       "      <td>909.973606</td>\n",
+       "      <td>True</td>\n",
+       "      <td>...</td>\n",
+       "      <td>5</td>\n",
+       "      <td>2018-02-10 05:11:35</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>12906</th>\n",
+       "      <td>983.429244</td>\n",
+       "      <td>True</td>\n",
+       "      <td>...</td>\n",
+       "      <td>6</td>\n",
+       "      <td>2018-02-11 06:19:58</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>12918</th>\n",
+       "      <td>1136.678150</td>\n",
+       "      <td>True</td>\n",
+       "      <td>...</td>\n",
+       "      <td>6</td>\n",
+       "      <td>2018-02-11 16:03:10</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>12919</th>\n",
+       "      <td>1105.211803</td>\n",
+       "      <td>True</td>\n",
+       "      <td>...</td>\n",
+       "      <td>6</td>\n",
+       "      <td>2018-02-11 05:36:05</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>13013</th>\n",
+       "      <td>1055.350213</td>\n",
+       "      <td>True</td>\n",
+       "      <td>...</td>\n",
+       "      <td>6</td>\n",
+       "      <td>2018-02-11 13:20:16</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>68 rows × 27 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "       AvgTicketPrice  Cancelled  ... dayOfWeek           timestamp\n",
+       "8          960.869736       True  ...         0 2018-01-01 12:09:35\n",
+       "26         975.812632       True  ...         0 2018-01-01 15:38:32\n",
+       "311        946.358410       True  ...         0 2018-01-01 11:51:12\n",
+       "651        975.383864       True  ...         2 2018-01-03 21:13:17\n",
+       "950        907.836523       True  ...         2 2018-01-03 05:14:51\n",
+       "...               ...        ...  ...       ...                 ...\n",
+       "12820      909.973606       True  ...         5 2018-02-10 05:11:35\n",
+       "12906      983.429244       True  ...         6 2018-02-11 06:19:58\n",
+       "12918     1136.678150       True  ...         6 2018-02-11 16:03:10\n",
+       "12919     1105.211803       True  ...         6 2018-02-11 05:36:05\n",
+       "13013     1055.350213       True  ...         6 2018-02-11 13:20:16\n",
+       "\n",
+       "[68 rows x 27 columns]"
+      ]
+     },
+     "execution_count": 33,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pd_flights.query('Carrier == \"Kibana Airlines\" & AvgTicketPrice > 900.0 & Cancelled == True')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "BOtIJQ8iNRFb"
+   },
+   "source": [
+    "`eland.DataFrame.query` requires qualifier on bool i.e.\n",
+    "\n",
+    "`ed_flights.query('Carrier == \"Kibana Airlines\" & AvgTicketPrice > 900.0 & Cancelled')` fails"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "execution": {
+     "iopub.execute_input": "2023-09-20T14:02:05.046390Z",
+     "iopub.status.busy": "2023-09-20T14:02:05.046016Z",
+     "iopub.status.idle": "2023-09-20T14:02:05.071493Z",
+     "shell.execute_reply": "2023-09-20T14:02:05.070982Z"
+    },
+    "id": "BQY-QkAENRFb",
+    "outputId": "c856a999-5fbf-4a54-b8fa-2e7cd5f5e3c8",
+    "pycharm": {
+     "is_executing": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "  ed_flights.query('Carrier == \"Kibana Airlines\" & AvgTicketPrice > 900.0 & Cancelled == True')\n",
+    "except Exception as e:\n",
+    "  print(f\"query() failed as expected: {repr(e)}.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "u669zWowNRFb"
+   },
+   "source": [
+    "#### Boolean indexing query"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 424
+    },
+    "execution": {
+     "iopub.execute_input": "2023-09-20T14:02:05.073998Z",
+     "iopub.status.busy": "2023-09-20T14:02:05.073854Z",
+     "iopub.status.idle": "2023-09-20T14:02:05.088978Z",
+     "shell.execute_reply": "2023-09-20T14:02:05.088344Z"
+    },
+    "id": "f59Szl_9NRFc",
+    "outputId": "c2d81587-cce8-45b2-fd4e-d7b4f60eb9c6",
+    "pycharm": {
+     "is_executing": false
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>AvgTicketPrice</th>\n",
+       "      <th>Cancelled</th>\n",
+       "      <th>...</th>\n",
+       "      <th>dayOfWeek</th>\n",
+       "      <th>timestamp</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>960.869736</td>\n",
+       "      <td>True</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0</td>\n",
+       "      <td>2018-01-01 12:09:35</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>26</th>\n",
+       "      <td>975.812632</td>\n",
+       "      <td>True</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0</td>\n",
+       "      <td>2018-01-01 15:38:32</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>311</th>\n",
+       "      <td>946.358410</td>\n",
+       "      <td>True</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0</td>\n",
+       "      <td>2018-01-01 11:51:12</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>651</th>\n",
+       "      <td>975.383864</td>\n",
+       "      <td>True</td>\n",
+       "      <td>...</td>\n",
+       "      <td>2</td>\n",
+       "      <td>2018-01-03 21:13:17</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>950</th>\n",
+       "      <td>907.836523</td>\n",
+       "      <td>True</td>\n",
+       "      <td>...</td>\n",
+       "      <td>2</td>\n",
+       "      <td>2018-01-03 05:14:51</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>12820</th>\n",
+       "      <td>909.973606</td>\n",
+       "      <td>True</td>\n",
+       "      <td>...</td>\n",
+       "      <td>5</td>\n",
+       "      <td>2018-02-10 05:11:35</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>12906</th>\n",
+       "      <td>983.429244</td>\n",
+       "      <td>True</td>\n",
+       "      <td>...</td>\n",
+       "      <td>6</td>\n",
+       "      <td>2018-02-11 06:19:58</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>12918</th>\n",
+       "      <td>1136.678150</td>\n",
+       "      <td>True</td>\n",
+       "      <td>...</td>\n",
+       "      <td>6</td>\n",
+       "      <td>2018-02-11 16:03:10</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>12919</th>\n",
+       "      <td>1105.211803</td>\n",
+       "      <td>True</td>\n",
+       "      <td>...</td>\n",
+       "      <td>6</td>\n",
+       "      <td>2018-02-11 05:36:05</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>13013</th>\n",
+       "      <td>1055.350213</td>\n",
+       "      <td>True</td>\n",
+       "      <td>...</td>\n",
+       "      <td>6</td>\n",
+       "      <td>2018-02-11 13:20:16</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>68 rows × 27 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "       AvgTicketPrice  Cancelled  ... dayOfWeek           timestamp\n",
+       "8          960.869736       True  ...         0 2018-01-01 12:09:35\n",
+       "26         975.812632       True  ...         0 2018-01-01 15:38:32\n",
+       "311        946.358410       True  ...         0 2018-01-01 11:51:12\n",
+       "651        975.383864       True  ...         2 2018-01-03 21:13:17\n",
+       "950        907.836523       True  ...         2 2018-01-03 05:14:51\n",
+       "...               ...        ...  ...       ...                 ...\n",
+       "12820      909.973606       True  ...         5 2018-02-10 05:11:35\n",
+       "12906      983.429244       True  ...         6 2018-02-11 06:19:58\n",
+       "12918     1136.678150       True  ...         6 2018-02-11 16:03:10\n",
+       "12919     1105.211803       True  ...         6 2018-02-11 05:36:05\n",
+       "13013     1055.350213       True  ...         6 2018-02-11 13:20:16\n",
+       "\n",
+       "[68 rows x 27 columns]"
+      ]
+     },
+     "execution_count": 35,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pd_flights[(pd_flights.Carrier==\"Kibana Airlines\") &\n",
+    "           (pd_flights.AvgTicketPrice > 900.0) &\n",
+    "           (pd_flights.Cancelled == True)]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 424
+    },
+    "execution": {
+     "iopub.execute_input": "2023-09-20T14:02:05.091368Z",
+     "iopub.status.busy": "2023-09-20T14:02:05.091037Z",
+     "iopub.status.idle": "2023-09-20T14:02:05.269653Z",
+     "shell.execute_reply": "2023-09-20T14:02:05.269097Z"
+    },
+    "id": "ZiewRsffNRFc",
+    "outputId": "2664c3f9-e509-4859-fc63-1c417e9104af",
+    "pycharm": {
+     "is_executing": false
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>AvgTicketPrice</th>\n",
+       "      <th>Cancelled</th>\n",
+       "      <th>...</th>\n",
+       "      <th>dayOfWeek</th>\n",
+       "      <th>timestamp</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>960.869736</td>\n",
+       "      <td>True</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0</td>\n",
+       "      <td>2018-01-01 12:09:35</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>26</th>\n",
+       "      <td>975.812632</td>\n",
+       "      <td>True</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0</td>\n",
+       "      <td>2018-01-01 15:38:32</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>311</th>\n",
+       "      <td>946.358410</td>\n",
+       "      <td>True</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0</td>\n",
+       "      <td>2018-01-01 11:51:12</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>651</th>\n",
+       "      <td>975.383864</td>\n",
+       "      <td>True</td>\n",
+       "      <td>...</td>\n",
+       "      <td>2</td>\n",
+       "      <td>2018-01-03 21:13:17</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>950</th>\n",
+       "      <td>907.836523</td>\n",
+       "      <td>True</td>\n",
+       "      <td>...</td>\n",
+       "      <td>2</td>\n",
+       "      <td>2018-01-03 05:14:51</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>12820</th>\n",
+       "      <td>909.973606</td>\n",
+       "      <td>True</td>\n",
+       "      <td>...</td>\n",
+       "      <td>5</td>\n",
+       "      <td>2018-02-10 05:11:35</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>12906</th>\n",
+       "      <td>983.429244</td>\n",
+       "      <td>True</td>\n",
+       "      <td>...</td>\n",
+       "      <td>6</td>\n",
+       "      <td>2018-02-11 06:19:58</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>12918</th>\n",
+       "      <td>1136.678150</td>\n",
+       "      <td>True</td>\n",
+       "      <td>...</td>\n",
+       "      <td>6</td>\n",
+       "      <td>2018-02-11 16:03:10</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>12919</th>\n",
+       "      <td>1105.211803</td>\n",
+       "      <td>True</td>\n",
+       "      <td>...</td>\n",
+       "      <td>6</td>\n",
+       "      <td>2018-02-11 05:36:05</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>13013</th>\n",
+       "      <td>1055.350213</td>\n",
+       "      <td>True</td>\n",
+       "      <td>...</td>\n",
+       "      <td>6</td>\n",
+       "      <td>2018-02-11 13:20:16</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>\n",
+       "<p>68 rows × 27 columns</p>"
+      ],
+      "text/plain": [
+       "       AvgTicketPrice  Cancelled  ... dayOfWeek           timestamp\n",
+       "8          960.869736       True  ...         0 2018-01-01 12:09:35\n",
+       "26         975.812632       True  ...         0 2018-01-01 15:38:32\n",
+       "311        946.358410       True  ...         0 2018-01-01 11:51:12\n",
+       "651        975.383864       True  ...         2 2018-01-03 21:13:17\n",
+       "950        907.836523       True  ...         2 2018-01-03 05:14:51\n",
+       "...               ...        ...  ...       ...                 ...\n",
+       "12820      909.973606       True  ...         5 2018-02-10 05:11:35\n",
+       "12906      983.429244       True  ...         6 2018-02-11 06:19:58\n",
+       "12918     1136.678150       True  ...         6 2018-02-11 16:03:10\n",
+       "12919     1105.211803       True  ...         6 2018-02-11 05:36:05\n",
+       "13013     1055.350213       True  ...         6 2018-02-11 13:20:16\n",
+       "\n",
+       "[68 rows x 27 columns]"
+      ]
+     },
+     "execution_count": 36,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ed_flights[(ed_flights.Carrier==\"Kibana Airlines\") &\n",
+    "           (ed_flights.AvgTicketPrice > 900.0) &\n",
+    "           (ed_flights.Cancelled == True)]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "2aEJXYr3NRFc"
+   },
+   "source": [
+    "## Function application, GroupBy & window"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "PLNjRajUNRFd"
+   },
+   "source": [
+    "### DataFrame.aggs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 143
+    },
+    "execution": {
+     "iopub.execute_input": "2023-09-20T14:02:05.272304Z",
+     "iopub.status.busy": "2023-09-20T14:02:05.272016Z",
+     "iopub.status.idle": "2023-09-20T14:02:05.281913Z",
+     "shell.execute_reply": "2023-09-20T14:02:05.281401Z"
+    },
+    "id": "-j7Hwl9FNRFd",
+    "outputId": "ef07eaea-b9cd-4333-b063-fded8d231a95",
+    "pycharm": {
+     "is_executing": false
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>DistanceKilometers</th>\n",
+       "      <th>AvgTicketPrice</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>sum</th>\n",
+       "      <td>9.261629e+07</td>\n",
+       "      <td>8.204365e+06</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>min</th>\n",
+       "      <td>0.000000e+00</td>\n",
+       "      <td>1.000205e+02</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>std</th>\n",
+       "      <td>4.578438e+03</td>\n",
+       "      <td>2.663969e+02</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "     DistanceKilometers  AvgTicketPrice\n",
+       "sum        9.261629e+07    8.204365e+06\n",
+       "min        0.000000e+00    1.000205e+02\n",
+       "std        4.578438e+03    2.663969e+02"
+      ]
+     },
+     "execution_count": 37,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pd_flights[['DistanceKilometers', 'AvgTicketPrice']].aggregate(['sum', 'min', 'std'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "BL2p1GPLNRFd"
+   },
+   "source": [
+    "`eland.DataFrame.aggregate` currently only supported numeric columns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 143
+    },
+    "execution": {
+     "iopub.execute_input": "2023-09-20T14:02:05.284252Z",
+     "iopub.status.busy": "2023-09-20T14:02:05.283974Z",
+     "iopub.status.idle": "2023-09-20T14:02:05.313585Z",
+     "shell.execute_reply": "2023-09-20T14:02:05.313101Z"
+    },
+    "id": "ok4Ui8BhNRFe",
+    "outputId": "796c616d-b4c1-42e9-b867-f8e0fd13f410",
+    "pycharm": {
+     "is_executing": false
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>DistanceKilometers</th>\n",
+       "      <th>AvgTicketPrice</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>sum</th>\n",
+       "      <td>9.261629e+07</td>\n",
+       "      <td>8.204365e+06</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>min</th>\n",
+       "      <td>0.000000e+00</td>\n",
+       "      <td>1.000205e+02</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>std</th>\n",
+       "      <td>4.578614e+03</td>\n",
+       "      <td>2.664071e+02</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "     DistanceKilometers  AvgTicketPrice\n",
+       "sum        9.261629e+07    8.204365e+06\n",
+       "min        0.000000e+00    1.000205e+02\n",
+       "std        4.578614e+03    2.664071e+02"
+      ]
+     },
+     "execution_count": 38,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ed_flights[['DistanceKilometers', 'AvgTicketPrice']].aggregate(['sum', 'min', 'std'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "v-49A_fDNRFe"
+   },
+   "source": [
+    "## Computations / descriptive stats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "00OupOBTNRFe"
+   },
+   "source": [
+    "### DataFrame.count"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "execution": {
+     "iopub.execute_input": "2023-09-20T14:02:05.315840Z",
+     "iopub.status.busy": "2023-09-20T14:02:05.315705Z",
+     "iopub.status.idle": "2023-09-20T14:02:05.358715Z",
+     "shell.execute_reply": "2023-09-20T14:02:05.358127Z"
+    },
+    "id": "-1b9NDszNRFe",
+    "outputId": "271a96d6-8abb-4f17-b5c3-de2359c15ed5",
+    "pycharm": {
+     "is_executing": false
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "AvgTicketPrice    13059\n",
+       "Cancelled         13059\n",
+       "Carrier           13059\n",
+       "Dest              13059\n",
+       "DestAirportID     13059\n",
+       "                  ...  \n",
+       "OriginLocation    13059\n",
+       "OriginRegion      13059\n",
+       "OriginWeather     13059\n",
+       "dayOfWeek         13059\n",
+       "timestamp         13059\n",
+       "Length: 27, dtype: int64"
+      ]
+     },
+     "execution_count": 39,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pd_flights.count()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "execution": {
+     "iopub.execute_input": "2023-09-20T14:02:05.361078Z",
+     "iopub.status.busy": "2023-09-20T14:02:05.360939Z",
+     "iopub.status.idle": "2023-09-20T14:02:05.438915Z",
+     "shell.execute_reply": "2023-09-20T14:02:05.438480Z"
+    },
+    "id": "GjHLdmvPNRFf",
+    "outputId": "4b846ac1-8804-494b-fe5f-b910b0861ed3",
+    "pycharm": {
+     "is_executing": false
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "AvgTicketPrice    13059\n",
+       "Cancelled         13059\n",
+       "Carrier           13059\n",
+       "Dest              13059\n",
+       "DestAirportID     13059\n",
+       "                  ...  \n",
+       "OriginLocation    13059\n",
+       "OriginRegion      13059\n",
+       "OriginWeather     13059\n",
+       "dayOfWeek         13059\n",
+       "timestamp         13059\n",
+       "Length: 27, dtype: int64"
+      ]
+     },
+     "execution_count": 40,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ed_flights.count()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "tF40dPiPNRFf"
+   },
+   "source": [
+    "### DataFrame.describe"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 330
+    },
+    "execution": {
+     "iopub.execute_input": "2023-09-20T14:02:05.441334Z",
+     "iopub.status.busy": "2023-09-20T14:02:05.441044Z",
+     "iopub.status.idle": "2023-09-20T14:02:05.463443Z",
+     "shell.execute_reply": "2023-09-20T14:02:05.462953Z"
+    },
+    "id": "IKjmnuuBNRFf",
+    "outputId": "29a8c8a2-3911-44d8-9839-c5c745ea51af",
+    "pycharm": {
+     "is_executing": false
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>AvgTicketPrice</th>\n",
+       "      <th>DistanceKilometers</th>\n",
+       "      <th>...</th>\n",
+       "      <th>FlightTimeMin</th>\n",
+       "      <th>dayOfWeek</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>count</th>\n",
+       "      <td>13059.000000</td>\n",
+       "      <td>13059.000000</td>\n",
+       "      <td>...</td>\n",
+       "      <td>13059.000000</td>\n",
+       "      <td>13059.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>mean</th>\n",
+       "      <td>628.253689</td>\n",
+       "      <td>7092.142455</td>\n",
+       "      <td>...</td>\n",
+       "      <td>511.127842</td>\n",
+       "      <td>2.835975</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>std</th>\n",
+       "      <td>266.396861</td>\n",
+       "      <td>4578.438497</td>\n",
+       "      <td>...</td>\n",
+       "      <td>334.753952</td>\n",
+       "      <td>1.939439</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>min</th>\n",
+       "      <td>100.020528</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>25%</th>\n",
+       "      <td>409.893816</td>\n",
+       "      <td>2459.705673</td>\n",
+       "      <td>...</td>\n",
+       "      <td>252.333192</td>\n",
+       "      <td>1.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>50%</th>\n",
+       "      <td>640.556668</td>\n",
+       "      <td>7610.330866</td>\n",
+       "      <td>...</td>\n",
+       "      <td>503.045170</td>\n",
+       "      <td>3.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>75%</th>\n",
+       "      <td>842.185470</td>\n",
+       "      <td>9736.637600</td>\n",
+       "      <td>...</td>\n",
+       "      <td>720.416036</td>\n",
+       "      <td>4.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>max</th>\n",
+       "      <td>1199.729053</td>\n",
+       "      <td>19881.482315</td>\n",
+       "      <td>...</td>\n",
+       "      <td>1902.902032</td>\n",
+       "      <td>6.000000</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>8 rows × 7 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "       AvgTicketPrice  DistanceKilometers  ...  FlightTimeMin     dayOfWeek\n",
+       "count    13059.000000        13059.000000  ...   13059.000000  13059.000000\n",
+       "mean       628.253689         7092.142455  ...     511.127842      2.835975\n",
+       "std        266.396861         4578.438497  ...     334.753952      1.939439\n",
+       "min        100.020528            0.000000  ...       0.000000      0.000000\n",
+       "25%        409.893816         2459.705673  ...     252.333192      1.000000\n",
+       "50%        640.556668         7610.330866  ...     503.045170      3.000000\n",
+       "75%        842.185470         9736.637600  ...     720.416036      4.000000\n",
+       "max       1199.729053        19881.482315  ...    1902.902032      6.000000\n",
+       "\n",
+       "[8 rows x 7 columns]"
+      ]
+     },
+     "execution_count": 41,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pd_flights.describe()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "O4FVtGT9NRFg"
+   },
+   "source": [
+    "Values returned from `eland.DataFrame.describe` may vary due to results of Elasticsearch aggregations."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 330
+    },
+    "execution": {
+     "iopub.execute_input": "2023-09-20T14:02:05.465743Z",
+     "iopub.status.busy": "2023-09-20T14:02:05.465608Z",
+     "iopub.status.idle": "2023-09-20T14:02:05.543075Z",
+     "shell.execute_reply": "2023-09-20T14:02:05.542488Z"
+    },
+    "id": "L7eKy3AINRFg",
+    "outputId": "27b722d6-ddfe-46d9-d6fb-1bded42058ca",
+    "pycharm": {
+     "is_executing": false
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>AvgTicketPrice</th>\n",
+       "      <th>Cancelled</th>\n",
+       "      <th>...</th>\n",
+       "      <th>FlightTimeMin</th>\n",
+       "      <th>dayOfWeek</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>count</th>\n",
+       "      <td>13059.000000</td>\n",
+       "      <td>13059.000000</td>\n",
+       "      <td>...</td>\n",
+       "      <td>13059.000000</td>\n",
+       "      <td>13059.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>mean</th>\n",
+       "      <td>628.253689</td>\n",
+       "      <td>0.128494</td>\n",
+       "      <td>...</td>\n",
+       "      <td>511.127842</td>\n",
+       "      <td>2.835975</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>std</th>\n",
+       "      <td>266.407061</td>\n",
+       "      <td>0.334664</td>\n",
+       "      <td>...</td>\n",
+       "      <td>334.766770</td>\n",
+       "      <td>1.939513</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>min</th>\n",
+       "      <td>100.020531</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>25%</th>\n",
+       "      <td>411.154491</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>...</td>\n",
+       "      <td>250.428538</td>\n",
+       "      <td>1.058527</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>50%</th>\n",
+       "      <td>639.433214</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>...</td>\n",
+       "      <td>502.777975</td>\n",
+       "      <td>2.935777</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>75%</th>\n",
+       "      <td>842.336195</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>...</td>\n",
+       "      <td>721.351220</td>\n",
+       "      <td>4.427843</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>max</th>\n",
+       "      <td>1199.729004</td>\n",
+       "      <td>1.000000</td>\n",
+       "      <td>...</td>\n",
+       "      <td>1902.901978</td>\n",
+       "      <td>6.000000</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>8 rows × 9 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "       AvgTicketPrice     Cancelled  ...  FlightTimeMin     dayOfWeek\n",
+       "count    13059.000000  13059.000000  ...   13059.000000  13059.000000\n",
+       "mean       628.253689      0.128494  ...     511.127842      2.835975\n",
+       "std        266.407061      0.334664  ...     334.766770      1.939513\n",
+       "min        100.020531      0.000000  ...       0.000000      0.000000\n",
+       "25%        411.154491      0.000000  ...     250.428538      1.058527\n",
+       "50%        639.433214      0.000000  ...     502.777975      2.935777\n",
+       "75%        842.336195      0.000000  ...     721.351220      4.427843\n",
+       "max       1199.729004      1.000000  ...    1902.901978      6.000000\n",
+       "\n",
+       "[8 rows x 9 columns]"
+      ]
+     },
+     "execution_count": 42,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# NBVAL_IGNORE_OUTPUT\n",
+    "ed_flights.describe()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "qDo76JgKNRFh"
+   },
+   "source": [
+    "### DataFrame.info"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "execution": {
+     "iopub.execute_input": "2023-09-20T14:02:05.545856Z",
+     "iopub.status.busy": "2023-09-20T14:02:05.545501Z",
+     "iopub.status.idle": "2023-09-20T14:02:05.595477Z",
+     "shell.execute_reply": "2023-09-20T14:02:05.594890Z"
+    },
+    "id": "GvvfPrPdNRFh",
+    "outputId": "ea8a7083-10db-4540-c8b9-a0b50802be11",
+    "pycharm": {
+     "is_executing": false
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<class 'pandas.core.frame.DataFrame'>\n",
+      "Index: 13059 entries, 0 to 13058\n",
+      "Data columns (total 27 columns):\n",
+      " #   Column              Non-Null Count  Dtype         \n",
+      "---  ------              --------------  -----         \n",
+      " 0   AvgTicketPrice      13059 non-null  float64       \n",
+      " 1   Cancelled           13059 non-null  bool          \n",
+      " 2   Carrier             13059 non-null  object        \n",
+      " 3   Dest                13059 non-null  object        \n",
+      " 4   DestAirportID       13059 non-null  object        \n",
+      " 5   DestCityName        13059 non-null  object        \n",
+      " 6   DestCountry         13059 non-null  object        \n",
+      " 7   DestLocation        13059 non-null  object        \n",
+      " 8   DestRegion          13059 non-null  object        \n",
+      " 9   DestWeather         13059 non-null  object        \n",
+      " 10  DistanceKilometers  13059 non-null  float64       \n",
+      " 11  DistanceMiles       13059 non-null  float64       \n",
+      " 12  FlightDelay         13059 non-null  bool          \n",
+      " 13  FlightDelayMin      13059 non-null  int64         \n",
+      " 14  FlightDelayType     13059 non-null  object        \n",
+      " 15  FlightNum           13059 non-null  object        \n",
+      " 16  FlightTimeHour      13059 non-null  float64       \n",
+      " 17  FlightTimeMin       13059 non-null  float64       \n",
+      " 18  Origin              13059 non-null  object        \n",
+      " 19  OriginAirportID     13059 non-null  object        \n",
+      " 20  OriginCityName      13059 non-null  object        \n",
+      " 21  OriginCountry       13059 non-null  object        \n",
+      " 22  OriginLocation      13059 non-null  object        \n",
+      " 23  OriginRegion        13059 non-null  object        \n",
+      " 24  OriginWeather       13059 non-null  object        \n",
+      " 25  dayOfWeek           13059 non-null  int64         \n",
+      " 26  timestamp           13059 non-null  datetime64[ns]\n",
+      "dtypes: bool(2), datetime64[ns](1), float64(5), int64(2), object(17)\n",
+      "memory usage: 3.1+ MB\n"
+     ]
+    }
+   ],
+   "source": [
+    "pd_flights.info()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 44,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "execution": {
+     "iopub.execute_input": "2023-09-20T14:02:05.597876Z",
+     "iopub.status.busy": "2023-09-20T14:02:05.597726Z",
+     "iopub.status.idle": "2023-09-20T14:02:06.048885Z",
+     "shell.execute_reply": "2023-09-20T14:02:06.048281Z"
+    },
+    "id": "ByVDPJXkNRFh",
+    "outputId": "a82c77af-b00b-46eb-b79d-4a8e59d24321",
+    "pycharm": {
+     "is_executing": false
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<class 'eland.dataframe.DataFrame'>\n",
+      "Index: 13059 entries, 0 to 13058\n",
+      "Data columns (total 27 columns):\n",
+      " #   Column              Non-Null Count  Dtype         \n",
+      "---  ------              --------------  -----         \n",
+      " 0   AvgTicketPrice      13059 non-null  float64       \n",
+      " 1   Cancelled           13059 non-null  bool          \n",
+      " 2   Carrier             13059 non-null  object        \n",
+      " 3   Dest                13059 non-null  object        \n",
+      " 4   DestAirportID       13059 non-null  object        \n",
+      " 5   DestCityName        13059 non-null  object        \n",
+      " 6   DestCountry         13059 non-null  object        \n",
+      " 7   DestLocation        13059 non-null  object        \n",
+      " 8   DestRegion          13059 non-null  object        \n",
+      " 9   DestWeather         13059 non-null  object        \n",
+      " 10  DistanceKilometers  13059 non-null  float64       \n",
+      " 11  DistanceMiles       13059 non-null  float64       \n",
+      " 12  FlightDelay         13059 non-null  bool          \n",
+      " 13  FlightDelayMin      13059 non-null  int64         \n",
+      " 14  FlightDelayType     13059 non-null  object        \n",
+      " 15  FlightNum           13059 non-null  object        \n",
+      " 16  FlightTimeHour      13059 non-null  float64       \n",
+      " 17  FlightTimeMin       13059 non-null  float64       \n",
+      " 18  Origin              13059 non-null  object        \n",
+      " 19  OriginAirportID     13059 non-null  object        \n",
+      " 20  OriginCityName      13059 non-null  object        \n",
+      " 21  OriginCountry       13059 non-null  object        \n",
+      " 22  OriginLocation      13059 non-null  object        \n",
+      " 23  OriginRegion        13059 non-null  object        \n",
+      " 24  OriginWeather       13059 non-null  object        \n",
+      " 25  dayOfWeek           13059 non-null  int64         \n",
+      " 26  timestamp           13059 non-null  datetime64[ns]\n",
+      "dtypes: bool(2), datetime64[ns](1), float64(5), int64(2), object(17)\n",
+      "memory usage: 64.000 bytes\n",
+      "Elasticsearch storage usage: 5.371 MB\n"
+     ]
+    }
+   ],
+   "source": [
+    "ed_flights.info()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "nW0sRoI3NRFi"
+   },
+   "source": [
+    "### DataFrame.max, DataFrame.min, DataFrame.mean, DataFrame.sum"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "iMSuS3Q9NRFi"
+   },
+   "source": [
+    "#### max"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 45,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "execution": {
+     "iopub.execute_input": "2023-09-20T14:02:06.051514Z",
+     "iopub.status.busy": "2023-09-20T14:02:06.051290Z",
+     "iopub.status.idle": "2023-09-20T14:02:06.059490Z",
+     "shell.execute_reply": "2023-09-20T14:02:06.059006Z"
+    },
+    "id": "a06G_BihNRFj",
+    "outputId": "3664f80d-7535-49de-80c9-7e3d7bd4eaaf",
+    "pycharm": {
+     "is_executing": false
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "AvgTicketPrice         1199.729053\n",
+       "Cancelled                     True\n",
+       "DistanceKilometers    19881.482315\n",
+       "DistanceMiles         12353.780369\n",
+       "FlightDelay                   True\n",
+       "FlightDelayMin                 360\n",
+       "FlightTimeHour           31.715034\n",
+       "FlightTimeMin          1902.902032\n",
+       "dayOfWeek                        6\n",
+       "dtype: object"
+      ]
+     },
+     "execution_count": 45,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pd_flights.max(numeric_only=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "a6F0YCOCNRFj"
+   },
+   "source": [
+    "`eland.DataFrame.max,min,mean,sum` only aggregate numeric columns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 46,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "execution": {
+     "iopub.execute_input": "2023-09-20T14:02:06.062020Z",
+     "iopub.status.busy": "2023-09-20T14:02:06.061868Z",
+     "iopub.status.idle": "2023-09-20T14:02:06.081171Z",
+     "shell.execute_reply": "2023-09-20T14:02:06.080696Z"
+    },
+    "id": "JG56E5IoNRFj",
+    "outputId": "ea29eae1-435e-4a49-cb8f-a2c889e5fe26",
+    "pycharm": {
+     "is_executing": false
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "AvgTicketPrice         1199.729004\n",
+       "Cancelled                 1.000000\n",
+       "DistanceKilometers    19881.482422\n",
+       "DistanceMiles         12353.780273\n",
+       "FlightDelay               1.000000\n",
+       "FlightDelayMin          360.000000\n",
+       "FlightTimeHour           31.715034\n",
+       "FlightTimeMin          1902.901978\n",
+       "dayOfWeek                 6.000000\n",
+       "dtype: float64"
+      ]
+     },
+     "execution_count": 46,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ed_flights.max(numeric_only=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "cigqPPNZNRFk"
+   },
+   "source": [
+    "#### min"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 47,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "execution": {
+     "iopub.execute_input": "2023-09-20T14:02:06.083416Z",
+     "iopub.status.busy": "2023-09-20T14:02:06.083274Z",
+     "iopub.status.idle": "2023-09-20T14:02:06.088986Z",
+     "shell.execute_reply": "2023-09-20T14:02:06.088478Z"
+    },
+    "id": "jy4YPXvmNRFk",
+    "outputId": "7a6b098d-c41e-418f-f164-09343021a3ba",
+    "pycharm": {
+     "is_executing": false
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "AvgTicketPrice        100.020528\n",
+       "Cancelled                  False\n",
+       "DistanceKilometers           0.0\n",
+       "DistanceMiles                0.0\n",
+       "FlightDelay                False\n",
+       "FlightDelayMin                 0\n",
+       "FlightTimeHour               0.0\n",
+       "FlightTimeMin                0.0\n",
+       "dayOfWeek                      0\n",
+       "dtype: object"
+      ]
+     },
+     "execution_count": 47,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pd_flights.min(numeric_only=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 48,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "execution": {
+     "iopub.execute_input": "2023-09-20T14:02:06.091517Z",
+     "iopub.status.busy": "2023-09-20T14:02:06.091189Z",
+     "iopub.status.idle": "2023-09-20T14:02:06.107648Z",
+     "shell.execute_reply": "2023-09-20T14:02:06.106656Z"
+    },
+    "id": "1n3xlYOuNRFk",
+    "outputId": "c45953ef-4ddb-4d79-c517-b9b6e91cfba1",
+    "pycharm": {
+     "is_executing": false
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "AvgTicketPrice        100.020531\n",
+       "Cancelled               0.000000\n",
+       "DistanceKilometers      0.000000\n",
+       "DistanceMiles           0.000000\n",
+       "FlightDelay             0.000000\n",
+       "FlightDelayMin          0.000000\n",
+       "FlightTimeHour          0.000000\n",
+       "FlightTimeMin           0.000000\n",
+       "dayOfWeek               0.000000\n",
+       "dtype: float64"
+      ]
+     },
+     "execution_count": 48,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ed_flights.min(numeric_only=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "PJuymQk-NRFl"
+   },
+   "source": [
+    "#### mean"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 49,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "execution": {
+     "iopub.execute_input": "2023-09-20T14:02:06.110533Z",
+     "iopub.status.busy": "2023-09-20T14:02:06.110361Z",
+     "iopub.status.idle": "2023-09-20T14:02:06.116665Z",
+     "shell.execute_reply": "2023-09-20T14:02:06.116196Z"
+    },
+    "id": "Rcj9OfiaNRFl",
+    "outputId": "5f71866c-bb52-41ef-e917-3706e4460a92",
+    "pycharm": {
+     "is_executing": false
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "AvgTicketPrice         628.253689\n",
+       "Cancelled                0.128494\n",
+       "DistanceKilometers    7092.142455\n",
+       "DistanceMiles         4406.853013\n",
+       "FlightDelay              0.251168\n",
+       "FlightDelayMin          47.335171\n",
+       "FlightTimeHour           8.518797\n",
+       "FlightTimeMin          511.127842\n",
+       "dayOfWeek                2.835975\n",
+       "dtype: float64"
+      ]
+     },
+     "execution_count": 49,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pd_flights.mean(numeric_only=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 50,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "execution": {
+     "iopub.execute_input": "2023-09-20T14:02:06.121636Z",
+     "iopub.status.busy": "2023-09-20T14:02:06.121307Z",
+     "iopub.status.idle": "2023-09-20T14:02:06.160962Z",
+     "shell.execute_reply": "2023-09-20T14:02:06.160290Z"
+    },
+    "id": "mNz42pJQNRFl",
+    "outputId": "6562c924-d0b3-46e3-b492-726217fe0c08",
+    "pycharm": {
+     "is_executing": false
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "AvgTicketPrice         628.253689\n",
+       "Cancelled                0.128494\n",
+       "DistanceKilometers    7092.142457\n",
+       "DistanceMiles         4406.853010\n",
+       "FlightDelay              0.251168\n",
+       "FlightDelayMin          47.335171\n",
+       "FlightTimeHour           8.518797\n",
+       "FlightTimeMin          511.127842\n",
+       "dayOfWeek                2.835975\n",
+       "dtype: float64"
+      ]
+     },
+     "execution_count": 50,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ed_flights.mean(numeric_only=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "deosSfnLNRFm"
+   },
+   "source": [
+    "#### sum"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 51,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "execution": {
+     "iopub.execute_input": "2023-09-20T14:02:06.163563Z",
+     "iopub.status.busy": "2023-09-20T14:02:06.163243Z",
+     "iopub.status.idle": "2023-09-20T14:02:06.170921Z",
+     "shell.execute_reply": "2023-09-20T14:02:06.170300Z"
+    },
+    "id": "uKXh2waNNRFm",
+    "outputId": "7816e3b3-5223-46a7-e814-0866ed68980e",
+    "pycharm": {
+     "is_executing": false
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "AvgTicketPrice        8.204365e+06\n",
+       "Cancelled             1.678000e+03\n",
+       "DistanceKilometers    9.261629e+07\n",
+       "DistanceMiles         5.754909e+07\n",
+       "FlightDelay           3.280000e+03\n",
+       "FlightDelayMin        6.181500e+05\n",
+       "FlightTimeHour        1.112470e+05\n",
+       "FlightTimeMin         6.674818e+06\n",
+       "dayOfWeek             3.703500e+04\n",
+       "dtype: float64"
+      ]
+     },
+     "execution_count": 51,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pd_flights.sum(numeric_only=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 52,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "execution": {
+     "iopub.execute_input": "2023-09-20T14:02:06.173681Z",
+     "iopub.status.busy": "2023-09-20T14:02:06.173491Z",
+     "iopub.status.idle": "2023-09-20T14:02:06.203837Z",
+     "shell.execute_reply": "2023-09-20T14:02:06.203200Z"
+    },
+    "id": "ecX1LL0KNRFn",
+    "outputId": "018674e7-f21c-441e-9bc3-9403298a9b58",
+    "pycharm": {
+     "is_executing": false
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "AvgTicketPrice        8.204365e+06\n",
+       "Cancelled             1.678000e+03\n",
+       "DistanceKilometers    9.261629e+07\n",
+       "DistanceMiles         5.754909e+07\n",
+       "FlightDelay           3.280000e+03\n",
+       "FlightDelayMin        6.181500e+05\n",
+       "FlightTimeHour        1.112470e+05\n",
+       "FlightTimeMin         6.674818e+06\n",
+       "dayOfWeek             3.703500e+04\n",
+       "dtype: float64"
+      ]
+     },
+     "execution_count": 52,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ed_flights.sum(numeric_only=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "BPd8ae8SNRFn"
+   },
+   "source": [
+    "### DataFrame.nunique"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 53,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "execution": {
+     "iopub.execute_input": "2023-09-20T14:02:06.206298Z",
+     "iopub.status.busy": "2023-09-20T14:02:06.206155Z",
+     "iopub.status.idle": "2023-09-20T14:02:06.216478Z",
+     "shell.execute_reply": "2023-09-20T14:02:06.215911Z"
+    },
+    "id": "H0_EAT-jNRFn",
+    "outputId": "0454d008-5c47-4619-abdc-794cc5aed84b",
+    "pycharm": {
+     "is_executing": false
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Carrier      4\n",
+       "Origin     156\n",
+       "Dest       156\n",
+       "dtype: int64"
+      ]
+     },
+     "execution_count": 53,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pd_flights[['Carrier', 'Origin', 'Dest']].nunique()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 54,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "execution": {
+     "iopub.execute_input": "2023-09-20T14:02:06.218995Z",
+     "iopub.status.busy": "2023-09-20T14:02:06.218802Z",
+     "iopub.status.idle": "2023-09-20T14:02:06.246898Z",
+     "shell.execute_reply": "2023-09-20T14:02:06.246363Z"
+    },
+    "id": "J7Y3r7BRNRFn",
+    "outputId": "d276d996-c0df-431b-adf3-635a3054becf",
+    "pycharm": {
+     "is_executing": false
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Carrier      4\n",
+       "Origin     156\n",
+       "Dest       156\n",
+       "dtype: int64"
+      ]
+     },
+     "execution_count": 54,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ed_flights[['Carrier', 'Origin', 'Dest']].nunique()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "OpLeL6gpNRFo"
+   },
+   "source": [
+    "### DataFrame.drop"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 55,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 424
+    },
+    "execution": {
+     "iopub.execute_input": "2023-09-20T14:02:06.249245Z",
+     "iopub.status.busy": "2023-09-20T14:02:06.249106Z",
+     "iopub.status.idle": "2023-09-20T14:02:06.276185Z",
+     "shell.execute_reply": "2023-09-20T14:02:06.275634Z"
+    },
+    "id": "xkGjF6p8NRFo",
+    "outputId": "79c21349-0fce-46fa-9348-5a71a288a5b7",
+    "pycharm": {
+     "is_executing": false
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Carrier</th>\n",
+       "      <th>DestRegion</th>\n",
+       "      <th>...</th>\n",
+       "      <th>dayOfWeek</th>\n",
+       "      <th>timestamp</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>Kibana Airlines</td>\n",
+       "      <td>SE-BD</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0</td>\n",
+       "      <td>2018-01-01 00:00:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>Logstash Airways</td>\n",
+       "      <td>IT-34</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0</td>\n",
+       "      <td>2018-01-01 18:27:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>Logstash Airways</td>\n",
+       "      <td>IT-34</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0</td>\n",
+       "      <td>2018-01-01 17:11:14</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>Kibana Airlines</td>\n",
+       "      <td>IT-34</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0</td>\n",
+       "      <td>2018-01-01 10:33:28</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>Kibana Airlines</td>\n",
+       "      <td>SE-BD</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0</td>\n",
+       "      <td>2018-01-01 05:13:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>13054</th>\n",
+       "      <td>Logstash Airways</td>\n",
+       "      <td>SE-BD</td>\n",
+       "      <td>...</td>\n",
+       "      <td>6</td>\n",
+       "      <td>2018-02-11 20:42:25</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>13055</th>\n",
+       "      <td>Logstash Airways</td>\n",
+       "      <td>CH-ZH</td>\n",
+       "      <td>...</td>\n",
+       "      <td>6</td>\n",
+       "      <td>2018-02-11 01:41:57</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>13056</th>\n",
+       "      <td>Logstash Airways</td>\n",
+       "      <td>RU-AMU</td>\n",
+       "      <td>...</td>\n",
+       "      <td>6</td>\n",
+       "      <td>2018-02-11 04:09:27</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>13057</th>\n",
+       "      <td>JetBeats</td>\n",
+       "      <td>SE-BD</td>\n",
+       "      <td>...</td>\n",
+       "      <td>6</td>\n",
+       "      <td>2018-02-11 08:28:21</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>13058</th>\n",
+       "      <td>JetBeats</td>\n",
+       "      <td>US-DC</td>\n",
+       "      <td>...</td>\n",
+       "      <td>6</td>\n",
+       "      <td>2018-02-11 14:54:34</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>13059 rows × 20 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                Carrier DestRegion  ... dayOfWeek           timestamp\n",
+       "0       Kibana Airlines      SE-BD  ...         0 2018-01-01 00:00:00\n",
+       "1      Logstash Airways      IT-34  ...         0 2018-01-01 18:27:00\n",
+       "2      Logstash Airways      IT-34  ...         0 2018-01-01 17:11:14\n",
+       "3       Kibana Airlines      IT-34  ...         0 2018-01-01 10:33:28\n",
+       "4       Kibana Airlines      SE-BD  ...         0 2018-01-01 05:13:00\n",
+       "...                 ...        ...  ...       ...                 ...\n",
+       "13054  Logstash Airways      SE-BD  ...         6 2018-02-11 20:42:25\n",
+       "13055  Logstash Airways      CH-ZH  ...         6 2018-02-11 01:41:57\n",
+       "13056  Logstash Airways     RU-AMU  ...         6 2018-02-11 04:09:27\n",
+       "13057          JetBeats      SE-BD  ...         6 2018-02-11 08:28:21\n",
+       "13058          JetBeats      US-DC  ...         6 2018-02-11 14:54:34\n",
+       "\n",
+       "[13059 rows x 20 columns]"
+      ]
+     },
+     "execution_count": 55,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pd_flights.drop(columns=['AvgTicketPrice',\n",
+    "                         'Cancelled',\n",
+    "                         'DestLocation',\n",
+    "                         'Dest',\n",
+    "                         'DestAirportID',\n",
+    "                         'DestCityName',\n",
+    "                         'DestCountry'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 56,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 424
+    },
+    "execution": {
+     "iopub.execute_input": "2023-09-20T14:02:06.278535Z",
+     "iopub.status.busy": "2023-09-20T14:02:06.278379Z",
+     "iopub.status.idle": "2023-09-20T14:02:07.015831Z",
+     "shell.execute_reply": "2023-09-20T14:02:07.015162Z"
+    },
+    "id": "dXLW2KyXNRFo",
+    "outputId": "3c01ff75-cd2d-4270-a0ba-3561162d72dd",
+    "pycharm": {
+     "is_executing": false
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Carrier</th>\n",
+       "      <th>DestRegion</th>\n",
+       "      <th>...</th>\n",
+       "      <th>dayOfWeek</th>\n",
+       "      <th>timestamp</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>Kibana Airlines</td>\n",
+       "      <td>SE-BD</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0</td>\n",
+       "      <td>2018-01-01 00:00:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>Logstash Airways</td>\n",
+       "      <td>IT-34</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0</td>\n",
+       "      <td>2018-01-01 18:27:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>Logstash Airways</td>\n",
+       "      <td>IT-34</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0</td>\n",
+       "      <td>2018-01-01 17:11:14</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>Kibana Airlines</td>\n",
+       "      <td>IT-34</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0</td>\n",
+       "      <td>2018-01-01 10:33:28</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>Kibana Airlines</td>\n",
+       "      <td>SE-BD</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0</td>\n",
+       "      <td>2018-01-01 05:13:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>13054</th>\n",
+       "      <td>Logstash Airways</td>\n",
+       "      <td>SE-BD</td>\n",
+       "      <td>...</td>\n",
+       "      <td>6</td>\n",
+       "      <td>2018-02-11 20:42:25</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>13055</th>\n",
+       "      <td>Logstash Airways</td>\n",
+       "      <td>CH-ZH</td>\n",
+       "      <td>...</td>\n",
+       "      <td>6</td>\n",
+       "      <td>2018-02-11 01:41:57</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>13056</th>\n",
+       "      <td>Logstash Airways</td>\n",
+       "      <td>RU-AMU</td>\n",
+       "      <td>...</td>\n",
+       "      <td>6</td>\n",
+       "      <td>2018-02-11 04:09:27</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>13057</th>\n",
+       "      <td>JetBeats</td>\n",
+       "      <td>SE-BD</td>\n",
+       "      <td>...</td>\n",
+       "      <td>6</td>\n",
+       "      <td>2018-02-11 08:28:21</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>13058</th>\n",
+       "      <td>JetBeats</td>\n",
+       "      <td>US-DC</td>\n",
+       "      <td>...</td>\n",
+       "      <td>6</td>\n",
+       "      <td>2018-02-11 14:54:34</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>\n",
+       "<p>13059 rows × 20 columns</p>"
+      ],
+      "text/plain": [
+       "                Carrier DestRegion  ... dayOfWeek           timestamp\n",
+       "0       Kibana Airlines      SE-BD  ...         0 2018-01-01 00:00:00\n",
+       "1      Logstash Airways      IT-34  ...         0 2018-01-01 18:27:00\n",
+       "2      Logstash Airways      IT-34  ...         0 2018-01-01 17:11:14\n",
+       "3       Kibana Airlines      IT-34  ...         0 2018-01-01 10:33:28\n",
+       "4       Kibana Airlines      SE-BD  ...         0 2018-01-01 05:13:00\n",
+       "...                 ...        ...  ...       ...                 ...\n",
+       "13054  Logstash Airways      SE-BD  ...         6 2018-02-11 20:42:25\n",
+       "13055  Logstash Airways      CH-ZH  ...         6 2018-02-11 01:41:57\n",
+       "13056  Logstash Airways     RU-AMU  ...         6 2018-02-11 04:09:27\n",
+       "13057          JetBeats      SE-BD  ...         6 2018-02-11 08:28:21\n",
+       "13058          JetBeats      US-DC  ...         6 2018-02-11 14:54:34\n",
+       "\n",
+       "[13059 rows x 20 columns]"
+      ]
+     },
+     "execution_count": 56,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ed_flights.drop(columns=['AvgTicketPrice',\n",
+    "                         'Cancelled',\n",
+    "                         'DestLocation',\n",
+    "                         'Dest',\n",
+    "                         'DestAirportID',\n",
+    "                         'DestCityName',\n",
+    "                         'DestCountry'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "g79LTpPBNRFp"
+   },
+   "source": [
+    "### Plotting"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 57,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 853
+    },
+    "execution": {
+     "iopub.execute_input": "2023-09-20T14:02:07.019059Z",
+     "iopub.status.busy": "2023-09-20T14:02:07.018885Z",
+     "iopub.status.idle": "2023-09-20T14:02:07.851593Z",
+     "shell.execute_reply": "2023-09-20T14:02:07.851086Z"
+    },
+    "id": "0NVvSP02NRFp",
+    "outputId": "f9448a9c-dfd5-4a9a-b44a-3cd878d182d4",
+    "pycharm": {
+     "is_executing": false
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA1AAAANECAYAAAC+XM68AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy81sbWrAAAACXBIWXMAAA9hAAAPYQGoP6dpAADRcElEQVR4nOzdeVhUdfs/8PeAzLDogKiAJCJiqSguoSK5ZIogkmlahppibmlQj/qkZrkAVqjlnsvTU0kL5FJmpqaMC664kaSimZrLUwnmAriOI/P5/eFvzteRxQPOCu/XdXnVnPOZc+77zMzN3HM2hRBCgIiIiIiIiB7JwdoBEBERERER2Qs2UERERERERDKxgSIiIiIiIpKJDRQREREREZFMbKCIiIiIiIhkYgNFREREREQkExsoIiIiIiIimdhAERERERERycQGioiIiIiISCY2UGRWDRo0wNChQ8v1nIyMDCgUCnz33XfmCcqEEhISoFAorB0GUYXw/Vu6Ll26oEuXLtLjc+fOQaFQICUlxWoxEdF9rF3yGL5PZWRkSNOGDh2KBg0aWC2myoINVCWyZMkSKBQKhIaGmm0dhg+jnH+2YsmSJSV+6Xk4FycnJzRs2BBDhgzBH3/8YflAiR5TSkqK0Xva2dkZvr6+iIyMxMKFC3H9+vXHXsfff/+NhIQEZGdnP37AFjZ06FBUr1692PQjR46gdu3aaNCgAc6dO2f5wEzoww8/xNq1a60dBlG5sHaVbejQoVAoFFCr1bh9+3ax+adOnZK23ccff2yFCKueatYOgEwnNTUVDRo0wIEDB3D69Gk0atTI5Oto2rQpvv76a6NpkydPRvXq1fHee+8VG3/y5Ek4OFi3T1+yZAlq165d6p6wt956C23btoVOp8Mvv/yCTz/9FBs2bMDRo0fh6+tb5rKnTJmCd955xwxRE1VcUlISAgICoNPpkJubi4yMDIwdOxZz587FunXr0KJFCwAVe//+/fffSExMRIMGDdCqVSszRG9Zx44dQ7du3eDm5obt27dLv8ymp6dbN7AK+vDDD/HSSy+hT58+1g6FqNxYu0pXrVo13Lp1Cz/99BP69+9vNC81NRXOzs64c+eO0fTOnTvj9u3bUCqVlgy1SmADVUmcPXsWe/fuxZo1a/D6668jNTUV06dPN/l6vL298eqrrxpNmzlzJmrXrl1sOgCoVCqTx2BqnTp1wksvvQQAeO211/DUU0/hrbfewpdffonJkyeX+JybN2/Czc0N1apVQ7Vq/BiRbYmKikKbNm2kx5MnT8a2bdvw/PPP44UXXsCJEyfg4uJS5d+/OTk56Nq1K1xcXLB9+3YEBARI8/iF4//cuXMHSqXS6j+GUeXH2lU6lUqFDh064Ntvvy3WQKWlpSE6Ohrff/+90XQHBwc4OztbMswqg9WwkkhNTUXNmjURHR2Nl156CampqQAAnU4HT09PvPbaa8WeU1hYCGdnZ7z99tvStPPnz+OFF16Am5sbvLy8MG7cOGzevLnYMbRylXQOVH5+PsaNG4cGDRpApVKhXr16GDJkCC5fvlzqcrRaLZ5//nm4u7tj7969AAC9Xo/58+ejWbNmcHZ2hre3N15//XVcu3bNaP05OTnYsWOHtHv7wfMaStK1a1cA95tS4P+OtT5+/DgGDhyImjVromPHjkbzHvbNN9+gXbt2cHV1Rc2aNdG5c+div2j//PPP6NSpE9zc3FCjRg1ER0cjJyenzNiIKqpr166YOnUqzp8/j2+++QZAye9fjUaDjh07wsPDA9WrV0fjxo3x7rvvArh/2Gvbtm0B3P+xwfCZMhwiu2vXLrz88suoX78+VCoV/Pz8MG7cuGKHnBgOpfvrr7/Qp08fVK9eHXXq1MHbb7+NoqIio7F6vR4LFixAcHAwnJ2dUadOHfTo0QOHDh0yGvfNN98gJCQELi4u8PT0RExMDP73v/+Vuj1OnDiBbt26QaVSYfv27WjYsKHR/IfPgSrNtm3bpM+xh4cHevfujRMnThiNMWzn33//Ha+++irc3d1Rp04dTJ06FUII/O9//0Pv3r2hVqvh4+ODOXPmFFuPVqvF9OnT0ahRI2nbTpw4EVqtVhqjUChw8+ZNfPnll9Jr82D9/euvvzBs2DB4e3tDpVKhWbNm+OKLL4zWYzi0ecWKFZgyZQqeeOIJuLq6orCwEDqdDomJiXjyySfh7OyMWrVqoWPHjtBoNI/cTkQVxdr1fwYOHIiff/4Z+fn50rSDBw/i1KlTGDhwYLHxJZ0DVRI536cA4NChQ4iMjETt2rXh4uKCgIAADBs2rMxlV1ZVq32vxFJTU9G3b18olUoMGDAAS5cuxcGDB9G2bVu8+OKLWLNmDf7zn/8Y/aq6du1aaLVaxMTEALi/V6Vr1664ePEi/vWvf8HHxwdpaWnYvn27yeK8ceMGOnXqhBMnTmDYsGF4+umncfnyZaxbtw5//vknateuXew5t2/fRu/evXHo0CFs2bJFKoKvv/46UlJS8Nprr+Gtt97C2bNn8cknn+Dw4cPYs2cPnJycMH/+fLz55ptGhxh6e3uXGeOZM2cAALVq1TKa/vLLL+PJJ5/Ehx9+CCFEqc9PTExEQkICnnnmGSQlJUGpVGL//v3Ytm0bIiIiAABff/01YmNjERkZiVmzZuHWrVtYunQpOnbsiMOHD/METzKLwYMH491330V6ejpGjhxZbH5OTg6ef/55tGjRAklJSVCpVDh9+jT27NkD4P4hvElJSZg2bRpGjRqFTp06AQCeeeYZAMDq1atx69YtjBkzBrVq1cKBAwewaNEi/Pnnn1i9erXRuoqKihAZGYnQ0FB8/PHH2LJlC+bMmYPAwECMGTNGGjd8+HCkpKQgKioKI0aMwL1797Br1y7s27dP+qX6gw8+wNSpU9G/f3+MGDEC//zzDxYtWoTOnTvj8OHD8PDwMFr3yZMn0bVrV1SrVg3bt29HYGBghbbnli1bEBUVhYYNGyIhIQG3b9/GokWL0KFDB/zyyy/FPsevvPIKmjZtipkzZ2LDhg14//334enpif/85z/o2rUrZs2ahdTUVLz99tto27YtOnfuDOD+l5sXXngBu3fvxqhRo9C0aVMcPXoU8+bNw++//y6d8/T1119jxIgRaNeuHUaNGgUAUm55eXlo3749FAoF4uPjUadOHfz8888YPnw4CgsLMXbsWKNYZ8yYAaVSibfffhtarRZKpRIJCQlITk6W1lFYWIhDhw7hl19+Qffu3Su0DYnkYO26r2/fvhg9ejTWrFkjNS5paWlo0qQJnn766QpvXznfpy5duoSIiAjUqVMH77zzDjw8PHDu3DmsWbOmwuu1a4Ls3qFDhwQAodFohBBC6PV6Ua9ePfGvf/1LCCHE5s2bBQDx008/GT2vZ8+eomHDhtLjOXPmCABi7dq10rTbt2+LJk2aCABi+/btJa6/WbNm4tlnny1xnr+/v4iNjZUeT5s2TQAQa9asKTZWr9cLIYTYvn27ACBWr14trl+/Lp599llRu3ZtcfjwYWnsrl27BACRmppqtIxNmzYVm15afIb1fPHFF+Kff/4Rf//9t9iwYYNo0KCBUCgU4uDBg0IIIaZPny4AiAEDBhRbhmGewalTp4SDg4N48cUXRVFRUYn5Xb9+XXh4eIiRI0cazc/NzRXu7u7FphPJtXz5cgFAeu+WxN3dXbRu3VoIUfz9O2/ePAFA/PPPP6U+/+DBgwKAWL58ebF5t27dKjYtOTlZKBQKcf78eWlabGysACCSkpKMxrZu3VqEhIRIj7dt2yYAiLfeeqvYcg2fp3PnzglHR0fxwQcfGM0/evSoqFatmtH02NhY4eTkJOrWrSt8fX3F77//Xmqezz77rFHdOHv2bLG8W7VqJby8vMSVK1ekab/++qtwcHAQQ4YMkaYZtvOoUaOkaffu3RP16tUTCoVCzJw5U5p+7do14eLiYlQ3v/76a+Hg4CB27dplFOOyZcsEALFnzx5pmpubm9FzDYYPHy7q1q0rLl++bDQ9JiZGuLu7S6+doS42bNiw2OvZsmVLER0dXcLWIno8rF3/p7Ta5ebmJoQQ4qWXXhLdunUTQghRVFQkfHx8RGJiolSjPvroI+l5hs/zg9/fYmNjhb+/v/RY7vepH3744ZGvUVXCQ/gqgdTUVHh7e+O5554DcP8wjldeeQUrVqxAUVERunbtitq1a2PlypXSc65duwaNRoNXXnlFmrZp0yY88cQTeOGFF6Rpzs7OJf7aU1Hff/89WrZsiRdffLHYvId3xxcUFCAiIgK//fYbMjIyjE76XL16Ndzd3dG9e3dcvnxZ+hcSEoLq1auXa6/ZsGHDUKdOHfj6+iI6Olo6BObB47ABYPTo0Y9c1tq1a6HX6zFt2rRi5wsY8tNoNMjPz8eAAQOMYnd0dERoaKhJ9/gRPax69eqlXtHK8Gvnjz/+CL1eX+5lu7i4SP9/8+ZNXL58Gc888wyEEDh8+HCx8Q9/pjp16mR0Bczvv/8eCoWixPM5DZ+nNWvWQK/Xo3///kafJx8fHzz55JPFPk9FRUW4fPkyPD09S9zjLdfFixeRnZ2NoUOHwtPTU5reokULdO/eHRs3biz2nBEjRkj/7+joiDZt2kAIgeHDh0vTPTw80LhxY6PtsHr1ajRt2hRNmjQxytFwuPGjaoYQAt9//z169eoFIYTRMiIjI1FQUIBffvnF6DmxsbFGr6chtpycHJw6dUrGFiIyrapeuwwGDhyIjIwM5ObmYtu2bcjNzS3x8D255H6fMmzj9evXQ6fTVXh9lQUP4bNzRUVFWLFiBZ577jnpnB0ACA0NxZw5c7B161ZERESgX79+SEtLg1arhUqlwpo1a6DT6YwaqPPnzyMwMLBYI2PKq/mdOXMG/fr1kzV27NixuHPnDg4fPoxmzZoZzTt16hQKCgrg5eVV4nMvXbokO6Zp06ahU6dOcHR0RO3atdG0adMST0598ATz0pw5cwYODg4ICgoqdYzhy4fhy8/D1Gq1zMiJyu/GjRulfm5eeeUVfPbZZxgxYgTeeecddOvWDX379sVLL70k6wICFy5cwLRp07Bu3bpix84XFBQYPTacE/CgmjVrGj3vzJkz8PX1NWpQHnbq1CkIIfDkk0+WON/JycnosYuLCz777DMMGjQI0dHR0Gg0cHNze2RuDzt//jwAoHHjxsXmNW3aFJs3b5YuNmNQv359o3Hu7u5wdnYu1si5u7vjypUr0uNTp07hxIkTxbaXwaPq3T///IP8/Hx8+umn+PTTT2Uto6R6l5SUhN69e+Opp55C8+bN0aNHDwwePFi6MhqROVX12mXQs2dP1KhRAytXrkR2djbatm2LRo0aVfgWDHK/Tz377LPo168fEhMTMW/ePHTp0gV9+vTBwIED7eKCYabGBsrObdu2DRcvXsSKFSuwYsWKYvNTU1MRERGBmJgY/Oc//8HPP/+MPn36YNWqVWjSpAlatmxphajl6d27N1asWIGZM2fiq6++MiqCer0eXl5e0sUyHlbaF42SBAcHIzw8/JHjHv41tqIMv459/fXX8PHxKTa/ql1ZiCznzz//REFBQak/iri4uGDnzp3Yvn07NmzYgE2bNmHlypXo2rUr0tPT4ejoWOqyi4qK0L17d1y9ehWTJk1CkyZN4Obmhr/++gtDhw4t9qtwWcsqD71eD4VCgZ9//rnEZZZ036eYmBhcu3YNb7zxBvr27YuffvrJIlfdKym+0raDeOA8S71ej+DgYMydO7fEsX5+fmWu17DtX331VcTGxpY45uEmqKR617lzZ5w5cwY//vgj0tPT8dlnn2HevHlYtmyZ0d41IlNj7fo/KpUKffv2xZdffok//vgDCQkJjx2HnO9TCoUC3333Hfbt24effvoJmzdvxrBhwzBnzhzs27ev1HgrK35Ts3Opqanw8vLC4sWLi81bs2YNfvjhByxbtgydO3dG3bp1sXLlSnTs2BHbtm0rdt8mf39/HD9+HEIIo71Qp0+fNlm8gYGBOHbsmKyxffr0QUREBIYOHYoaNWpg6dKlRsvZsmULOnTo8MjGxpI39Q0MDIRer8fx48dLvc+E4aRuLy8vWY0bkakY7uEWGRlZ6hgHBwd069YN3bp1w9y5c/Hhhx/ivffew/bt2xEeHl7q5+no0aP4/fff8eWXX2LIkCHS9Me5QltgYCA2b96Mq1evlvpLbmBgIIQQCAgIwFNPPSV72WPGjMHVq1cxZcoUvPrqq1ixYkW5LtPt7+8P4P4FKR7222+/oXbt2hXas1WSwMBA/Prrr+jWrdsj61lJ8+vUqYMaNWqgqKjosWuO4aqur732Gm7cuIHOnTsjISGBDRSZFWuXsYEDB+KLL76Ag4ODdCGwx4lV7vcpAGjfvj3at2+PDz74AGlpaRg0aBBWrFhR5WoAz4GyY7dv38aaNWvw/PPP46WXXir2Lz4+HtevX8e6devg4OCAl156CT/99BO+/vpr3Lt3z+jwPeB+Yfrrr7+wbt06adqdO3fw3//+12Qx9+vXD7/++it++OGHYvNECVe2GzJkCBYuXIhly5Zh0qRJ0vT+/fujqKgIM2bMKPace/fuGV3i083NzeixOfXp0wcODg5ISkoq9quVIb/IyEio1Wp8+OGHJR5H/M8//1gkVqpatm3bhhkzZiAgIACDBg0qcczVq1eLTTP8EGC4XLahKXj4M2X4BfXBz7EQAgsWLKhwzP369YMQAomJicXmGdbTt29fODo6IjExsVgNEUIYHQr3sPfeew/jxo3D6tWr8frrr5crtrp166JVq1b48ssvjbbFsWPHkJ6ejp49e5ZreWXp378//vrrrxJr8e3bt3Hz5k3pcUn1ztHREf369cP3339f4g9YcmvOw9uyevXqaNSokdGl1IlMjbWruOeeew4zZszAJ598UuKRLOUh9/vUtWvXisX58DauSrgHyo6tW7cO169fN7row4Pat2+POnXqIDU1Fa+88gpeeeUVLFq0CNOnT0dwcDCaNm1qNP7111/HJ598ggEDBuBf//oX6tatK93dGjDNnpwJEybgu+++w8svv4xhw4YhJCQEV69exbp167Bs2bISDymMj49HYWEh3nvvPbi7u+Pdd9/Fs88+i9dffx3JycnIzs5GREQEnJyccOrUKaxevRoLFiyQbo4bEhKCpUuX4v3330ejRo3g5eVV6vlHj6tRo0Z47733MGPGDHTq1Al9+/aFSqXCwYMH4evri+TkZKjVaixduhSDBw/G008/jZiYGNSpUwcXLlzAhg0b0KFDB3zyySdmiY+qhp9//hm//fYb7t27h7y8PGzbtg0ajQb+/v5Yt25dqTdWTEpKws6dOxEdHQ1/f39cunQJS5YsQb169aR7nwUGBsLDwwPLli1DjRo14ObmhtDQUDRp0gSBgYF4++238ddff0GtVuP7778vdj5BeTz33HMYPHgwFi5ciFOnTqFHjx7Q6/XYtWsXnnvuOcTHxyMwMBDvv/8+Jk+ejHPnzqFPnz6oUaMGzp49ix9++AGjRo0yutfdw+bMmYNr167hs88+g6enJ2bNmiU7vo8++ghRUVEICwvD8OHDpcuYu7u7P/ZhNQ8aPHgwVq1ahdGjR2P79u3o0KEDioqK8Ntvv2HVqlXYvHmzdNGbkJAQbNmyBXPnzoWvry8CAgIQGhqKmTNnYvv27QgNDcXIkSMRFBSEq1ev4pdffsGWLVtK/AL6sKCgIHTp0gUhISHw9PTEoUOH8N133yE+Pt5kuVLVxtolr3Y5ODhgypQpFY7vQXK/T3355ZdYsmQJXnzxRQQGBuL69ev473//C7VabdIfjOyGpS73R6bXq1cv4ezsLG7evFnqmKFDhwonJydx+fJlodfrhZ+fnwAg3n///RLH//HHHyI6Olq4uLiIOnXqiH//+9/i+++/FwDEvn37SnxOeS5jLoQQV65cEfHx8eKJJ54QSqVS1KtXT8TGxkqX133wMuYPmjhxogAgPvnkE2nap59+KkJCQoSLi4uoUaOGCA4OFhMnThR///23NCY3N1dER0eLGjVqCABSrKWt52GGy6WWdHnUhy+lavDFF1+I1q1bC5VKJWrWrCmeffZZ6TLzBtu3bxeRkZHC3d1dODs7i8DAQDF06FBx6NChMuMhKo3hUsCGf0qlUvj4+Iju3buLBQsWiMLCQqPxD79/t27dKnr37i18fX2FUqkUvr6+YsCAAcUu9/3jjz+KoKAgUa1aNaPLAh8/flyEh4eL6tWri9q1a4uRI0eKX3/9tdilgx+8JG9Z8Qhx/3LfH330kWjSpIlQKpWiTp06IioqSmRlZRmN+/7770XHjh2Fm5ubcHNzE02aNBFxcXHi5MmTj1zvvXv3RJ8+fQQAkZycLISQdxlzIYTYsmWL6NChg3BxcRFqtVr06tVLHD9+vMS8Hq4hpcXz7LPPimbNmhlNu3v3rpg1a5Zo1qyZVFdCQkJEYmKiKCgokMb99ttvonPnzsLFxUUAMKq/eXl5Ii4uTvj5+QknJyfh4+MjunXrJj799FNpTFl18f333xft2rUTHh4ewsXFRTRp0kR88MEH4u7du8XGEpUHa1fFateDKnoZc4NHfZ/65ZdfxIABA0T9+vWFSqUSXl5e4vnnn6+y31kUQpRxR1AiAPPnz8e4cePw559/4oknnrB2OEREREREVsMGiozcvn3b6CTCO3fuoHXr1igqKsLvv/9uxciIiIiIiKyP50CRkb59+6J+/fpo1aoVCgoK8M033+C3334r9fKWRERERERVCRsoMhIZGYnPPvsMqampKCoqQlBQEFasWFHsin1ERERERFURD+EjIiIiIiKSifeBIiIiIiIikokNFBERERERkUxV+hwovV6Pv//+GzVq1DDJTWKJ6D4hBK5fvw5fX184OFS932lYW4jMh/WF9YXIXOTWlyrdQP3999/w8/OzdhhEldb//vc/1KtXz9phWBxrC5H5sb4Qkbk8qr5U6QaqRo0aAO5vJLVabeVoAJ1Oh/T0dERERMDJycna4chibzHbW7yA/cWs0+mwdu1ajBgxQvqMVTVya4u9vbYlqQw5AJUjj6qSQ2FhIfz8/FhfqkB9sRZuu8djz9tPbn2p0g2UYde3Wq22mQbK1dUVarXabt5w9hazvcUL2F/MhngBVNnDS+TWFnt7bUtSGXIAKkceVS0H1pfKX1+shdvu8VSG7feo+lL1Dh4mIru1dOlStGjRQvriEBYWhp9//lmaf+fOHcTFxaFWrVqoXr06+vXrh7y8PKNlXLhwAdHR0XB1dYWXlxcmTJiAe/fuGY3JyMjA008/DZVKhUaNGiElJcUS6RGRFbG+EJFcbKCIyG7Uq1cPM2fORFZWFg4dOoSuXbuid+/eyMnJAQCMGzcOP/30E1avXo0dO3bg77//Rt++faXnFxUVITo6Gnfv3sXevXvx5ZdfIiUlBdOmTZPGnD17FtHR0XjuueeQnZ2NsWPHYsSIEdi8ebPF8yUiy2F9ISK5qvQhfERkX3r16mX0+IMPPsDSpUuxb98+1KtXD59//jnS0tLQtWtXAMDy5cvRtGlT7Nu3D+3bt0d6ejqOHz+OLVu2wNvbG61atcKMGTMwadIkJCQkQKlUYtmyZQgICMCcOXMAAE2bNsXu3bsxb948REZGWjxnIrIM1hcikosNFBHZpaKiIqxevRo3b95EWFgYsrKyoNPpEB4eLo1p0qQJ6tevj8zMTLRv3x6ZmZkIDg6Gt7e3NCYyMhJjxoxBTk4OWrdujczMTKNlGMaMHTu21Fi0Wi20Wq30uLCwEMD948B1Ol2pzzPMK2uMrasMOQCVI4+qkoMl8mN9qdq47R6PPW8/uTGzgSIiu3L06FGEhYXhzp07qF69On744QcEBQUhOzsbSqUSHh4eRuO9vb2Rm5sLAMjNzTX6cmOYb5hX1pjCwkLcvn0bLi4uxWJKTk5GYmJisenp6enSBTXKotFoHjnG1lWGHIDKkUdlz+HWrVtmWy/rCz2I2+7x2OP2k1tf2EARkV1p3LgxsrOzUVBQgO+++w6xsbHYsWOHVWOaPHkyxo8fLz02XAY1IiLikVfJ0mg06N69u91eqagy5ABUjjyqSg6GPTDmwPpCALfd47Ln7Se3vrCBIiK7olQq0ahRIwBASEgIDh48iAULFuCVV17B3bt3kZ+fb/QrcV5eHnx8fAAAPj4+OHDggNHyDFfRenDMw1fWysvLg1qtLvHXYQBQqVRQqVTFpjs5Ocn64yF3nC2rDDkAlSOPyp6DOXNjfaEHcds9HnvcfnLjZQNFVVaDdzaYbFnnZkabbFlUPnq9HlqtFiEhIXBycsLWrVvRr18/AMDJkydx4cIFhIWFAQDCwsLwwQcf4NKlS/Dy8gJw/xADtVqNoKAgaczGjRuN1qHRaKRlmEPzhM3QFpnmnjZ8LxKZDuuLMdYXovvYQBGR3Zg8eTKioqJQv359XL9+HWlpacjIyMDmzZvh7u6O4cOHY/z48fD09IRarcabb76JsLAwtG/fHgAQERGBoKAgDB48GLNnz0Zubi6mTJmCuLg46Rfe0aNH45NPPsHEiRMxbNgwbNu2DatWrcKGDaZruInI9rC+EJFcbKCIyG5cunQJQ4YMwcWLF+Hu7o4WLVpg8+bN6N69OwBg3rx5cHBwQL9+/aDVahEZGYklS5ZIz3d0dMT69esxZswYhIWFwc3NDbGxsUhKSpLGBAQEYMOGDRg3bhwWLFiAevXq4bPPPuMlhm2QKfcin5oRYbJlkX1ifSGD5gmbMbud6fbecc9d5cMGiojsxueff17mfGdnZyxevBiLFy8udYy/v3+xQ2ge1qVLFxw+fLhCMRKRfWJ9ISK5HKwdABERERERkb3gHiiyG6Y4XEflKKTd8oBpTqolIiIioqqDe6CIiIiIiIhkYgNFREREREQkExsoIiIiIiIimdhAERERERERycQGioiIiIiISCY2UERERERERDKxgSIiIiIiIpKJDRQREREREZFMbKCIiIiIiIhkqmbtAIgqgwbvbDDp8s7NjDbp8oiIiIjINLgHioiIiIiISCY2UERERERERDLxED4yK1Mf2kZEREREZE3cA0VERERERCQTGygiIiIiIiKZeAgfERFZBA/pJSJzMWV9UTmabFFUSXEPFBERERERkUxsoIiIiIiIiGRiA0VERERERCQTGygiIiIiIiKZ2EARERERERHJxAaKiOxGcnIy2rZtixo1asDLywt9+vTByZMnjcZ06dIFCoXC6N/o0aONxly4cAHR0dFwdXWFl5cXJkyYgHv37hmNycjIwNNPPw2VSoVGjRohJSXF3OkRkRWxvhCRXGygiMhu7NixA3Fxcdi3bx80Gg10Oh0iIiJw8+ZNo3EjR47ExYsXpX+zZ8+W5hUVFSE6Ohp3797F3r178eWXXyIlJQXTpk2Txpw9exbR0dF47rnnkJ2djbFjx2LEiBHYvHmzxXIlIstifSEiuXgfKCKyG5s2bTJ6nJKSAi8vL2RlZaFz587SdFdXV/j4+JS4jPT0dBw/fhxbtmyBt7c3WrVqhRkzZmDSpElISEiAUqnEsmXLEBAQgDlz5gAAmjZtit27d2PevHmIjIw0X4JEZDWsL0Qkl8n3QO3cuRO9evWCr68vFAoF1q5dazR/6NChxXZ/9+jRw2jM1atXMWjQIKjVanh4eGD48OG4ceOG0ZgjR46gU6dOcHZ2hp+fn9EvQERUNRQUFAAAPD09jaanpqaidu3aaN68OSZPnoxbt25J8zIzMxEcHAxvb29pWmRkJAoLC5GTkyONCQ8PN1pmZGQkMjMzzZUKEdkY1hciKo3J90DdvHkTLVu2xLBhw9C3b98Sx/To0QPLly+XHqtUKqP5gwYNwsWLF6Vd6K+99hpGjRqFtLQ0AEBhYSEiIiIQHh6OZcuW4ejRoxg2bBg8PDwwatQoU6dUpZT3Tt4qR4HZ7YDmCZuhLVKYKSqi4vR6PcaOHYsOHTqgefPm0vSBAwfC398fvr6+OHLkCCZNmoSTJ09izZo1AIDc3FyjLzcApMe5ublljiksLMTt27fh4uJiNE+r1UKr1UqPCwsLAQA6nQ46na7UHAzzVA6iXLmXpaz1mYNhfXLWq3I0XZ6mVp48bFVVycES+bG+lL1MW2TK+mLYZqbadra83czBnmuR3JhN3kBFRUUhKiqqzDEqlarU3d8nTpzApk2bcPDgQbRp0wYAsGjRIvTs2RMff/wxfH19kZqairt37+KLL76AUqlEs2bNkJ2djblz57KBIqoi4uLicOzYMezevdto+oM1IDg4GHXr1kW3bt1w5swZBAYGmiWW5ORkJCYmFpuenp4OV1fXRz5/Rhu9yWLZuHGjyZZVHhqN5pFjZrezQCAVZIhfTh62rrLn8OAeH3NhfSmZteqLHOaoL6badra83czJHmuR3PpilXOgMjIy4OXlhZo1a6Jr1654//33UatWLQD3d217eHhIzRMAhIeHw8HBAfv378eLL76IzMxMdO7cGUqlUhoTGRmJWbNm4dq1a6hZs6bFcyIiy4mPj8f69euxc+dO1KtXr8yxoaGhAIDTp08jMDAQPj4+OHDggNGYvLw8AJB+2PHx8ZGmPThGrVYX+3UYACZPnozx48dLjwsLC+Hn54eIiAio1epSY9PpdNBoNJh6yAFavWn24B5LsOw5FIYcunfvDicnpzLHNk+w3ZPkD7/XVXYetqo8r4WtkpODYQ+MubC+lM7S9aU8TFlfVA4CM9roTbbtbHm7mYM91yK59cXiDVSPHj3Qt29fBAQE4MyZM3j33XcRFRWFzMxMODo6Ijc3F15eXsZBVqsGT09Po93fAQEBRmMe3EVeWgNV0d3glmILuzzLuwvc1Lu5zc1e4n3wPWAL74vyMGecQgi8+eab+OGHH5CRkVGsDpQkOzsbAFC3bl0AQFhYGD744ANcunRJqjUajQZqtRpBQUHSmId/MdRoNAgLCytxHSqVqtihyADg5OQk64+HVq8w2SGw1vpjJSdXWz7M1xC73NfMllX2HMyVG+vLo9ny+8oc9cVU286Wt5s52WMtkhuvxRuomJgY6f+Dg4PRokULBAYGIiMjA926dTPruh93N7ilWHOXZ0V3gZvyEAFLsPV4S9rdb4+7wk0tLi4OaWlp+PHHH1GjRg3pRxV3d3e4uLjgzJkzSEtLQ8+ePVGrVi0cOXIE48aNQ+fOndGiRQsAQEREBIKCgjB48GDMnj0bubm5mDJlCuLi4qQvKaNHj8Ynn3yCiRMnYtiwYdi2bRtWrVqFDRvKd44gEdkP1hciksvqlzFv2LAhateujdOnT6Nbt27w8fHBpUuXjMbcu3cPV69efeTub8O80lR0N7il2MIuz/LuAjf1bm5zs5d4H9zdbwvvi/LQ6XT48ccfzbLspUuXArh/M8sHLV++HEOHDoVSqcSWLVswf/583Lx5E35+fujXrx+mTJkijXV0dMT69esxZswYhIWFwc3NDbGxsUhKSpLGBAQEYMOGDRg3bhwWLFiAevXq4bPPPuMlhokqMdYXIpLL6g3Un3/+iStXrhjt/s7Pz0dWVhZCQkIAANu2bYNer5eONQ4LC8N7770HnU4nfaHUaDRo3Lhxmec/Pe5ucEuxZjwV3VVtykMELMHW4y3p9be196k1CFH2oZd+fn7YsWPHI5fj7+//yJN6u3TpgsOHD5crPiKyX6wvRCSXye8DdePGDWRnZ0vHBZ89exbZ2dm4cOECbty4gQkTJmDfvn04d+4ctm7dit69e6NRo0bSLy9NmzZFjx49MHLkSBw4cAB79uxBfHw8YmJi4OvrC+D+ZUSVSiWGDx+OnJwcrFy5EgsWLDDau0RERERERGRqJm+gDh06hNatW6N169YAgPHjx6N169aYNm0aHB0dceTIEbzwwgt46qmnMHz4cISEhGDXrl1Ge4ZSU1PRpEkTdOvWDT179kTHjh3x6aefSvPd3d2Rnp6Os2fPIiQkBP/+978xbdo0XsKciIiIiIjMyuSH8HXp0qXM3eCbNz/6HBtPT0/pprmladGiBXbt2lXu+IiIiIiIiCrK5HugiIiIiIiIKis2UERERERERDJZ/Sp89PgavMN7RxARERERWQL3QBEREREREcnEBoqIiIiIiEgmNlBEREREREQysYEiIiIiIiKSiQ0UERERERGRTGygiIiIiIiIZGIDRUREREREJBMbKCIiIiIiIpnYQBEREREREcnEBoqIiIiIiEgmNlBEREREREQysYEiIiIiIiKSiQ0UERERERGRTGygiIiIiIiIZGIDRUREREREJBMbKCIiIiIiIpnYQBEREREREcnEBoqIiIiIiEgmNlBEZDeSk5PRtm1b1KhRA15eXujTpw9OnjxpNObOnTuIi4tDrVq1UL16dfTr1w95eXlGYy5cuIDo6Gi4urrCy8sLEyZMwL1794zGZGRk4Omnn4ZKpUKjRo2QkpJi7vSIyIpYX4hIrmrWDqAqavDOhhKnqxwFZrcDmidshrZIYeGoiGzfjh07EBcXh7Zt2+LevXt49913ERERgePHj8PNzQ0AMG7cOGzYsAGrV6+Gu7s74uPj0bdvX+zZswcAUFRUhOjoaPj4+GDv3r24ePEihgwZAicnJ3z44YcAgLNnzyI6OhqjR49Gamoqtm7dihEjRqBu3bqIjIy0Wv5EZD6sL0QkFxsoIrIbmzZtMnqckpICLy8vZGVloXPnzigoKMDnn3+OtLQ0dO3aFQCwfPlyNG3aFPv27UP79u2Rnp6O48ePY8uWLfD29karVq0wY8YMTJo0CQkJCVAqlVi2bBkCAgIwZ84cAEDTpk2xe/duzJs3j19wiCop1hcikosNFBHZrYKCAgCAp6cnACArKws6nQ7h4eHSmCZNmqB+/frIzMxE+/btkZmZieDgYHh7e0tjIiMjMWbMGOTk5KB169bIzMw0WoZhzNixY0uMQ6vVQqvVSo8LCwsBADqdDjqdrtT4DfNUDqIcWZetrPWZg2F9ctarcjRdnqZWnjxsVVXJwVL5sb6UvkxbZMr6Ythmptp2trzdzMGea5HcmNlAEZFd0uv1GDt2LDp06IDmzZsDAHJzc6FUKuHh4WE01tvbG7m5udKYB7/cGOYb5pU1prCwELdv34aLi4vRvOTkZCQmJhaLMT09Ha6uro/MZUYb/SPHyLVx40aTLas8NBrNI8fMbmeBQCrIEL+cPGxdZc/h1q1bZl8/60vJrFVf5DBHfTHVtrPl7WZO9liL5NYXNlBEZJfi4uJw7Ngx7N6929qhYPLkyRg/frz0uLCwEH5+foiIiIBarS71eTqdDhqNBlMPOUCrN815j8cSLHsIkCGH7t27w8nJqcyxzRM2Wyiq8jv8XlfZediq8rwWtkpODoY9MObE+lIyS9eX8jBlfVE5CMxoozfZtrPl7WYO9lyL5NYXNlBEZHfi4+Oxfv167Ny5E/Xq1ZOm+/j44O7du8jPzzf6lTgvLw8+Pj7SmAMHDhgtz3AVrQfHPHxlrby8PKjV6mK/DgOASqWCSqUqNt3JyUnWHw+tXmGyC8dY64+VnFxt+eI4htjlvma2rLLnYO7cWF9KZ8vvK3PUF1NtO1vebuZkj7VIbry8jDkR2Q0hBOLj4/HDDz9g27ZtCAgIMJofEhICJycnbN26VZp28uRJXLhwAWFhYQCAsLAwHD16FJcuXZLGaDQaqNVqBAUFSWMeXIZhjGEZRFT5sL4QkVzcA0VEdiMuLg5paWn48ccfUaNGDemcAnd3d7i4uMDd3R3Dhw/H+PHj4enpCbVajTfffBNhYWFo3749ACAiIgJBQUEYPHgwZs+ejdzcXEyZMgVxcXHSr7yjR4/GJ598gokTJ2LYsGHYtm0bVq1ahQ0bSr4FARHZP9YXIpKLe6CIyG4sXboUBQUF6NKlC+rWrSv9W7lypTRm3rx5eP7559GvXz907twZPj4+WLNmjTTf0dER69evh6OjI8LCwvDqq69iyJAhSEpKksYEBARgw4YN0Gg0aNmyJebMmYPPPvuMlxgmqsRYX4hILu6BIiK7IcSjLynr7OyMxYsXY/HixaWO8ff3f+RVkbp06YLDhw+XO0Yisk+sL0QkF/dAERERERERycQGioiIiIiISCY2UERERERERDKxgSIiIiIiIpKJDRQREREREZFMbKCIiIiIiIhkYgNFREREREQkExsoIiIiIiIimdhAERERERERycQGioiIiIiISCY2UERERERERDKxgSIiIiIiIpKJDRQREREREZFMbKCIiIiIiIhkMnkDtXPnTvTq1Qu+vr5QKBRYu3at0XwhBKZNm4a6devCxcUF4eHhOHXqlNGYq1evYtCgQVCr1fDw8MDw4cNx48YNozFHjhxBp06d4OzsDD8/P8yePdvUqRARERERERkxeQN18+ZNtGzZEosXLy5x/uzZs7Fw4UIsW7YM+/fvh5ubGyIjI3Hnzh1pzKBBg5CTkwONRoP169dj586dGDVqlDS/sLAQERER8Pf3R1ZWFj766CMkJCTg008/NXU6REREREREkmqmXmBUVBSioqJKnCeEwPz58zFlyhT07t0bAPDVV1/B29sba9euRUxMDE6cOIFNmzbh4MGDaNOmDQBg0aJF6NmzJz7++GP4+voiNTUVd+/exRdffAGlUolmzZohOzsbc+fONWq0iIiIiIiITMnkDVRZzp49i9zcXISHh0vT3N3dERoaiszMTMTExCAzMxMeHh5S8wQA4eHhcHBwwP79+/Hiiy8iMzMTnTt3hlKplMZERkZi1qxZuHbtGmrWrFni+rVaLbRarfS4sLAQAKDT6aDT6UydbqlUjqLk6Q7C6L/2wN5itpd4H3w/Gv7fku/Rx2EvcRIRERFVhEUbqNzcXACAt7e30XRvb29pXm5uLry8vIzmV6tWDZ6enkZjAgICii3DMK+0Bio5ORmJiYnFpqenp8PV1bUCGVXM7HZlz5/RRm+ZQEzI3mK29Xg3btxYbJpGo7FCJERERET0IIs2UNY2efJkjB8/XnpcWFgIPz8/REREQK1WWyyO5gmbS5yuchCY0UaPqYccoNUrLBbP47C3mO0l3mMJkdL/63Q6aDQadO/eHU5OTlaMSh6dTocff/zR2mEQERERmYVFGygfHx8AQF5eHurWrStNz8vLQ6tWraQxly5dMnrevXv3cPXqVen5Pj4+yMvLMxpjeGwYUxKVSgWVSlVsupOTk0W/mGqLyv7irtUrHjnG1thbzLYeb0nvR0u/T4mIiIioOIveByogIAA+Pj7YunWrNK2wsBD79+9HWFgYACAsLAz5+fnIysqSxmzbtg16vR6hoaHSmJ07dxqda6HRaNC4ceNSD98jIiIiIiJ6XCZvoG7cuIHs7GxkZ2cDuH/hiOzsbFy4cAEKhQJjx47F+++/j3Xr1uHo0aMYMmQIfH190adPHwBA06ZN0aNHD4wcORIHDhzAnj17EB8fj5iYGPj6+gIABg4cCKVSieHDhyMnJwcrV67EggULjA7PIyIiIiIiMjWTN1CHDh1C69at0bp1awDA+PHj0bp1a0ybNg0AMHHiRLz55psYNWoU2rZtixs3bmDTpk1wdnaWlpGamoomTZqgW7du6NmzJzp27Gh0jyd3d3ekp6fj7NmzCAkJwb///W9MmzaNlzAnquQedaPuoUOHQqFQGP3r0aOH0RjeqJuISsL6QkRymfwcqC5dukCI0i8RrVAokJSUhKSkpFLHeHp6Ii0trcz1tGjRArt27apwnERkfww36h42bBj69u1b4pgePXpg+fLl0uOHz3scNGgQLl68CI1GA51Oh9deew2jRo2Sao7hRt3h4eFYtmwZjh49imHDhsHDw4M/0hBVYqwvRCRXlboKHxHZt7Ju1G2gUqlKvZgMb9RNRKVhfSEiuSx6EQkiInPLyMiAl5cXGjdujDFjxuDKlSvSvEfdqNswpqQbdZ88eRLXrl2zXCJEZHNYX4gI4B4oIqpEevTogb59+yIgIABnzpzBu+++i6ioKGRmZsLR0dFsN+rWarXQarXS48LCQgD374n14NVCH2aYp3Io/bDn8iprfeZgWJ+c9aocTZenqZUnD1tVVXKwVn6sL7b93jJlfTFsM1NtO1vebuZgz7VIbsxsoIio0oiJiZH+Pzg4GC1atEBgYCAyMjLQrVs3s603OTkZiYmJxaanp6fD1dX1kc+f0UZvslg2btxosmWVh0ajeeSY2e0sEEgFGeKXk4etq+w53Lp1y4KR/B/WF+vVFznMUV9Mte1sebuZkz3WIrn1hQ0UEVVaDRs2RO3atXH69Gl069bNbDfqnjx5stFtFAoLC+Hn54eIiAio1epS49PpdNBoNJh6yAFavWlu7HwsIdIky5HLkEP37t0feaPn5gmbLRRV+R1+r6vsPGxVeV4LWyUnB8MeGGtjfbEtpqwvKgeBGW30Jtt2trzdzMGea5Hc+sIGiogqrT///BNXrlxB3bp1ARjfqDskJARAyTfqfu+996DT6aTC/6gbdatUqmJX4wIAJycnWX88tHoFtEWm+YJjrT9WcnI1VY7mYIhd7mtmyyp7DraSG+uLbTFHfTHVtrPl7WZO9liL5MbLi0gQkd0o60bdN27cwIQJE7Bv3z6cO3cOW7duRe/evdGoUSNERt7/9Y836iai0rC+EJFcbKCIyG6UdaNuR0dHHDlyBC+88AKeeuopDB8+HCEhIdi1a5fRr7e8UTcRlYT1hYjk4iF8RGQ3HnWj7s2bH30MPG/UTUQlYX0hIrm4B4qIiIiIiEgmNlBEREREREQysYEiIiIiIiKSiQ0UERERERGRTLyIhAwN3tlg7RCIiIiIiMgGcA8UERERERGRTNwDRUREVV7zhM2Y3e7+f7VFisde3rmZ0SaIiogqA1MfycT6Yn3cA0VERERERCQTGygiIiIiIiKZ2EARERERERHJxAaKiIiIiIhIJjZQREREREREMrGBIiIiIiIikokNFBERERERkUxsoIiIiIiIiGRiA0VERERERCRTNWsHQETFPXjXcpWjwOx2QPOEzdAWKSq0PN61nIiIiMg0uAeKiIiIiIhIJjZQREREREREMrGBIiIiIiIikokNFBERERERkUxsoIiIiIiIiGRiA0VERERERCQTGygiIiIiIiKZ2EARkd3YuXMnevXqBV9fXygUCqxdu9ZovhAC06ZNQ926deHi4oLw8HCcOnXKaMzVq1cxaNAgqNVqeHh4YPjw4bhx44bRmCNHjqBTp05wdnaGn58fZs+ebe7UiMjKWF+ISC42UERkN27evImWLVti8eLFJc6fPXs2Fi5ciGXLlmH//v1wc3NDZGQk7ty5I40ZNGgQcnJyoNFosH79euzcuROjRo2S5hcWFiIiIgL+/v7IysrCRx99hISEBHz66admz4+IrIf1hYjkqmbtAIiI5IqKikJUVFSJ84QQmD9/PqZMmYLevXsDAL766it4e3tj7dq1iImJwYkTJ7Bp0yYcPHgQbdq0AQAsWrQIPXv2xMcffwxfX1+kpqbi7t27+OKLL6BUKtGsWTNkZ2dj7ty5Rl+EiKhyYX0hIrnYQBFRpXD27Fnk5uYiPDxcmubu7o7Q0FBkZmYiJiYGmZmZ8PDwkL7cAEB4eDgcHBywf/9+vPjii8jMzETnzp2hVCqlMZGRkZg1axauXbuGmjVrFlu3VquFVquVHhcWFgIAdDoddDpdqTEb5qkcRMUTL2WZlmJYn5z1qhxNl6epGV4DU70Wln4dHlynNdZtKnJysEZ+rC/Gy7RFpqwvpq4HpmbLrwNg37VIbsxsoIioUsjNzQUAeHt7G0339vaW5uXm5sLLy8tofrVq1eDp6Wk0JiAgoNgyDPNK+oKTnJyMxMTEYtPT09Ph6ur6yNhntNE/coxcGzduNNmyykOj0TxyzOx2FgjkMZnqtbDW6wDIey1sXVk53Lp1y4KR3Mf6cp8139ePYo76YsptZ0q2/Do8yB5rkdz6wgaKiOgxTZ48GePHj5ceFxYWws/PDxEREVCr1aU+T6fTQaPRYOohB2j1CpPEciwh0iTLkcuQQ/fu3eHk5FTm2OYJmy0UVfmpHARmtNGb7LWw9OsAlO+1sFVycjDsgakqqnJ9KQ9T1hdT1wNTs+XXAbDvWiS3vrCBIqJKwcfHBwCQl5eHunXrStPz8vLQqlUracylS5eMnnfv3j1cvXpVer6Pjw/y8vKMxhgeG8Y8TKVSQaVSFZvu5OQk64+HVq+Atsg0f6St9cdKTq6mytGcTPVaWPNLg9z3nS0rKwdr5Mb68n/rtFXmqC+m3HamZMuvw4PssRbJjZdX4SOiSiEgIAA+Pj7YunWrNK2wsBD79+9HWFgYACAsLAz5+fnIysqSxmzbtg16vR6hoaHSmJ07dxodB63RaNC4ceMSD68hosqP9YWIHsQGiojsxo0bN5CdnY3s7GwA90/szs7OxoULF6BQKDB27Fi8//77WLduHY4ePYohQ4bA19cXffr0AQA0bdoUPXr0wMiRI3HgwAHs2bMH8fHxiImJga+vLwBg4MCBUCqVGD58OHJycrBy5UosWLDA6BAaIqp8WF+ISC4ewkdEduPQoUN47rnnpMeGLx2xsbFISUnBxIkTcfPmTYwaNQr5+fno2LEjNm3aBGdnZ+k5qampiI+PR7du3eDg4IB+/fph4cKF0nx3d3ekp6cjLi4OISEhqF27NqZNm8ZLDBNVcqwvRCQXGygishtdunSBEKVfVlahUCApKQlJSUmljvH09ERaWlqZ62nRogV27dpV4TiJyP6wvhCRXDyEj4iIiIiISCarNFAJCQlQKBRG/5o0aSLNv3PnDuLi4lCrVi1Ur14d/fr1K3bVmgsXLiA6Ohqurq7w8vLChAkTcO/ePUunQkREREREVYjVDuFr1qwZtmzZ8n+BVPu/UMaNG4cNGzZg9erVcHd3R3x8PPr27Ys9e/YAAIqKihAdHQ0fHx/s3bsXFy9exJAhQ+Dk5IQPP/zQ4rkQEREREVHVYLUGqlq1aiXe86CgoACff/450tLS0LVrVwDA8uXL0bRpU+zbtw/t27dHeno6jh8/ji1btsDb2xutWrXCjBkzMGnSJCQkJECpVFo6HSIiIiIiqgKsdg7UqVOn4Ovri4YNG2LQoEG4cOECACArKws6nQ7h4eHS2CZNmqB+/frIzMwEAGRmZiI4OBje3t7SmMjISBQWFiInJ8eyiRARERERUZVhlT1QoaGhSElJQePGjXHx4kUkJiaiU6dOOHbsGHJzc6FUKuHh4WH0HG9vb+Tm5gIAcnNzjZonw3zDvNJotVpotVrpcWFhIQBAp9MZ3dTuYSrH0q/KY0oqB2H0X3tgbzHbW7yAaWIu6/1tapZcFxEREZGlWaWBioqKkv6/RYsWCA0Nhb+/P1atWgUXFxezrTc5ORmJiYnFpqenp8PV1bXU581uZ7aQSjSjjd6yKzQBe4vZ3uIFHi/mjRs3mjASIiIioqrLJu4D5eHhgaeeegqnT59G9+7dcffuXeTn5xvthcrLy5POmfLx8cGBAweMlmG4Sl9J51UZTJ482ehu34WFhfDz80NERATUanWpz2uesLkiaZWbykFgRhs9ph5ygFavsMg6H5e9xWxv8QKmiflYQqSJoyqdTqfDjz/+aLH1EREREVmSTTRQN27cwJkzZzB48GCEhITAyckJW7duRb9+/QAAJ0+exIULFxAWFgYACAsLwwcffIBLly7By8sLAKDRaKBWqxEUFFTqelQqFVQqVbHpTk5OcHJyKvV52iLLftHW6hUWX+fjsreY7S1e4PFiLuv9TURERETyWaWBevvtt9GrVy/4+/vj77//xvTp0+Ho6IgBAwbA3d0dw4cPx/jx4+Hp6Qm1Wo0333wTYWFhaN++PQAgIiICQUFBGDx4MGbPno3c3FxMmTIFcXFxJTZIRERVRYN3NphsWedmRptsWURk/1hfiO6zSgP1559/YsCAAbhy5Qrq1KmDjh07Yt++fahTpw4AYN68eXBwcEC/fv2g1WoRGRmJJUuWSM93dHTE+vXrMWbMGISFhcHNzQ2xsbFISkqyRjpERERERFRFWKWBWrFiRZnznZ2dsXjxYixevLjUMf7+/jwxnoiIiIiILMpq94EiIiIiIiKyNzZxEQkiIrI9cs53UDkKzG53/2ql9nZhFiKyHlOeT0VkaWygiKoAnvhLREREZBo8hI+IiIiIiEgmNlBEREREREQysYEiIiIiIiKSiedAERERmRjPOyQic2F9sT7ugSIiIiIiIpKJDRQREREREZFMbKCIiIiIiIhkYgNFREREREQkExsoIqpUEhISoFAojP41adJEmn/nzh3ExcWhVq1aqF69Ovr164e8vDyjZVy4cAHR0dFwdXWFl5cXJkyYgHv37lk6FSKyIawtRGTAq/ARUaXTrFkzbNmyRXpcrdr/lbpx48Zhw4YNWL16Ndzd3REfH4++fftiz549AICioiJER0fDx8cHe/fuxcWLFzFkyBA4OTnhww8/tHguRGQ7WFuICGADRUSVULVq1eDj41NsekFBAT7//HOkpaWha9euAIDly5ejadOm2LdvH9q3b4/09HQcP34cW7Zsgbe3N1q1aoUZM2Zg0qRJSEhIgFKptHQ6RGQjWFuICGADRUSV0KlTp+Dr6wtnZ2eEhYUhOTkZ9evXR1ZWFnQ6HcLDw6WxTZo0Qf369ZGZmYn27dsjMzMTwcHB8Pb2lsZERkZizJgxyMnJQevWra2RElVhcu/5onIUmN0OaJ6wGdoiRanjeN+XimNtocrGlPeUAqpOfWEDRUSVSmhoKFJSUtC4cWNcvHgRiYmJ6NSpE44dO4bc3FwolUp4eHgYPcfb2xu5ubkAgNzcXKMvOIb5hnkl0Wq10Gq10uPCwkIAgE6ng06nKzVWwzyVgyhfkjbEELs95wBUjjzk5lDWe9LaDLHJ+dxYmjVqC1C164u1VIZ6YC0Pvi9tudaURm7MbKCIqFKJioqS/r9FixYIDQ2Fv78/Vq1aBRcXF7OsMzk5GYmJicWmp6enw9XV9ZHPn9FGb46wLKoy5ABUjjwelcPGjRstFEnFaTSaUufdunXLgpH8H2vUFoD1xZq47crvwfpS1ufYVsmtL2ygiKhS8/DwwFNPPYXTp0+je/fuuHv3LvLz841+Kc7Ly5POa/Dx8cGBAweMlmG4klZJ5z4AwOTJkzF+/HjpcWFhIfz8/BAREQG1Wl1qbDqdDhqNBlMPOUCrL/2QK1umchCY0UZv1zkAlSMPuTkcS4i0YFTlY/hMdO/eHU5OTiWOMeyBsTZL1BagatcXa6kM9cBajiVEyvoc2yq59YUNFBFVajdu3MCZM2cwePBghISEwMnJCVu3bkW/fv0AACdPnsSFCxcQFhYGAAgLC8MHH3yAS5cuwcvLC8D9X9HUajWCgoJKXIdKpYJKpSo23cnJSdYfD61eUeY5K/agMuQAVI48HpWDPXyhKeuzYyvxW6K2AKwv1sRtV34Pviflvkdtidx42UARUaXy9ttvo1evXvD398fff/+N6dOnw9HREQMGDIC7uzuGDx+O8ePHw9PTE2q1Gm+++SbCwsLQvn17AEBERASCgoIwePBgzJ49G7m5uZgyZQri4uJK/BJDRFUDawsRGbCBIqJK5c8//8SAAQNw5coV1KlTBx07dsS+fftQp04dAMC8efPg4OCAfv36QavVIjIyEkuWLJGe7+joiPXr12PMmDEICwuDm5sbYmNjkZSUZK2UiMgGsLYQkQEbKCKqVFasWFHmfGdnZyxevBiLFy8udYy/v79dnGhPVBGmvGxxVblkMcDaQiRHg3c2yL6lwqPYcn1xsHYARERERERE9oINFBERERERkUxsoIiIiIiIiGRiA0VERERERCQTGygiIiIiIiKZ2EARERERERHJxAaKiIiIiIhIJjZQREREREREMrGBIiIiIiIikokNFBERERERkUxsoIiIiIiIiGRiA0VERERERCQTGygiIiIiIiKZ2EARERERERHJxAaKiIiIiIhIJjZQREREREREMrGBIiIiIiIikokNFBERERERkUxsoIiIiIiIiGRiA0VERERERCQTGygiIiIiIiKZqlk7ACIiIrJPDd7ZYNLlnZoRYdLlEZH9MnV9OTcz2mTL4h4oIiIiIiIimdhAERERERERyWT3DdTixYvRoEEDODs7IzQ0FAcOHLB2SERUSbC+EJG5sL4Q2S+7bqBWrlyJ8ePHY/r06fjll1/QsmVLREZG4tKlS9YOjYjsHOsLEZkL6wuRfbPrBmru3LkYOXIkXnvtNQQFBWHZsmVwdXXFF198Ye3QiMjOsb4QkbmwvhDZN7u9Ct/du3eRlZWFyZMnS9McHBwQHh6OzMzMEp+j1Wqh1WqlxwUFBQCAq1evQqfTlbquavdumijqslXTC9y6pUc1nQOK9AqLrPNx2VvM9hYvYHsxX7lypcz5Op0Ot27dAgAIISwRksmVt75UtLYYtpWtvLYVYWvvz4qqDHlUhhyuXLmCW7du4cqVK3BycipxzPXr1wGwvlSF+mItleGzZE22uv0e9f0FkF9f7LaBunz5MoqKiuDt7W003dvbG7/99luJz0lOTkZiYmKx6QEBAWaJsSIGWjuACrC3mO0tXsC2Yq49R/7Y69evw93d3XzBmEl564s91BZzsqX35+OoDHnYew51WV+Kja/q9cVa7P2zZG22uP1M+f3Fbhuoipg8eTLGjx8vPdbr9bh69Spq1aoFhcL6HXJhYSH8/Pzwv//9D2q12trhyGJvMdtbvID9xWyI9/jx4/D19bV2OBZR0dpib69tSSpDDkDlyKOq5CCEwPXr11lfqkB9sRZuu8djz9tPbn2x2waqdu3acHR0RF5entH0vLw8+Pj4lPgclUoFlUplNM3Dw8NcIVaYWq22uzecvcVsb/EC9hfzE088AQcH+zzNsrz15XFri729tiWpDDkAlSOPqpCDPe55MmB9sR/cdo/HXrefnPpin99uACiVSoSEhGDr1q3SNL1ej61btyIsLMyKkRGRvWN9ISJzYX0hsn92uwcKAMaPH4/Y2Fi0adMG7dq1w/z583Hz5k289tpr1g6NiOwc6wsRmQvrC5F9s+sG6pVXXsE///yDadOmITc3F61atcKmTZuKnZhpL1QqFaZPn15sV70ts7eY7S1ewP5itrd4S2OJ+lIZtlVlyAGoHHkwB/vB+mLbuO0eT1XYfgphr9cBJSIiIiIisjC7PQeKiIiIiIjI0thAERERERERycQGioiIiIiISCY2UERERERERDKxgTKz5ORktG3bFjVq1ICXlxf69OmDkydPGo3p0qULFAqF0b/Ro0cbjblw4QKio6Ph6uoKLy8vTJgwAffu3TNLzAkJCcXiadKkiTT/zp07iIuLQ61atVC9enX069ev2A0BLRlvgwYNisWrUCgQFxcHwDa2786dO9GrVy/4+vpCoVBg7dq1RvOFEJg2bRrq1q0LFxcXhIeH49SpU0Zjrl69ikGDBkGtVsPDwwPDhw/HjRs3jMYcOXIEnTp1grOzM/z8/DB79myTx6vT6TBp0iQEBwfDzc0Nvr6+GDJkCP7++2+jZZT0usycOdMs8dqrxYsXo0GDBnB2dkZoaCgOHDhglTgs9ZnPyMjA008/DZVKhUaNGiElJaXCMdvSZ2r16tVo0qQJnJ2dERwcjI0bN5osj6FDhxZ7bXr06GEzecj5G2fJ94+tfKZsQVXfFvZY16ylstRTixJkVpGRkWL58uXi2LFjIjs7W/Ts2VPUr19f3LhxQxrz7LPPipEjR4qLFy9K/woKCqT59+7dE82bNxfh4eHi8OHDYuPGjaJ27dpi8uTJZol5+vTpolmzZkbx/PPPP9L80aNHCz8/P7F161Zx6NAh0b59e/HMM89YLd5Lly4ZxarRaAQAsX37diGEbWzfjRs3ivfee0+sWbNGABA//PCD0fyZM2cKd3d3sXbtWvHrr7+KF154QQQEBIjbt29LY3r06CFatmwp9u3bJ3bt2iUaNWokBgwYIM0vKCgQ3t7eYtCgQeLYsWPi22+/FS4uLuI///mPSePNz88X4eHhYuXKleK3334TmZmZol27diIkJMRoGf7+/iIpKclouz/4vjdlvPZoxYoVQqlUii+++ELk5OSIkSNHCg8PD5GXl2fxWCzxmf/jjz+Eq6urGD9+vDh+/LhYtGiRcHR0FJs2bapQzLbymdqzZ49wdHQUs2fPFsePHxdTpkwRTk5O4ujRoybJIzY2VvTo0cPotbl69arRGGvmIedvnKXeP7b0mbI2bgv7rGvWUlnqqSWxgbKwS5cuCQBix44d0rRnn31W/Otf/yr1ORs3bhQODg4iNzdXmrZ06VKhVquFVqs1eYzTp08XLVu2LHFefn6+cHJyEqtXr5amnThxQgAQmZmZVon3Yf/6179EYGCg0Ov1Qgjb274PFye9Xi98fHzERx99JE3Lz88XKpVKfPvtt0IIIY4fPy4AiIMHD0pjfv75Z6FQKMRff/0lhBBiyZIlombNmkYxT5o0STRu3Nik8ZbkwIEDAoA4f/68NM3f31/Mmzev1OeYK1570a5dOxEXFyc9LioqEr6+viI5OdnisVjiMz9x4kTRrFkzo2W/8sorIjIy8rHjt+Znqn///iI6OtoontDQUPH6668/dh5C3G+gevfuXepzbC2Ph//GWfL9Y0ufKWvjtrD/umYtlaWemhsP4bOwgoICAICnp6fR9NTUVNSuXRvNmzfH5MmTcevWLWleZmYmgoODjW6wFxkZicLCQuTk5JglzlOnTsHX1xcNGzbEoEGDcOHCBQBAVlYWdDodwsPDpbFNmjRB/fr1kZmZabV4De7evYtvvvkGw4YNg0KhkKbb2vZ90NmzZ5Gbm2u0Td3d3REaGmq0TT08PNCmTRtpTHh4OBwcHLB//35pTOfOnaFUKo3yOHnyJK5du2bWHAoKCqBQKODh4WE0febMmahVqxZat26Njz76yOjQB2vGa213795FVlaW0Wvu4OCA8PBw6TW3NHN/5jMzM42WYRhjjnwt+ZmyRF4ZGRnw8vJC48aNMWbMGFy5ckWaZ2t5PPw3zlLvH1v8TFkLt8X/qUx1zVoqWz01lWrWDqAq0ev1GDt2LDp06IDmzZtL0wcOHAh/f3/4+vriyJEjmDRpEk6ePIk1a9YAAHJzc4vdndzwODc31+RxhoaGIiUlBY0bN8bFixeRmJiITp064dixY8jNzYVSqSz2Rdnb21uKxdLxPmjt2rXIz8/H0KFDpWm2tn0fZlhHSTE8uE29vLyM5lerVg2enp5GYwICAootwzCvZs2aZon/zp07mDRpEgYMGAC1Wi1Nf+utt/D000/D09MTe/fuxeTJk3Hx4kXMnTvXqvHagsuXL6OoqKjE1/y3336zeDyW+MyXNqawsBC3b9+Gi4uLyfKx5GeqtLxMVTt69OiBvn37IiAgAGfOnMG7776LqKgoZGZmwtHR0abyKOlvnKXeP9euXbOpz5Q12Vp9sZbKVtespTLVU1NiA2VBcXFxOHbsGHbv3m00fdSoUdL/BwcHo27duujWrRvOnDmDwMBAS4eJqKgo6f9btGiB0NBQ+Pv7Y9WqVTZfDD7//HNERUXB19dXmmZr27cy0el06N+/P4QQWLp0qdG88ePHS//fokULKJVKvP7660hOToZKpbJ0qFQGe/7MV3YxMTHS/wcHB6NFixYIDAxERkYGunXrZsXIiivtbxyRNbCukTnxED4LiY+Px/r167F9+3bUq1evzLGhoaEAgNOnTwMAfHx8il0ZxvDYx8fHDNEa8/DwwFNPPYXTp0/Dx8cHd+/eRX5+frF4DLFYK97z589jy5YtGDFiRJnjbG37GtZRUgwPbtNLly4Zzb937x6uXr1qte1uaJ7Onz8PjUZjtPepJKGhobh37x7OnTtnlXhtSe3ateHo6Fjma25N5vjMlzZGrVab/MuMJT9TpY0x1+vYsGFD1K5d26h+2UIepf2Ns9T7x9Y/U5bEbVEye69r1lKZ6+njYANlZkIIxMfH44cffsC2bduK7b4sSXZ2NgCgbt26AICwsDAcPXrU6M1p+MIaFBRklrgfdOPGDZw5cwZ169ZFSEgInJycsHXrVmn+yZMnceHCBYSFhVk13uXLl8PLywvR0dFljrO17RsQEAAfHx+jbVpYWIj9+/cbbdP8/HxkZWVJY7Zt2wa9Xi81hGFhYdi5cyd0Op1RHo0bNzb54XCG5unUqVPYsmULatWq9cjnZGdnw8HBQdrNb8l4bY1SqURISIjRa67X67F161bpNbcmc3zmw8LCjJZhGGOOfC35mbJkXgDw559/4sqVK0b1y5p5POpvnKXeP7b+mbIkbouS2Xtds5bKXE8fi5UvYlHpjRkzRri7u4uMjAyjS2neunVLCCHE6dOnRVJSkjh06JA4e/as+PHHH0XDhg1F586dpWUYLqUZEREhsrOzxaZNm0SdOnXMdlnwf//73yIjI0OcPXtW7NmzR4SHh4vatWuLS5cuCSHuX/qzfv36Ytu2beLQoUMiLCxMhIWFWS1eIe5fYah+/fpi0qRJRtNtZftev35dHD58WBw+fFgAEHPnzhWHDx+Wrlo3c+ZM4eHhIX788Udx5MgR0bt37xIvEdq6dWuxf/9+sXv3bvHkk08aXSI0Pz9feHt7i8GDB4tjx46JFStWCFdX1wpdFryseO/evSteeOEFUa9ePZGdnW30vjZcXWfv3r1i3rx5Ijs7W5w5c0Z88803ok6dOmLIkCFmidcerVixQqhUKpGSkiKOHz8uRo0aJTw8PIyu+GQplvjMGy73O2HCBHHixAmxePHix7rcr618pvbs2SOqVasmPv74Y3HixAkxffr0cl12t6w8rl+/Lt5++22RmZkpzp49K7Zs2SKefvpp8eSTT4o7d+7YRB6P+hsnhOXeP7b0mbI2bgv7rGvWUlnqqSWxgTIzACX+W758uRBCiAsXLojOnTsLT09PoVKpRKNGjcSECROM7lMkhBDnzp0TUVFRwsXFRdSuXVv8+9//Fjqdziwxv/LKK6Ju3bpCqVSKJ554Qrzyyivi9OnT0vzbt2+LN954Q9SsWVO4urqKF198UVy8eNFq8QohxObNmwUAcfLkSaPptrJ9t2/fXuL7IDY2Vghx/zKhU6dOFd7e3kKlUolu3boVy+XKlStiwIABonr16kKtVovXXntNXL9+3WjMr7/+Kjp27ChUKpV44oknxMyZM00e79mzZ0t9XxvuvZWVlSVCQ0OFu7u7cHZ2Fk2bNhUffvih0Zc+U8ZrrxYtWiTq168vlEqlaNeundi3b59V4rDUZ3779u2iVatWQqlUioYNG0p1sCJs6TO1atUq8dRTTwmlUimaNWsmNmzYYJI8bt26JSIiIkSdOnWEk5OT8Pf3FyNHjiz2JdiaeTzqb5wQln3/2MpnyhZU9W1hj3XNWipLPbUkhRBCmHy3FhERERERUSXEc6CIiIiIiIhkYgNFREREREQkExsoIiIiIiIimdhAERERERERycQGioiIiIiISCY2UERERERERDKxgSIiIiIiIpKJDRQREREREZFMbKCIiIiIiIhkYgNFREREREQkExsoIiIiIiIimdhAERERERERycQGioiIiIiISCY2UERERERERDKxgSIiIiIiIpKJDRQREREREZFMbKCIiIiIiIhkYgNFREREREQkExsoIiIiIiIimdhAERERERERycQGqpJr0KABhg4dKj3OyMiAQqFARkZGuZdleO53331nugBNTKFQICEhwdphlMiWYyMqD3utKykpKVAoFDh37pzZ10VEpsOaY1kPb28qjg2UHTN8MEv6984771g1trS0NMyfP7/Y9HPnzhnF6eTkhNq1a+OZZ57Bu+++iwsXLlg+2HJ4cJvv3r272HwhBPz8/KBQKPD8889bIUKix2NvdaVLly6lxvvgP2v/ePGoL21Dhw5F9erVLRwVkfWx5piHoeYoFAp88803JY7p0KEDFAoFmjdvbuHo7F81awdAjy8pKQkBAQFG00r7MHTu3Bm3b9+GUqk0a0xpaWk4duwYxo4dW+L8AQMGoGfPntDr9bh27RoOHjyI+fPnY8GCBfj8888RExNj1vgel7OzM9LS0tCxY0ej6Tt27MCff/4JlUpV7Dm3b99GtWr8yJF9sJe68t5772HEiBHS44MHD2LhwoV499130bRpU2l6ixYt0KxZM8TExJT4+SQi62LNMQ/D95VXX33VaPq5c+ewd+9eODs7F3vOyZMn4eDAfSxl4be5SiAqKgpt2rSRNdbBwaHED4ulPf3008U+zOfPn0dERARiY2PRtGlTtGzZ0krRPVrPnj2xevVqLFy40KgpSktLQ0hICC5fvlzsObaw3Ynkspe60r17d6PHzs7OWLhwIbp3744uXboUG+/o6GihyOzDnTt3oFQq+WWJrI41xzx69uyJdevW4fLly6hdu7Y0PS0tDd7e3njyySdx7do1o+fwR6ZHY8WsYko7bnjx4sVo2LAhXFxc0K5dO+zatQtdunQpsRjo9Xp88MEHqFevHpydndGtWzecPn1amt+lSxds2LAB58+fl3YfN2jQ4JGx+fv7IyUlBXfv3sXs2bON5uXn52Ps2LHw8/ODSqVCo0aNMGvWLOj1+jKXef78ebzxxhto3LgxXFxcUKtWLbz88stGxyP/8ccfUCgUmDdvXrHn7927FwqFAt9++63R9AEDBuDKlSvQaDTStLt37+K7777DwIEDS4zl4V36CQkJUCgUOH36NIYOHQoPDw+4u7vjtddew61bt8rMi8iW2HJdeVBJ5yM0aNAAzz//PDIyMtCmTRu4uLggODhYymXNmjUIDg6Gs7MzQkJCcPjw4WLL/e233/DSSy/B09MTzs7OaNOmDdatW1eu2EqzZMkSNGvWDCqVCr6+voiLi0N+fr7RmNLOV3h4WxtepxUrVmDKlCl44okn4OrqisLCQpPESmQprDnya07v3r2hUqmwevVqo+lpaWno379/iQ3ewzXFkMeePXswfvx41KlTB25ubnjxxRfxzz//lGubVBbcA1UJFBQUFNvj8eCvDI+ydOlSxMfHo1OnThg3bhzOnTuHPn36oGbNmqhXr16x8TNnzoSDgwPefvttFBQUYPbs2Rg0aBD2798P4P7u7YKCAvz5559SUyL32P6wsDAEBgYaNSa3bt3Cs88+i7/++guvv/466tevj71792Ly5Mm4ePFiiedaGRw8eBB79+5FTEwM6tWrh3PnzmHp0qXo0qULjh8/DldXVzRs2BAdOnRAamoqxo0bZ/T81NRU1KhRA7179zaa3qBBA4SFheHbb79FVFQUAODnn39GQUEBYmJisHDhQln5AkD//v0REBCA5ORk/PLLL/jss8/g5eWFWbNmyV4GkalVprryKKdPn8bAgQPx+uuv49VXX8XHH3+MXr16YdmyZXj33XfxxhtvAACSk5PRv39/o8NbcnJy0KFDBzzxxBN455134ObmhlWrVqFPnz74/vvv8eKLLxqt6/r16yXuodZqtcWmJSQkIDExEeHh4RgzZgxOnjyJpUuX4uDBg9izZw+cnJwqlO+MGTOgVCrx9ttvQ6vVmv0wKCI5WHPMU3NcXV3Ru3dvfPvttxgzZgwA4Ndff0VOTg4+++wzHDlyRHbcb775JmrWrInp06fj3LlzmD9/PuLj47Fy5UqTbBe7IshuLV++XAAo8Z+Bv7+/iI2NlR5v375dABDbt28XQgih1WpFrVq1RNu2bYVOp5PGpaSkCADi2WefLfbcpk2bCq1WK01fsGCBACCOHj0qTYuOjhb+/v7FYj579qwAID766KNS8+rdu7cAIAoKCoQQQsyYMUO4ubmJ33//3WjcO++8IxwdHcWFCxekaQDE9OnTpce3bt0qtvzMzEwBQHz11VfStP/85z8CgDhx4oQ07e7du6J27dpG28+wzQ8ePCg++eQTUaNGDWkdL7/8snjuueeEEPe3e3R0tNF6H45t+vTpAoAYNmyY0bgXX3xR1KpVq9TtQ2RO9lhXHrR69WqjWErK7ezZs0a5ABB79+6Vpm3evFkAEC4uLuL8+fPSdEOdeHDZ3bp1E8HBweLOnTvSNL1eL5555hnx5JNPFsuzrH9ubm7S+EuXLgmlUikiIiJEUVGRNP2TTz4RAMQXX3xhlMODr4fBs88+W+K2btiwYYm1kcgaWHPMW3NWr14t1q9fLxQKhfR9acKECaJhw4ZCiPt1olmzZkZxP7y9DXmEh4cLvV4vTR83bpxwdHQU+fn5ZW6jyoiH8FUCixcvhkajMfon16FDh3DlyhWMHDnS6FyeQYMGoWbNmiU+57XXXjP6xbJTp04A7h8KZwqGX3iuX78OAFi9ejU6deqEmjVr4vLly9K/8PBwFBUVYefOnaUuy8XFRfp/nU6HK1euoFGjRvDw8MAvv/wizevfvz+cnZ2RmpoqTdu8eTMuX75c7FytB59z+/ZtrF+/HtevX8f69etLPXyvLKNHjzZ63KlTJ1y5coWH1ZBVVba6UpagoCCEhYVJj0NDQwEAXbt2Rf369YtNN8R09epVbNu2Df3795f2LF2+fBlXrlxBZGQkTp06hb/++stoXdOmTSu2XTUaDSIiIozGbdmyBXfv3sXYsWONzk8aOXIk1Go1NmzYUOF8Y2NjjWojkS1gzTFPzQGAiIgIeHp6YsWKFRBCYMWKFRgwYEC54x41ahQUCoX0uFOnTigqKsL58+fLvSx7x0P4KoF27drJPvHyYYY3faNGjYymV6tWrdRjfR/8cAOQitPDJyFW1I0bNwAANWrUAACcOnUKR44cQZ06dUocf+nSpVKXdfv2bSQnJ2P58uX466+/IISQ5hUUFEj/7+HhgV69eiEtLQ0zZswAcP/wvSeeeAJdu3Ytcdl16tRBeHg40tLScOvWLRQVFeGll14qX7Ioe3uq1epyL4/IFCpbXSnLw+t2d3cHAPj5+ZU43RDT6dOnIYTA1KlTMXXq1BKXfenSJTzxxBPS4+DgYISHhxcb9/Blhg3bsHHjxkbTlUolGjZs+FhfWB6+0hmRLWDNMU/NAQAnJye8/PLLSEtLQ7t27fC///2vQj/4WnOb2Ro2UFRupV1R5sHm5HEcO3YMXl5eUvOg1+vRvXt3TJw4scTxTz31VKnLevPNN7F8+XKMHTsWYWFhcHd3h0KhQExMTLELUAwZMgSrV6/G3r17ERwcjHXr1uGNN94o8+pUAwcOxMiRI5Gbm4uoqCh4eHiUO19zb08ie2DNz0Fp635UTIYa8vbbbyMyMrLEsQ9/oTOHB38RflBRUVGJOXDvE1HVqzkDBw7EsmXLkJCQgJYtWyIoKKi8YfP7ygPYQFVx/v7+AO7/qvHcc89J0+/du4dz586hRYsWFVpuaX/QHyUzMxNnzpwxOmwuMDAQN27cKPFX20f57rvvEBsbizlz5kjT7ty5U+wqVgDQo0cP1KlTB6mpqQgNDcWtW7cwePDgMpf/4osv4vXXX8e+ffuq5kmURCWwtbpiLg0bNgRw/9fditSnshi24cmTJ6X1APev9nn27Fmj9dWsWbPEmnb+/Hmj5xJVVqw5j9axY0fUr18fGRkZvEiVCfAcqCquTZs2qFWrFv773//i3r170vTU1NTH2iXr5uZmdIicHOfPn8fQoUOhVCoxYcIEaXr//v2RmZmJzZs3F3tOfn6+UdwPc3R0LPbLyKJFi1BUVFRsbLVq1TBgwACsWrUKKSkpCA4OfmTRrV69OpYuXYqEhAT06tXrUSkSVQm2VFfMycvLC126dMF//vMfXLx4sdj8x7m8b3h4OJRKJRYuXGhUwz7//HMUFBQgOjpamhYYGIh9+/bh7t270rT169fjf//7X4XXT2RPWHPuK6vmKBQKLFy4ENOnT3/kj8P0aNwDVcUplUokJCTgzTffRNeuXdG/f3+cO3cOKSkpCAwMrPCvLyEhIVi5ciXGjx+Ptm3bonr16kYNxi+//IJvvvkGer0e+fn5OHjwIL7//nsoFAp8/fXXRo3LhAkTsG7dOjz//PMYOnQoQkJCcPPmTRw9ehTfffcdzp07V+qlTp9//nl8/fXXcHd3R1BQEDIzM7FlyxbUqlWrxPFDhgzBwoULsX37dtm/0MTGxpZjyxBVftaqK9awePFidOzYEcHBwRg5ciQaNmyIvLw8ZGZm4s8//8Svv/5aoeXWqVMHkydPRmJiInr06IEXXngBJ0+exJIlS9C2bVujvfQjRozAd999hx49eqB///44c+YMvvnmGwQGBpoqTSKbxpojr+b07t272G1ZqGLYQBHi4+MhhMCcOXPw9ttvo2XLlli3bh3eeuutCt/p+4033kB2djaWL1+OefPmwd/f36jofPvtt/j2229RrVo1qNVqPPnkkxg7dixGjx5d7CRFV1dX7NixAx9++CFWr16Nr776Cmq1Gk899RQSExOlkyxLsmDBAjg6OiI1NRV37txBhw4dsGXLllKPHQ4JCUGzZs1w4sQJDBo0qEK5E5F16oo1BAUF4dChQ0hMTERKSgquXLkCLy8vtG7dGtOmTXusZSckJKBOnTr45JNPMG7cOHh6emLUqFH48MMPje4BFRkZiTlz5mDu3LkYO3Ys2rRpg/Xr1+Pf//7346ZHZDdYcx6/5pB8ClEVz/yiR9Lr9ahTpw769u2L//73v9YOx6Jat24NT09PbN261dqhEFUqVbmuEJHlseaQufAcKMKdO3eKnSf01Vdf4erVq+jSpYt1grKSQ4cOITs7G0OGDLF2KER2jXWFiCyJNYcsiXugCBkZGRg3bhxefvll1KpVC7/88gs+//xzNG3aFFlZWUY3mqusjh07hqysLMyZMweXL1/GH3/8UeFd/kTEukJElsWaQ5bEc6AIDRo0gJ+fHxYuXIirV6/C09MTQ4YMwcyZM6tMwfnuu++QlJSExo0b49tvv2XzRPSYWFeIyJJYc8iSuAeKiIiIiIhIJp4DRUREREREJBMbKCIiIiIiIpmq9DlQer0ef//9N2rUqFHhm6wRUXFCCFy/fh2+vr5wcKh6v9OwthCZD+sL6wuRucitL1W6gfr777/h5+dn7TCIKq3//e9/qFevnrXDsDjWFiLzY30hInN5VH2p0g1UjRo1ANzfSGq1usQxOp0O6enpiIiIMLrze2VQWXNjXtZXWFgIPz8/6TNW1cipLYB9vaamxLyrTt7myJn1pWrWl8qUD3OxXXLrS5VuoAy7vtVqdZkNlKurK9RqdaV4YzyosubGvGxHVT28RE5tAezzNTUF5l118jZnzqwvVau+VKZ8mIvte1R9qXoHDxMREREREVUQGygiIiIiIiKZ2EARERERERHJxAaKiIiIiIhIpnI3UDt37kSvXr3g6+sLhUKBtWvXGs0XQmDatGmoW7cuXFxcEB4ejlOnThmNuXr1KgYNGgS1Wg0PDw8MHz4cN27cMBpz5MgRdOrUCc7OzvDz88Ps2bOLxbJ69Wo0adIEzs7OCA4OxsaNG8ubDhERERERkWzlbqBu3ryJli1bYvHixSXOnz17NhYuXIhly5Zh//79cHNzQ2RkJO7cuSONGTRoEHJycqDRaLB+/Xrs3LkTo0aNkuYXFhYiIiIC/v7+yMrKwkcffYSEhAR8+umn0pi9e/diwIABGD58OA4fPow+ffqgT58+OHbsWHlTIiIiIiIikqXclzGPiopCVFRUifOEEJg/fz6mTJmC3r17AwC++uoreHt7Y+3atYiJicGJEyewadMmHDx4EG3atAEALFq0CD179sTHH38MX19fpKam4u7du/jiiy+gVCrRrFkzZGdnY+7cuVKjtWDBAvTo0QMTJkwAAMyYMQMajQaffPIJli1bVqGNQUREREREVBaTngN19uxZ5ObmIjw8XJrm7u6O0NBQZGZmAgAyMzPh4eEhNU8AEB4eDgcHB+zfv18a07lzZyiVSmlMZGQkTp48iWvXrkljHlyPYYxhPURERERERKZm0hvp5ubmAgC8vb2Npnt7e0vzcnNz4eXlZRxEtWrw9PQ0GhMQEFBsGYZ5NWvWRG5ubpnrKYlWq4VWq5UeFxYWArh/EzCdTlficwzTQ5I2Qas3zU37jiVEmmQ5j8uQW2m52yvmZX32ECM9WoN3Nph0eedmRpt0eURkv8pbX1SOArPbAc0TNkNbVPz7GOsLWZJJGyhbl5ycjMTExGLT09PT4erqWuZzZ7TRmywOW7vYhUajsXYIZsG8rOfWrVvWDoGIiIjILEzaQPn4+AAA8vLyULduXWl6Xl4eWrVqJY25dOmS0fPu3buHq1evSs/38fFBXl6e0RjD40eNMcwvyeTJkzF+/HjpcWFhIfz8/BAREQG1Wl3ic3Q6HTQaDaYecqiUe6A0Gg26d+8OJycna4djMszL+gx7d4mIiIgqG5M2UAEBAfDx8cHWrVulhqmwsBD79+/HmDFjAABhYWHIz89HVlYWQkJCAADbtm2DXq9HaGioNOa9996DTqeTvihqNBo0btwYNWvWlMZs3boVY8eOldav0WgQFhZWanwqlQoqlarYdCcnp0d+IdXqFSXuMq4IW/vyKyd/e8S8rMfW4yMiIiKqqHJfROLGjRvIzs5GdnY2gPsXjsjOzsaFCxegUCgwduxYvP/++1i3bh2OHj2KIUOGwNfXF3369AEANG3aFD169MDIkSNx4MAB7NmzB/Hx8YiJiYGvry8AYODAgVAqlRg+fDhycnKwcuVKLFiwwGjv0b/+9S9s2rQJc+bMwW+//YaEhAQcOnQI8fHxj79ViIiIiIiISlDuPVCHDh3Cc889Jz02NDWxsbFISUnBxIkTcfPmTYwaNQr5+fno2LEjNm3aBGdnZ+k5qampiI+PR7du3eDg4IB+/fph4cKF0nx3d3ekp6cjLi4OISEhqF27NqZNm2Z0r6hnnnkGaWlpmDJlCt599108+eSTWLt2LZo3b16hDUFERERERPQo5W6gunTpAiFEqfMVCgWSkpKQlJRU6hhPT0+kpaWVuZ4WLVpg165dZY55+eWX8fLLL5cdMBERERERkYmY9D5QRERERERElRkbKCIiIiIiIpnYQBGR3Vi6dClatGgBtVoNtVqNsLAw/Pzzz9L8O3fuIC4uDrVq1UL16tXRr1+/Yrc7uHDhAqKjo+Hq6govLy9MmDAB9+7dMxqTkZGBp59+GiqVCo0aNUJKSool0iMiK2J9ISK52EARkd2oV68eZs6ciaysLBw6dAhdu3ZF7969kZOTAwAYN24cfvrpJ6xevRo7duzA33//jb59+0rPLyoqQnR0NO7evYu9e/fiyy+/REpKCqZNmyaNOXv2LKKjo/Hcc88hOzsbY8eOxYgRI7B582aL50tElsP6QkRymfQ+UERE5tSrVy+jxx988AGWLl2Kffv2oV69evj888+RlpaGrl27AgCWL1+Opk2bYt++fWjfvj3S09Nx/PhxbNmyBd7e3mjVqhVmzJiBSZMmISEhAUqlEsuWLUNAQADmzJkD4P6tF3bv3o158+YhMtI2boJNRKbH+kJEcrGBIiK7VFRUhNWrV+PmzZsICwtDVlYWdDodwsPDpTFNmjRB/fr1kZmZifbt2yMzMxPBwcHw9vaWxkRGRmLMmDHIyclB69atkZmZabQMw5gHb9r9MK1WC61WKz0uLCwEAOh0Ouh0ulKfZ5hX1hhrUjmWfsXVing4X1vN21yqYt7myNkS24/1xfzKW19UDsLovw+z1TxLYuuvTXlUplwA+XmwgSIiu3L06FGEhYXhzp07qF69On744QcEBQUhOzsbSqUSHh4eRuO9vb2Rm5sLAMjNzTX6cmOYb5hX1pjCwkLcvn0bLi4uxWJKTk5GYmJisenp6elwdXV9ZE4ajeaRY6xhdjvTLm/jxo1Gj201b3OrinmbMudbt26ZbFkPY32xnIrWlxlt9CVOf7i+2ANbfW0qorLkIre+sIEiIrvSuHFjZGdno6CgAN999x1iY2OxY8cOq8Y0efJk6abiwP1fiP38/BAREQG1Wl3q83Q6HTQaDbp37w4nJydLhFouzRNMe17GsYT7hyjZet7mUhXzNkfOhj0w5sD6YjnlrS8qB4EZbfSYesgBWr2i2HxDfbEHtv7alEdlygWQX1/YQBGRXVEqlWjUqBEAICQkBAcPHsSCBQvwyiuv4O7du8jPzzf6lTgvLw8+Pj4AAB8fHxw4cMBoeYaraD045uEra+Xl5UGtVpf46zAAqFQqqFSqYtOdnJxk/UGRO87StEXFv6Q8jodztNW8za0q5m3KnM257VhfLKei9UWrV5T4XFvM8VFs9bWpiMqSi9wceBU+IrJrer0eWq0WISEhcHJywtatW6V5J0+exIULFxAWFgYACAsLw9GjR3Hp0iVpjEajgVqtRlBQkDTmwWUYxhiWQURVB+sLEZWEe6CIyG5MnjwZUVFRqF+/Pq5fv460tDRkZGRg8+bNcHd3x/DhwzF+/Hh4enpCrVbjzTffRFhYGNq3bw8AiIiIQFBQEAYPHozZs2cjNzcXU6ZMQVxcnPQL7+jRo/HJJ59g4sSJGDZsGLZt24ZVq1Zhw4YN1kydiMyM9YWI5GIDRUR249KlSxgyZAguXrwId3d3tGjRAps3b0b37t0BAPPmzYODgwP69esHrVaLyMhILFmyRHq+o6Mj1q9fjzFjxiAsLAxubm6IjY1FUlKSNCYgIAAbNmzAuHHjsGDBAtSrVw+fffYZLzFMVMmxvhCRXGygiMhufP7552XOd3Z2xuLFi7F48eJSx/j7+z/yak1dunTB4cOHKxQjEdkn1hcikovnQBEREREREcnEBoqIiIiIiEgmNlBEREREREQy8RwoIiIra56w2WT3XDo3M9okyyGiyoH1hcj0uAeKiIiIiIhIJjZQREREREREMrGBIiIiIiIikokNFBERERERkUxsoIiIiIiIiGRiA0VERERERCQTGygiIiIiIiKZ2EARERERERHJxAaKiIiIiIhIJjZQREREREREMrGBIiIiIiIikokNFBERERERkUxsoIiIiIiIiGQyeQNVVFSEqVOnIiAgAC4uLggMDMSMGTMghJDGCCEwbdo01K1bFy4uLggPD8epU6eMlnP16lUMGjQIarUaHh4eGD58OG7cuGE05siRI+jUqROcnZ3h5+eH2bNnmzodIiIiIiIiickbqFmzZmHp0qX45JNPcOLECcyaNQuzZ8/GokWLpDGzZ8/GwoULsWzZMuzfvx9ubm6IjIzEnTt3pDGDBg1CTk4ONBoN1q9fj507d2LUqFHS/MLCQkRERMDf3x9ZWVn46KOPkJCQgE8//dTUKREREREREQEAqpl6gXv37kXv3r0RHR0NAGjQoAG+/fZbHDhwAMD9vU/z58/HlClT0Lt3bwDAV199BW9vb6xduxYxMTE4ceIENm3ahIMHD6JNmzYAgEWLFqFnz574+OOP4evri9TUVNy9exdffPEFlEolmjVrhuzsbMydO9eo0SIiIiIiIjIVkzdQzzzzDD799FP8/vvveOqpp/Drr79i9+7dmDt3LgDg7NmzyM3NRXh4uPQcd3d3hIaGIjMzEzExMcjMzISHh4fUPAFAeHg4HBwcsH//frz44ovIzMxE586doVQqpTGRkZGYNWsWrl27hpo1axaLTavVQqvVSo8LCwsBADqdDjqdrsR8DNNVDqLE+RVR2roszRCHrcRjKszL+uwhRiIiIqKKMHkD9c4776CwsBBNmjSBo6MjioqK8MEHH2DQoEEAgNzcXACAt7e30fO8vb2lebm5ufDy8jIOtFo1eHp6Go0JCAgotgzDvJIaqOTkZCQmJhabnp6eDldX1zLzmtFGX+b88ti4caPJlmUKGo3G2iGYBfOynlu3bpllucnJyVizZg1+++03uLi44JlnnsGsWbPQuHFjaUyXLl2wY8cOo+e9/vrrWLZsmfT4woULGDNmDLZv347q1asjNjYWycnJqFbt/0piRkYGxo8fj5ycHPj5+WHKlCkYOnSoWfKqKhq8swEAoHIUmN0OaJ6wGdoiRYWXd25mtKlCI2J9sXOG+mIKrC30KCZvoFatWoXU1FSkpaVJh9WNHTsWvr6+iI2NNfXqymXy5MkYP3689LiwsBB+fn6IiIiAWq0u8Tk6nQ4ajQZTDzlAq6/4H/oHHUuINMlyHpcht+7du8PJycna4ZgM87I+w95dU9uxYwfi4uLQtm1b3Lt3D++++y4iIiJw/PhxuLm5SeNGjhyJpKQk6fGDP5AUFRUhOjoaPj4+2Lt3Ly5evIghQ4bAyckJH374IYD7e8qjo6MxevRopKamYuvWrRgxYgTq1q2LyEjb+PwSkWmxvhCRXCZvoCZMmIB33nkHMTExAIDg4GCcP38eycnJiI2NhY+PDwAgLy8PdevWlZ6Xl5eHVq1aAQB8fHxw6dIlo+Xeu3cPV69elZ7v4+ODvLw8ozGGx4YxD1OpVFCpVMWmOzk5PfILqVaveKxfSh9eny2Rk789Yl7WY674Nm3aZPQ4JSUFXl5eyMrKQufOnaXprq6updaB9PR0HD9+HFu2bIG3tzdatWqFGTNmYNKkSUhISIBSqcSyZcsQEBCAOXPmAACaNm2K3bt3Y968efyCQ1RJsb4QkVwmb6Bu3boFBwfji/s5OjpCr79/CFxAQAB8fHywdetWqWEqLCzE/v37MWbMGABAWFgY8vPzkZWVhZCQEADAtm3boNfrERoaKo157733oNPppC9rGo0GjRs3LvHwPSKqfAoKCgAAnp6eRtNTU1PxzTffwMfHB7169cLUqVOlX4kzMzMRHBxsdBhxZGQkxowZg5ycHLRu3RqZmZlG52kaxowdO7bEOCpyfqVhPmC751iqHE0Xl9Fy/3++j5u3vZ1rZ0/nMZqKOXK21PZjfSl9maZQ3vpiqrohh7nfY5WpFlSmXAD5eZi8gerVqxc++OAD1K9fH82aNcPhw4cxd+5cDBs2DACgUCgwduxYvP/++3jyyScREBCAqVOnwtfXF3369AFw/9eYHj16YOTIkVi2bBl0Oh3i4+MRExMDX19fAMDAgQORmJiI4cOHY9KkSTh27BgWLFiAefPmmTolIrJBer0eY8eORYcOHdC8eXNp+sCBA+Hv7w9fX18cOXIEkyZNwsmTJ7FmzRoA98+RLOkcTMO8ssYUFhbi9u3bcHFxMZr3OOdXArZ7juXsdiZbVIkeN29bO59ULns4j9HUTJmzuc6xfBDrS8lsob6YMp/SWKq2VKZaUFlykVtfTN5ALVq0CFOnTsUbb7yBS5cuwdfXF6+//jqmTZsmjZk4cSJu3ryJUaNGIT8/Hx07dsSmTZvg7OwsjUlNTUV8fDy6desGBwcH9OvXDwsXLpTmu7u7Iz09HXFxcQgJCUHt2rUxbdo0XsKcqIqIi4vDsWPHsHv3bqPpD9aA4OBg1K1bF926dcOZM2cQGBhollgqcn4lYPvnWDZP2GyyZT1I5SAwo43+sfO2lfNJ5bKn8xhNxRw5m+scywexvpTMmvXFVHVDDnPXlspUCypTLoD8+mLyBqpGjRqYP38+5s+fX+oYhUKBpKQko5MwH+bp6Ym0tLQy19WiRQvs2rWroqESkZ2Kj4+XbrBdr169MscaDvs9ffo0AgMD4ePjI92XzuDh8ydLO8dSrVYX+3UYeLzzKwHbPcfSVDGVuvzHzNte/1jbw3mMpmbKnM297VhfSmcL9cWU+ZTGUp/PylQLKksucnNwePQQIiLbIIRAfHw8fvjhB2zbtq3YrQxKkp2dDQDSRWvCwsJw9OhRowvVaDQaqNVqBAUFSWO2bt1qtByNRoOwsDATZUJEtob1hYjkYgNFRHYjLi4O33zzDdLS0lCjRg3k5uYiNzcXt2/fBgCcOXMGM2bMQFZWFs6dO4d169ZhyJAh6Ny5M1q0aAEAiIiIQFBQEAYPHoxff/0VmzdvxpQpUxAXFyf9yjt69Gj88ccfmDhxIn777TcsWbIEq1atwrhx46yWOxGZF+sLEcnFBoqI7MbSpUtRUFCALl26oG7dutK/lStXAgCUSiW2bNmCiIgINGnSBP/+97/Rr18//PTTT9IyHB0dsX79ejg6OiIsLAyvvvoqhgwZYnRIcUBAADZs2ACNRoOWLVtizpw5+Oyzz3iJYaJKjPWFiOQy+TlQRETmIkTZl6/18/PDjh07Hrkcf3//R15lqUuXLjh8+HC54iMi+8X6QkRycQ8UERERERGRTGygiIiIiIiIZGIDRUREREREJBMbKCIiIiIiIpnYQBEREREREcnEBoqIiIiIiEgmNlBEREREREQysYEiIiIiIiKSiQ0UERERERGRTGygiIiIiIiIZGIDRUREREREJBMbKCIiIiIiIpnYQBEREREREcnEBoqIiIiIiEgmNlBEREREREQysYEiIiIiIiKSiQ0UERERERGRTGygiIiIiIiIZGIDRUREREREJBMbKCIiIiIiIpnYQBGR3UhOTkbbtm1Ro0YNeHl5oU+fPjh58qTRmDt37iAuLg61atVC9erV0a9fP+Tl5RmNuXDhAqKjo+Hq6govLy9MmDAB9+7dMxqTkZGBp59+GiqVCo0aNUJKSoq50yMiK2J9ISK52EARkd3YsWMH4uLisG/fPmg0Guh0OkRERODmzZvSmHHjxuGnn37C6tWrsWPHDvz999/o27evNL+oqAjR0dG4e/cu9u7diy+//BIpKSmYNm2aNObs2bOIjo7Gc889h+zsbIwdOxYjRozA5s2bLZovEVkO6wsRyVXN2gEQEcm1adMmo8cpKSnw8vJCVlYWOnfujIKCAnz++edIS0tD165dAQDLly9H06ZNsW/fPrRv3x7p6ek4fvw4tmzZAm9vb7Rq1QozZszApEmTkJCQAKVSiWXLliEgIABz5swBADRt2hS7d+/GvHnzEBkZafG8icj8WF+ISC7ugSIiu1VQUAAA8PT0BABkZWVBp9MhPDxcGtOkSRPUr18fmZmZAIDMzEwEBwfD29tbGhMZGYnCwkLk5ORIYx5chmGMYRlEVPmxvhBRabgHiojskl6vx9ixY9GhQwc0b94cAJCbmwulUgkPDw+jsd7e3sjNzZXGPPjlxjDfMK+sMYWFhbh9+zZcXFyM5mm1Wmi1WulxYWEhAECn00Gn05Wag2GeykHIylmOstZXXipH08VltNz/n+/j5m3KXC3BEK+9xf04zJGzJbYf60vZyzSF8tYXU9UNOcz9HqtMtaAy5QLIz8MsDdRff/2FSZMm4eeff8atW7fQqFEjLF++HG3atAEACCEwffp0/Pe//0V+fj46dOiApUuX4sknn5SWcfXqVbz55pv46aef4ODggH79+mHBggWoXr26NObIkSOIi4vDwYMHUadOHbz55puYOHGiOVIiIhsTFxeHY8eOYffu3dYOBcnJyUhMTCw2PT09Ha6uro98/ow2epPFsnHjRpMta3Y7ky2qRI+btylztSSNRmPtECzOlDnfunXLZMsqDetLyWyhvpgyn9JYqrZUplpQWXKRW19M3kBdu3YNHTp0wHPPPYeff/4ZderUwalTp1CzZk1pzOzZs7Fw4UJ8+eWXCAgIwNSpUxEZGYnjx4/D2dkZADBo0CBcvHhROpHztddew6hRo5CWlgbg/i8wERERCA8Px7Jly3D06FEMGzYMHh4eGDVqlKnTIiIbEh8fj/Xr12Pnzp2oV6+eNN3Hxwd3795Ffn6+0a/EeXl58PHxkcYcOHDAaHmGq2g9OObhK2vl5eVBrVYX+3UYACZPnozx48dLjwsLC+Hn54eIiAio1epS89DpdNBoNJh6yAFavUJm9mU7lmC6cyiaJ5jnpHaVg8CMNvrHztuUuVqC4fXu3r07nJycrB2ORZgjZ8MeGHNhfSmdNeuLqeqGHOauLZWpFlSmXAD59cXkDdSsWbPg5+eH5cuXS9MCAgKk/xdCYP78+ZgyZQp69+4NAPjqq6/g7e2NtWvXIiYmBidOnMCmTZtw8OBBaa/VokWL0LNnT3z88cfw9fVFamoq7t69iy+++AJKpRLNmjVDdnY25s6dywaKqJISQuDNN9/EDz/8gIyMDKPaAgAhISFwcnLC1q1b0a9fPwDAyZMnceHCBYSFhQEAwsLC8MEHH+DSpUvw8vICcP+XM7VajaCgIGnMw79AajQaaRkPU6lUUKlUxaY7OTnJ+oOi1SugLTLNFwJT/gEzVUylLv8x87bXP9Zy3xeViSlzNte2Y315NFuoL6bMpzSW+nxWplpQWXKRm4PJLyKxbt06tGnTBi+//DK8vLzQunVr/Pe//5Xmnz17Frm5uUYnULq7uyM0NNToJEwPDw+peQKA8PBwODg4YP/+/dKYzp07Q6lUSmMiIyNx8uRJXLt2zdRpEZENiIuLwzfffIO0tDTUqFEDubm5yM3Nxe3btwHcryXDhw/H+PHjsX37dmRlZeG1115DWFgY2rdvDwCIiIhAUFAQBg8ejF9//RWbN2/GlClTEBcXJ31JGT16NP744w9MnDgRv/32G5YsWYJVq1Zh3LhxVsudiMyL9YWI5DL5Hqg//vgDS5cuxfjx4/Huu+/i4MGDeOutt6BUKhEbGyudRFnSCZQPnmBp+OVGCrRaNXh6ehqNefjXoQdP1HzwkEGDipyIaesnYT6OynbinwHzsj5zxbh06VIAQJcuXYymL1++HEOHDgUAzJs3TzpvUqvVIjIyEkuWLJHGOjo6Yv369RgzZgzCwsLg5uaG2NhYJCUlSWMCAgKwYcMGjBs3DgsWLEC9evXw2Wef8RLDRJUY6wsRyWXyBkqv16NNmzb48MMPAQCtW7fGsWPHsGzZMsTGxpp6deXyOCdi2upJmKZQWU78exjzsh5zneQtxKN/yHB2dsbixYuxePHiUsf4+/s/8nPYpUsXHD58uNwxEpF9Yn0hIrlM3kDVrVtXOs7XoGnTpvj+++8B/N9JlHl5eahbt640Ji8vD61atZLGXLp0yWgZ9+7dw9WrVx95EuaD63hYRU7EtPWTMB9HZTvxz4B5WZ+5T/ImIiIishaTN1AdOnTAyZMnjab9/vvv8Pf3B3B/17WPjw+2bt0qNUyFhYXYv38/xowZA+D+CZb5+fnIyspCSEgIAGDbtm3Q6/UIDQ2Vxrz33nvQ6XTSl0mNRoPGjRuXePge8HgnYtrqSZimUFlO/HsY87IeW4+PiIiIqKJMfhGJcePGYd++ffjwww9x+vRppKWl4dNPP0VcXBwAQKFQYOzYsXj//fexbt06HD16FEOGDIGvry/69OkD4P4eqx49emDkyJE4cOAA9uzZg/j4eMTExMDX1xcAMHDgQCiVSgwfPhw5OTlYuXIlFixYYLSHiYiIiIiIyJRMvgeqbdu2+OGHHzB58mQkJSUhICAA8+fPx6BBg6QxEydOxM2bNzFq1Cjk5+ejY8eO2LRpk3QPKABITU1FfHw8unXrJp2wuXDhQmm+u7s70tPTERcXh5CQENSuXRvTpk3jJcyJiIiIiMhsTN5AAcDzzz+P559/vtT5CoUCSUlJRleleZinp6d009zStGjRArt27apwnEREREREROVh8kP4iIiIiIiIKis2UERERERERDKxgSIiIiIiIpKJDRQREREREZFMbKCIiIiIiIhkYgNFREREREQkExsoIiIiIiIimdhAERERERERycQGioiIiIiISCY2UERERERERDKxgSIiIiIiIpKJDRQREREREZFM1awdABERmU6DdzZYOwQiqqRYX4ju4x4oIiIiIiIimdhAERERERERycQGioiIiIiISCY2UERkN3bu3IlevXrB19cXCoUCa9euNZo/dOhQKBQKo389evQwGnP16lUMGjQIarUaHh4eGD58OG7cuGE05siRI+jUqROcnZ3h5+eH2bNnmzs1IrIy1hcikosNFBHZjZs3b6Jly5ZYvHhxqWN69OiBixcvSv++/fZbo/mDBg1CTk4ONBoN1q9fj507d2LUqFHS/MLCQkRERMDf3x9ZWVn46KOPkJCQgE8//dRseRGR9bG+EJFcvAofEdmNqKgoREVFlTlGpVLBx8enxHknTpzApk2bcPDgQbRp0wYAsGjRIvTs2RMff/wxfH19kZqairt37+KLL76AUqlEs2bNkJ2djblz5xp9ESLrM+UVwc7NjDbZssg+sb6QgamvNsj6UvmwgSKiSiUjIwNeXl6oWbMmunbtivfffx+1atUCAGRmZsLDw0P6cgMA4eHhcHBwwP79+/Hiiy8iMzMTnTt3hlKplMZERkZi1qxZuHbtGmrWrFlsnVqtFlqtVnpcWFgIANDpdNDpdKXGapinchCPl7SdMeRrS3mX9TqZeh2WWJetMEfO1tx+rC/WY4t1Q66HX6fKVAsqUy6A/DzYQBFRpdGjRw/07dsXAQEBOHPmDN59911ERUUhMzMTjo6OyM3NhZeXl9FzqlWrBk9PT+Tm5gIAcnNzERAQYDTG29tbmlfSF5zk5GQkJiYWm56eng5XV9dHxj2jjV52jpWJLeW9ceNGi61Lo9FYbF22wpQ537p1y2TLKg/WF9tgj/mUVl8qUy2oLLnIrS9soIio0oiJiZH+Pzg4GC1atEBgYCAyMjLQrVs3s6138uTJGD9+vPS4sLAQfn5+iIiIgFqtLvV5Op0OGo0GUw85QKtXmC0+W6NyEJjRRm9TeR9LiDT7Ogyvd/fu3eHk5GT29dkCc+Rs2ANjaawv1mWLdUOuh+tLZaoFlSkXQH59YQNF/6+9e4+Oor7/P/7a3DYESMItCSkBgygX5WaCYbkVJSRgtFJpFaWAluJXGvwWU7XSn+UitlEUUDSKVgVtpaA9gggUEoNcDSCRlIuWguI3UkkQkISAJJtkfn94MnXNhQE2u9nN83FOzmFnPjv7fk+ST/bF7MwAfqtr165q3769Dh8+rBEjRigmJkbHjx93GVNZWalTp06Z5zXExMSouLjYZUzN4/rOfbDb7bLb7bWWBwcHW/qDUl5tU3mVb70hcIem1Lcn//Bb/bnwJ+7suansO+YX7/DFfur7PvnTXOAvvVjtgavwAfBbR48e1cmTJ9WxY0dJksPh0OnTp5Wfn2+O2bhxo6qrq5WUlGSO2bJli8vnoHNyctS9e/c6P14DoHlifgGaLwIUAJ9RVlamgoICFRQUSJKOHDmigoICFRYWqqysTA899JB27NihL774Qrm5ubr11lvVrVs3paZ+9/GJnj17atSoUZoyZYp27dql7du3a9q0aRo3bpxiY2MlSXfddZdCQkI0efJkHThwQCtWrNCzzz7r8hEaAP6H+QWAVQQoAD5j9+7d6t+/v/r37y9JysjIUP/+/TVz5kwFBgZq7969+slPfqKrr75akydPVkJCgrZu3ery8Zc333xTPXr00IgRI3TTTTdpyJAhLvdgiYiIUHZ2to4cOaKEhAT99re/1cyZM7nEMODnmF8AWMU5UAB8xvDhw2UY9V/CdsOGDRfcRtu2bbVs2bIGx/Tp00dbt2696PoA+C7mFwBWcQQKAAAAACwiQAEAAACARQQoAAAAALCo0QPUE088IZvNpunTp5vLzp8/r/T0dLVr106tWrXS2LFja90XobCwUGlpaQoLC1NUVJQeeughVVZWuozZtGmTrrvuOtntdnXr1k1Lly5t7HYAAAAANGONGqA++ugjvfTSS+rTp4/L8gceeEDvvfee3n77bW3evFlfffWVbrvtNnN9VVWV0tLSVFFRoQ8//FCvv/66li5dqpkzZ5pjjhw5orS0NN1www0qKCjQ9OnT9atf/crSSZ4AAAAAcCkaLUCVlZVp/Pjx+vOf/+xyc7iSkhK9+uqrWrBggW688UYlJCRoyZIl+vDDD7Vjxw5JUnZ2tj755BP99a9/Vb9+/TR69GjNnTtXWVlZqqiokCQtXrxY8fHxmj9/vnr27Klp06bpZz/7mRYuXNhYLQEAAABo5hrtMubp6elKS0tTcnKyHn/8cXN5fn6+nE6nkpOTzWU9evRQ586dlZeXp4EDByovL0+9e/dWdHS0OSY1NVVTp07VgQMH1L9/f+Xl5blso2bM9z8q+EPl5eUqLy83H5eWlkqSnE6ny13Bv69muT2g/kubXqz6XsvTaupoKvW4C315ny/UCAAAcCkaJUAtX75cH3/8sT766KNa64qKihQSEqLIyEiX5dHR0SoqKjLHfD881ayvWdfQmNLSUn377bdq0aJFrdfOzMzUnDlzai3Pzs5WWFhYgz3NTaxucP3FWLdundu25Q45OTneLqFR0Jf3nDt3ztslAAAANAq3B6gvv/xSv/nNb5STk6PQ0FB3b/6yzJgxQxkZGebj0tJSxcXFKSUlReHh4XU+x+l0KicnR3/YHaDyaptb6tg/O9Ut27lcNb2NHDlSwcHB3i7HbejL+2qO7gIAAPgbtweo/Px8HT9+XNddd525rKqqSlu2bNHzzz+vDRs2qKKiQqdPn3Y5ClVcXKyYmBhJUkxMjHbt2uWy3Zqr9H1/zA+v3FdcXKzw8PA6jz5Jkt1ul91ur7U8ODj4gm9Iy6ttKq9yT4Bqam9+rfTvi+jLe5p6fQAAAJfK7ReRGDFihPbt26eCggLzKzExUePHjzf/HRwcrNzcXPM5Bw8eVGFhoRwOhyTJ4XBo3759On78uDkmJydH4eHh6tWrlznm+9uoGVOzDQAAAABwN7cfgWrdurWuvfZal2UtW7ZUu3btzOWTJ09WRkaG2rZtq/DwcN1///1yOBwaOHCgJCklJUW9evXShAkTNG/ePBUVFenRRx9Venq6eQTpvvvu0/PPP6+HH35Yv/zlL7Vx40a99dZbWrt2rbtbAgAAAABJjXgVvoYsXLhQAQEBGjt2rMrLy5WamqoXXnjBXB8YGKg1a9Zo6tSpcjgcatmypSZNmqTHHnvMHBMfH6+1a9fqgQce0LPPPqtOnTrplVdeUWpq0zi/CAAAAID/8UiA2rRpk8vj0NBQZWVlKSsrq97ndOnS5YJXqxs+fLj27NnjjhIBAAAA4IIa7Ua6AAAAAOBvCFAAAAAAYBEBCgAAAAAsIkABAAAAgEUEKAAAAACwiAAFAAAAABYRoAAAAADAIgIUAJ+xZcsW3XLLLYqNjZXNZtOqVatc1huGoZkzZ6pjx45q0aKFkpOTdejQIZcxp06d0vjx4xUeHq7IyEhNnjxZZWVlLmP27t2roUOHKjQ0VHFxcZo3b15jtwbAy5hfAFhFgALgM86ePau+ffvWexPuefPmadGiRVq8eLF27typli1bKjU1VefPnzfHjB8/XgcOHFBOTo7WrFmjLVu26N577zXXl5aWKiUlRV26dFF+fr6eeuopzZ49Wy+//HKj9wfAe5hfAFgV5O0CAMCq0aNHa/To0XWuMwxDzzzzjB599FHdeuutkqQ33nhD0dHRWrVqlcaNG6dPP/1U69ev10cffaTExERJ0nPPPaebbrpJTz/9tGJjY/Xmm2+qoqJCr732mkJCQnTNNdeooKBACxYscHkjBMC/ML8AsIoABcAvHDlyREVFRUpOTjaXRUREKCkpSXl5eRo3bpzy8vIUGRlpvrmRpOTkZAUEBGjnzp366U9/qry8PA0bNkwhISHmmNTUVD355JP65ptv1KZNm1qvXV5ervLycvNxaWmpJMnpdMrpdNZbc806e4Bx6Y37oJp+m1LfDX2f3P0annitpqIxevbG/mN+8b6mOG9Y9cPvkz/NBf7Ui2S9DwIUAL9QVFQkSYqOjnZZHh0dba4rKipSVFSUy/qgoCC1bdvWZUx8fHytbdSsq+sNTmZmpubMmVNreXZ2tsLCwi5Y+9zE6guO8UdNqe9169Z57LVycnI89lpNhTt7PnfunNu2ZRXzS9Phi/3UN7/401zgL71YnV8IUABwmWbMmKGMjAzzcWlpqeLi4pSSkqLw8PB6n+d0OpWTk6M/7A5QebXNE6U2CfYAQ3MTq5tU3/tnpzb6a9R8v0eOHKng4OBGf72moDF6rjkC01wwv3ynKc4bVv1wfvGnucCfepGszy8EKAB+ISYmRpJUXFysjh07msuLi4vVr18/c8zx48ddnldZWalTp06Zz4+JiVFxcbHLmJrHNWN+yG63y26311oeHBxs6Q9KebVN5VW+9YbAHZpS3578w2/158KfuLNnb+w75pemwxf7qe/75E9zgb/0YrUHrsIHwC/Ex8crJiZGubm55rLS0lLt3LlTDodDkuRwOHT69Gnl5+ebYzZu3Kjq6molJSWZY7Zs2eLyOeicnBx17969zo/XAPB/zC8Avo8ABcBnlJWVqaCgQAUFBZK+O7G7oKBAhYWFstlsmj59uh5//HGtXr1a+/bt08SJExUbG6sxY8ZIknr27KlRo0ZpypQp2rVrl7Zv365p06Zp3Lhxio2NlSTdddddCgkJ0eTJk3XgwAGtWLFCzz77rMtHaAD4H+YXAFbxET4APmP37t264YYbzMc1bzomTZqkpUuX6uGHH9bZs2d177336vTp0xoyZIjWr1+v0NBQ8zlvvvmmpk2bphEjRiggIEBjx47VokWLzPURERHKzs5Wenq6EhIS1L59e82cOZNLDAN+jvkFgFUEKAA+Y/jw4TKM+i9ha7PZ9Nhjj+mxxx6rd0zbtm21bNmyBl+nT58+2rp16yXXCcD3ML8AsIqP8AEAAACARQQoAAAAALCIAAUAAAAAFhGgAAAAAMAiAhQAAAAAWESAAgAAAACLCFAAAAAAYBEBCgAAAAAsIkABAAAAgEUEKAAAAACwKMjbBQAA4G1XPLLWrdv74ok0t24PgO/64fxiDzQ073rp2tkbVF5lu+jtMb94n9uPQGVmZmrAgAFq3bq1oqKiNGbMGB08eNBlzPnz55Wenq527dqpVatWGjt2rIqLi13GFBYWKi0tTWFhYYqKitJDDz2kyspKlzGbNm3SddddJ7vdrm7dumnp0qXubgcAAAAATG4PUJs3b1Z6erp27NihnJwcOZ1OpaSk6OzZs+aYBx54QO+9957efvttbd68WV999ZVuu+02c31VVZXS0tJUUVGhDz/8UK+//rqWLl2qmTNnmmOOHDmitLQ03XDDDSooKND06dP1q1/9Shs2bHB3SwAAAAAgqRE+wrd+/XqXx0uXLlVUVJTy8/M1bNgwlZSU6NVXX9WyZct04403SpKWLFminj17aseOHRo4cKCys7P1ySef6P3331d0dLT69eunuXPn6ne/+51mz56tkJAQLV68WPHx8Zo/f74kqWfPntq2bZsWLlyo1NRUd7cFAAAAAI1/EYmSkhJJUtu2bSVJ+fn5cjqdSk5ONsf06NFDnTt3Vl5eniQpLy9PvXv3VnR0tDkmNTVVpaWlOnDggDnm+9uoGVOzDQAAAABwt0a9iER1dbWmT5+uwYMH69prr5UkFRUVKSQkRJGRkS5jo6OjVVRUZI75fniqWV+zrqExpaWl+vbbb9WiRYta9ZSXl6u8vNx8XFpaKklyOp1yOp119lCz3B5gWOrZivpey9Nq6mgq9bgLfXmfL9QIAABwKRo1QKWnp2v//v3atm1bY76MZZmZmZozZ06t5dnZ2QoLC2vwuXMTq91Wx7p169y2LXfIycnxdgmNgr6859y5c94uAQAAoFE0WoCaNm2a1qxZoy1btqhTp07m8piYGFVUVOj06dMuR6GKi4sVExNjjtm1a5fL9mqu0vf9MT+8cl9xcbHCw8PrPPokSTNmzFBGRob5uLS0VHFxcUpJSVF4eHidz3E6ncrJydEfdgeovPriLzVZl/2zm8Y5WjW9jRw5UsHBwd4ux23oy/tqju4CAAD4G7cHKMMwdP/992vlypXatGmT4uPjXdYnJCQoODhYubm5Gjt2rCTp4MGDKiwslMPhkCQ5HA798Y9/1PHjxxUVFSXpu/91Dw8PV69evcwxPzySk5OTY26jLna7XXa7vdby4ODgC74hLa+2XdK1+uvS1N78WunfF9GX9zT1+gAAAC6V2wNUenq6li1bpnfffVetW7c2z1mKiIhQixYtFBERocmTJysjI0Nt27ZVeHi47r//fjkcDg0cOFCSlJKSol69emnChAmaN2+eioqK9Oijjyo9Pd0MQPfdd5+ef/55Pfzww/rlL3+pjRs36q233tLate69GSIAAAAA1HD7VfhefPFFlZSUaPjw4erYsaP5tWLFCnPMwoULdfPNN2vs2LEaNmyYYmJi9M4775jrAwMDtWbNGgUGBsrhcOgXv/iFJk6cqMcee8wcEx8fr7Vr1yonJ0d9+/bV/Pnz9corr3AJc6CZmz17tmw2m8tXjx49zPXuupE3gOaFuQVAjUb5CN+FhIaGKisrS1lZWfWO6dKlywUvtjB8+HDt2bPnomsE4N+uueYavf/+++bjoKD/TnUPPPCA1q5dq7ffflsRERGaNm2abrvtNm3fvl3Sf2/kHRMTow8//FDHjh3TxIkTFRwcrD/96U8e7wVA08HcAkBq5KvwAYA3BAUFmRec+T533cgbQPPE3AJA8sCNdAHA0w4dOqTY2Fh17dpV48ePV2FhoST33cgbQPPE3AJA4ggUAD+TlJSkpUuXqnv37jp27JjmzJmjoUOHav/+/W67kfcPXcpNumvWS+69UbcvqOnXn/uu6/vuSzfDdpfG6Nlb+88bc4vE/FLDn+aNy+2lKc0h/javWe2DAAXAr4wePdr8d58+fZSUlKQuXbrorbfeqvcecZfrcm7SLbn3Rt2+xJ/7bugcXl+4Gba7ubNnb92o2xtzi8T88kP+1M+l9nKhawR4g7/Ma1bnFwIUAL8WGRmpq6++WocPH9bIkSPdciPvH7qUm3RLjXOjbl9gDzA0N7Har/uu64bpvnQzbHdpjJ6byo26PTG3SMwvNfxp3rjcXuqaX7zF3+Y1q/MLAQqAXysrK9Nnn32mCRMmuO1G3j90OTfpltx7o25f4s99N/R994WbYbubO3tuKvvOE3OLxPzyQ/7Uz6X20lR+B77PX+Y1qz0QoAD4lQcffFC33HKLunTpoq+++kqzZs1SYGCg7rzzTrfdyBtA88PcAqAGAQqAXzl69KjuvPNOnTx5Uh06dNCQIUO0Y8cOdejQQdJ3N/IOCAjQ2LFjVV5ertTUVL3wwgvm82tu5D116lQ5HA61bNlSkyZNcrmRN4Dmh7kFQA0CFAC/snz58gbXu+tG3gCaF+YWADW4DxQAAAAAWESAAgAAAACLCFAAAAAAYBEBCgAAAAAsIkABAAAAgEUEKAAAAACwiMuYAwDgZlc8srbWMnugoXnXS9fO3qDyKpvlbX3xRJo7SwPg4+qaXy4V88ul4QgUAAAAAFhEgAIAAAAAiwhQAAAAAGARAQoAAAAALCJAAQAAAIBFBCgAAAAAsIgABQAAAAAWEaAAAAAAwCJupAsAQBPmzptmStw4E8B/Xe788sMbhDeX+YUABbgBb3AAAACaBwKUH7jUN+8//F8DqWm/cbfaZ1191aUp9+pu7gx4zWm/AQAA/BDnQAEAAACARRyBQrPl7o/dAQAAwP8RoLygKb9xb8q1NSd1fR+sfjQRAAAAjcfnP8KXlZWlK664QqGhoUpKStKuXbu8XRIAP8H8AqCxML8Avsunj0CtWLFCGRkZWrx4sZKSkvTMM88oNTVVBw8eVFRUlLfLA+DDmF/gr7iojPcxv8BfNZf5xaePQC1YsEBTpkzRPffco169emnx4sUKCwvTa6+95u3SAPg45hcAjYX5BfBtPnsEqqKiQvn5+ZoxY4a5LCAgQMnJycrLy6vzOeXl5SovLzcfl5SUSJJOnTolp9NZ53OcTqfOnTunIGeAqqr967yToGpD585V+11v9NW4Tp48ecExZ86ckSQZhtHY5TSKi51fLmVukfx7fmlIU/lZ9jR/7PtC80HNz/jJkycVHBzsltdkfmme84s//f7QizVW3m+4m9X5xWcD1IkTJ1RVVaXo6GiX5dHR0frXv/5V53MyMzM1Z86cWsvj4+MbpUZfcJe3C2gk9NV42s+3PvbMmTOKiIhovGIaycXOL8wtF68p/Cx7g7/1fTHzgbsxvzS/+cWffn/o5cKa8vziswHqUsyYMUMZGRnm4+rqap06dUrt2rWTzVZ3ai4tLVVcXJy+/PJLhYeHe6pUj/DX3ujL+wzD0JkzZxQbG+vtUjziUuYWybe+p+5E382n78bomfmlec4v/tQPvTRdVucXnw1Q7du3V2BgoIqLi12WFxcXKyYmps7n2O122e12l2WRkZGWXi88PNwvfjDq4q+90Zd3+eL/DNe42PnlcuYWyXe+p+5G382Hu3tmfom0/Hr+9vPmT/3QS9NkZX7x2YtIhISEKCEhQbm5ueay6upq5ebmyuFweLEyAL6O+QVAY2F+AXyfzx6BkqSMjAxNmjRJiYmJuv766/XMM8/o7Nmzuueee7xdGgAfx/wCoLEwvwC+zacD1B133KGvv/5aM2fOVFFRkfr166f169fXOjHzctjtds2aNavW4XN/4K+90Rfcgfml8dB38+m7OfZsBfPLxfOnfujF99kMX70OKAAAAAB4mM+eAwUAAAAAnkaAAgAAAACLCFAAAAAAYBEBCgAAAAAsIkBdQFZWlq644gqFhoYqKSlJu3bt8nZJDdqyZYtuueUWxcbGymazadWqVS7rDcPQzJkz1bFjR7Vo0ULJyck6dOiQy5hTp05p/PjxCg8PV2RkpCZPnqyysjIPdlFbZmamBgwYoNatWysqKkpjxozRwYMHXcacP39e6enpateunVq1aqWxY8fWulFhYWGh0tLSFBYWpqioKD300EOqrKz0ZCsuXnzxRfXp08e8AZ3D4dA//vEPc70v9gTrfG1+uVjumI98jbvmKl/jjrkM7tXU55fZs2fLZrO5fPXo0cNc39T//nnq/dbevXs1dOhQhYaGKi4uTvPmzfN4L3fffXet79WoUaOaZC8eY6Bey5cvN0JCQozXXnvNOHDggDFlyhQjMjLSKC4u9nZp9Vq3bp3x//7f/zPeeecdQ5KxcuVKl/VPPPGEERERYaxatcr45z//afzkJz8x4uPjjW+//dYcM2rUKKNv377Gjh07jK1btxrdunUz7rzzTg934io1NdVYsmSJsX//fqOgoMC46aabjM6dOxtlZWXmmPvuu8+Ii4szcnNzjd27dxsDBw40Bg0aZK6vrKw0rr32WiM5OdnYs2ePsW7dOqN9+/bGjBkzvNGSYRiGsXr1amPt2rXGv//9b+PgwYPG73//eyM4ONjYv3+/YRi+2ROs8cX55WK5Yz7yNe6Yq3zR5c5lcC9fmF9mzZplXHPNNcaxY8fMr6+//tpc39T//nni/VZJSYkRHR1tjB8/3ti/f7/xt7/9zWjRooXx0ksvebSXSZMmGaNGjXL5Xp06dcplTFPpxVMIUA24/vrrjfT0dPNxVVWVERsba2RmZnqxKut++EtQXV1txMTEGE899ZS57PTp04bdbjf+9re/GYZhGJ988okhyfjoo4/MMf/4xz8Mm81m/Oc///FY7Rdy/PhxQ5KxefNmwzC+6yM4ONh4++23zTGffvqpIcnIy8szDOO7CSIgIMAoKioyx7z44otGeHi4UV5e7tkGGtCmTRvjlVde8aueUJuvzy8X61LmI39wKXOVv7iYuQzu5Qvzy6xZs4y+ffvWuc7X/v411vutF154wWjTpo1LP7/73e+M7t27e6wXw/guQN166631Pqep9tKY+AhfPSoqKpSfn6/k5GRzWUBAgJKTk5WXl+fFyi7dkSNHVFRU5NJTRESEkpKSzJ7y8vIUGRmpxMREc0xycrICAgK0c+dOj9dcn5KSEklS27ZtJUn5+flyOp0uvfXo0UOdO3d26a13794uNypMTU1VaWmpDhw44MHq61ZVVaXly5fr7NmzcjgcftET6uaP88vFsjIf+YNLmat83aXMZXAfX5pfDh06pNjYWHXt2lXjx49XYWGhJN//m+6u91t5eXkaNmyYQkJCzDGpqak6ePCgvvnmGw91851NmzYpKipK3bt319SpU3Xy5Elzna/14g4EqHqcOHFCVVVVte4KHh0draKiIi9VdXlq6m6op6KiIkVFRbmsDwoKUtu2bZtM39XV1Zo+fboGDx6sa6+9VtJ3dYeEhCgyMtJl7A97q6v3mnXesm/fPrVq1Up2u1333XefVq5cqV69evl0T2iYP84vF8vKfOTrLnWu8lWXM5fBfXxlfklKStLSpUu1fv16vfjiizpy5IiGDh2qM2fO+PzfP3e932oqPY4aNUpvvPGGcnNz9eSTT2rz5s0aPXq0qqqqzFp8pRd3CfJ2AcDFSk9P1/79+7Vt2zZvl+IW3bt3V0FBgUpKSvT3v/9dkyZN0ubNm71dFoDL5G9z1YUwl+FijB492vx3nz59lJSUpC5duuitt95SixYtvFgZfmjcuHHmv3v37q0+ffroyiuv1KZNmzRixAgvVuY9HIGqR/v27RUYGFjrii/FxcWKiYnxUlWXp6buhnqKiYnR8ePHXdZXVlbq1KlTTaLvadOmac2aNfrggw/UqVMnc3lMTIwqKip0+vRpl/E/7K2u3mvWeUtISIi6deumhIQEZWZmqm/fvnr22Wd9uic0zB/nl4tlZT7yZZczV/mqy5nL4D6+Or9ERkbq6quv1uHDh33+75+73m811R67du2q9u3b6/Dhw2YtvtrLpSJA1SMkJEQJCQnKzc01l1VXVys3N1cOh8OLlV26+Ph4xcTEuPRUWlqqnTt3mj05HA6dPn1a+fn55piNGzequrpaSUlJHq+5hmEYmjZtmlauXKmNGzcqPj7eZX1CQoKCg4Ndejt48KAKCwtdetu3b5/LL3lOTo7Cw8PVq1cvzzRiQXV1tcrLy/2qJ7jyx/nlYlmZj3yRO+Yqf3Excxncx1fnl7KyMn322Wfq2LGjz//9c9f7LYfDoS1btsjpdJpjcnJy1L17d7Vp08ZD3dR29OhRnTx5Uh07dpTk271cMm9fxaIpW758uWG3242lS5can3zyiXHvvfcakZGRLld8aWrOnDlj7Nmzx9izZ48hyViwYIGxZ88e4//+7/8Mw/juspqRkZHGu+++a+zdu9e49dZb67ysZv/+/Y2dO3ca27ZtM6666iqvX8Z86tSpRkREhLFp0yaXy2ieO3fOHHPfffcZnTt3NjZu3Gjs3r3bcDgchsPhMNfXXPI0JSXFKCgoMNavX2906NDBq5f8fuSRR4zNmzcbR44cMfbu3Ws88sgjhs1mM7Kzsw3D8M2eYI0vzi8Xyx3zka9xx1zliy53LoN7+cL88tvf/tbYtGmTceTIEWP79u1GcnKy0b59e+P48eOGYTT9v3+eeL91+vRpIzo62pgwYYKxf/9+Y/ny5UZYWJjbL/3dUC9nzpwxHnzwQSMvL884cuSI8f777xvXXXedcdVVVxnnz59vcr14CgHqAp577jmjc+fORkhIiHH99dcbO3bs8HZJDfrggw8MSbW+Jk2aZBjGd5fW/MMf/mBER0cbdrvdGDFihHHw4EGXbZw8edK48847jVatWhnh4eHGPffcY5w5c8YL3fxXXT1JMpYsWWKO+fbbb41f//rXRps2bYywsDDjpz/9qXHs2DGX7XzxxRfG6NGjjRYtWhjt27c3fvvb3xpOp9PD3fzXL3/5S6NLly5GSEiI0aFDB2PEiBHmGw7D8M2eYJ2vzS8Xyx3zka9x11zla9wxl8G9mvr8cscddxgdO3Y0QkJCjB/96EfGHXfcYRw+fNhc39T//nnq/dY///lPY8iQIYbdbjd+9KMfGU888YRHezl37pyRkpJidOjQwQgODja6dOliTJkypVYYbyq9eIrNMAyjcY9xAQAAAIB/4BwoAAAAALCIAAUAAAAAFhGgAAAAAMAiAhQAAAAAWESAAgAAAACLCFAAAAAAYBEBCgAAAAAsIkABAAAAgEUEKAAAAACwiAAFAAAAABYRoAAAAADAIgIUAAAAAFhEgAIAAAAAiwhQAAAAAGARAQoAAAAALCJAAQAAAIBFBCgAAAAAsIgABQAAAAAWEaAAAAAAwCICFAAAAABYRICCi9mzZ8tms3m7DBeVlZV6+OGHFRcXp4CAAI0ZM8bbJdXyxRdfyGaz6emnn/Z2KQAAAGhEBCh4nNPp1KJFizRgwAC1bt1arVq10oABA7Ro0SI5nc5a41977TU99dRT+tnPfqbXX39dDzzwgMLDw3XrrbfWGrtw4ULZbDZNmjSp1rqZM2fKZrPp3//+d6P0BQAAAP8X5O0C0LycPXtWaWlp2rx5s26++WbdfffdCggI0Pr16/Wb3/xG77zzjtauXauWLVuaz9m4caN+9KMfaeHCheaygQMH6sMPP6y1/e3btysoKEjbt2+vc11UVJSuvvrqxmkOAAAAfo8jUPCojIwMbd68Wc8995zee+89paena+rUqXr33Xf1/PPPa/PmzXrwwQddnnP8+HFFRka6LBsyZIhOnDihTz/91GX59u3bdfvtt+uzzz5TUVGRubyyslI7d+7U4MGDG603AAAA+D8CVDO2bds2DRgwQKGhobryyiv10ksv1RqzZMkS3XjjjYqKipLdblevXr304osvuoyZNGmS2rdvX+fH71JSUtS9e3dJ0tGjR/Xqq6/qxhtv1LRp02qNTU9P1w033KBXXnlFR48eNc8r+uCDD3TgwAHZbDbZbDZt2rRJQ4YMkSSXI02ff/65ioqKNG3aNIWGhrqsKygo0NmzZ83nSdK//vUv/exnP1Pbtm0VGhqqxMRErV69ulZdp0+f1vTp0xUXFye73a5u3brpySefVHV1dYP71zAM3XvvvQoJCdE777zT4FgAAAD4BgJUM7Vv3z6lpKTo+PHjmj17tu655x7NmjVLK1eudBn34osvqkuXLvr973+v+fPnKy4uTr/+9a+VlZVljpkwYYJOnjypDRs2uDy3qKhIGzdu1C9+8QtJ0j/+8Q9VVVVp4sSJ9dY1ceJEVVZWav369erQoYP+8pe/qEePHurUqZP+8pe/6C9/+Yt69uypgQMHKigoSNu2bTOfu337drVs2VIDBgxQYmKiS4Cq+XdNgDpw4IAGDhyoTz/9VI888ojmz5+vli1basyYMS774Ny5c/rxj3+sv/71r5o4caIWLVqkwYMHa8aMGcrIyKi3j6qqKt1999164403tHLlSt122231jgUAAIAPMdAsjRkzxggNDTX+7//+z1z2ySefGIGBgcb3fyzOnTtX67mpqalG165dzcdVVVVGp06djDvuuMNl3IIFCwybzWZ8/vnnhmEYxvTp0w1Jxp49e+qt6+OPPzYkGRkZGeayH//4x8Y111xTa+yAAQOMK6+80nz8P//zP8YNN9xgGIZhPPzww8aAAQPMdT/72c+MsLAww+l0GoZhGCNGjDB69+5tnD9/3hxTXV1tDBo0yLjqqqvMZXPnzjVatmxp/Pvf/3Z57UceecQIDAw0CgsLDcMwjCNHjhiSjKeeespwOp3GHXfcYbRo0cLYsGFDvb0CAADA93AEqhmqqqrShg0bNGbMGHXu3Nlc3rNnT6WmprqMbdGihfnvkpISnThxQj/+8Y/1+eefq6SkRJIUEBCg8ePHa/Xq1Tpz5ow5/s0339SgQYMUHx8vSea61q1b11tbzbrS0tIL9jFkyBCXc522b9+uQYMGSZIGDx6sPXv26Ny5c+a6pKQkBQUF6dSpU9q4caNuv/12nTlzRidOnNCJEyd08uRJpaam6tChQ/rPf/4jSXr77bc1dOhQtWnTxhx34sQJJScnq6qqSlu2bHGpqaKiQj//+c+1Zs0arVu3TikpKRfsAwAAAL6DANUMff311/r222911VVX1VpXc75Sje3btys5OVktW7ZUZGSkOnTooN///veSZAYo6buP3n377bfmx98OHjyo/Px8TZgwwRxTE46+H7J+yErIqvH986BOnz6tAwcOmBeJGDRokCorK7Vr1y4dOXJEx44dM8cfPnxYhmHoD3/4gzp06ODyNWvWLEnfXbhCkg4dOmR+nPD7X8nJyS7jamRmZmrVqlX6+9//ruHDh1+wBwAAAPgWLmOOen322WcaMWKEevTooQULFiguLk4hISFat26dFi5c6HIRhV69eikhIcE8V+ivf/2rQkJCdPvtt5tjevbsKUnau3ev+vXrV+dr7t2719zehdQEom3btiksLEyS5HA4JEnt27fXVVddpW3btunLL790GV9T94MPPljriFuNbt26mWNHjhyphx9+uM5xP7wkempqqtavX6958+Zp+PDhCg0NvWAfAAAA8B0EqGaoQ4cOatGihQ4dOlRr3cGDB81/v/feeyovL9fq1atdPur3wQcf1LndiRMnKiMjQ8eOHdOyZcuUlpamNm3amOtHjx6twMBA/eUvf6n3QhJvvPGGgoKCNGrUqAv2ERUVZYakli1bqlevXi6XOx80aJC2b9+uo0ePKjAw0AxXXbt2lSQFBwebR5Lqc+WVV6qsrOyC42oMHDhQ9913n26++Wb9/Oc/18qVKxUUxK8ZAACAv+AjfM1QYGCgUlNTtWrVKhUWFprLP/30U5cr6QUGBkr67nLcNUpKSrRkyZI6t3vnnXfKZrPpN7/5jT7//HPz6ns14uLidM899+j999+vdSl0SVq8eLE2btyoyZMnq1OnTpZ6GTJkiAoKCpSdnW2e/1Rj0KBBysvL09atW9WnTx/zY4FRUVEaPny4XnrpJR07dqzWNr/++mvz37fffrvy8vJqXWFQ+u7y5pWVlbWWJycna/ny5Vq/fr0mTJhwwcudAwAAwHfwX+PN1Jw5c7R+/XoNHTpUv/71r1VZWannnntO11xzjfkxupSUFIWEhOiWW27R//zP/6isrEx//vOfFRUVVWfw6NChg0aNGqW3335bkZGRSktLqzVm4cKF+te//qVf//rXWr9+vXmkacOGDXr33Xf14x//WPPnz7fcx5AhQ7RkyRJ99NFHSk9Pd1k3aNAglZSUqKSkRPfff7/LuqysLA0ZMkS9e/fWlClT1LVrVxUXFysvL09Hjx7VP//5T0nSQw89pNWrV+vmm2/W3XffrYSEBJ09e1b79u3T3//+d33xxRdq3759rbrGjBmjJUuWaOLEiQoPD6/zHlsAAADwQd6+DCC8Z/PmzUZCQoIREhJidO3a1Vi8eLExa9Ysl8uYr1692ujTp48RGhpqXHHFFcaTTz5pvPbaa4Yk48iRI7W2+dZbbxmSjHvvvbfe1y0vLzcWLlxoJCQkGC1btjTCwsKM6667znjmmWeMioqKWuPru4y5YRjGwYMHDUmGpFqXGq+urjYiIyMNScaKFStqPfezzz4zJk6caMTExBjBwcHGj370I+Pmm282/v73v7uMO3PmjDFjxgyjW7duRkhIiNG+fXtj0KBBxtNPP23W+/3LmH/fCy+8YEgyHnzwwXr3BwAAAHyHzTC+9/ks4DK9++67GjNmjLZs2aKhQ4d6uxwAAADArQhQcKubb75Zn376qQ4fPiybzebtcgAAAAC34hwouMXy5cu1d+9erV27Vs8++yzhCQAAAH6JI1BwC5vNplatWumOO+7Q4sWLuXQ3AAAA/BLvcuEW5HAAAAA0B9wHCgAAAAAsIkABAAAAgEXN+iN81dXV+uqrr9S6dWsuegC4kWEYOnPmjGJjYxUQwP/TAAAA/9GsA9RXX32luLg4b5cB+K0vv/xSnTp18nYZAAAAbtOsA1Tr1q0lffcmLzw8vM4xTqdT2dnZSklJUXBwsCfLa1LYD+wDyfo+KC0tVVxcnPk7BgAA4C+adYCq+dheeHh4gwEqLCxM4eHhzfZNs8R+kNgH0sXvAz4aCwAA/A0nJwAAAACARQQoAAAAALCIAAUAAAAAFhGgAAAAAMAiAhQAAAAAWESAAgAAAACL3B6gMjMzNWDAALVu3VpRUVEaM2aMDh486DLm/PnzSk9PV7t27dSqVSuNHTtWxcXFLmMKCwuVlpamsLAwRUVF6aGHHlJlZaXLmE2bNum6666T3W5Xt27dtHTpUne3AwAAAAAmtweozZs3Kz09XTt27FBOTo6cTqdSUlJ09uxZc8wDDzyg9957T2+//bY2b96sr776Srfddpu5vqqqSmlpaaqoqNCHH36o119/XUuXLtXMmTPNMUeOHFFaWppuuOEGFRQUaPr06frVr36lDRs2uLslAAAAAJDUCDfSXb9+vcvjpUuXKioqSvn5+Ro2bJhKSkr06quvatmyZbrxxhslSUuWLFHPnj21Y8cODRw4UNnZ2frkk0/0/vvvKzo6Wv369dPcuXP1u9/9TrNnz1ZISIgWL16s+Ph4zZ8/X5LUs2dPbdu2TQsXLlRqaqq729K1szeovMo9NwX94ok0t2wHAAAAgGc1+jlQJSUlkqS2bdtKkvLz8+V0OpWcnGyO6dGjhzp37qy8vDxJUl5ennr37q3o6GhzTGpqqkpLS3XgwAFzzPe3UTOmZhsAAAAA4G5uPwL1fdXV1Zo+fboGDx6sa6+9VpJUVFSkkJAQRUZGuoyNjo5WUVGROeb74almfc26hsaUlpbq22+/VYsWLWrVU15ervLycvNxaWmpJMnpdMrpdNbZQ81ye4BhqWcr6nutpqymZl+s3V3YB9b3QXPeRwAAwL81aoBKT0/X/v37tW3btsZ8GcsyMzM1Z86cWsuzs7MVFhbW4HPnJla7rY5169a5bVuelpOT4+0SvI59cOF9cO7cOQ9VAgAA4FmNFqCmTZumNWvWaMuWLerUqZO5PCYmRhUVFTp9+rTLUaji4mLFxMSYY3bt2uWyvZqr9H1/zA+v3FdcXKzw8PA6jz5J0owZM5SRkWE+Li0tVVxcnFJSUhQeHl7nc5xOp3JycvSH3QEqr3bPOVD7Z7v/HK3GVrMfRo4cqeDgYG+X4xbXzr64C47YAwzNTayu82fBF7+nl8Lqz0HN0V0AAAB/4/YAZRiG7r//fq1cuVKbNm1SfHy8y/qEhAQFBwcrNzdXY8eOlSQdPHhQhYWFcjgckiSHw6E//vGPOn78uKKioiR99z/e4eHh6tWrlznmh0dycnJyzG3UxW63y26311oeHBx8wVBQXm1z20UkfDmAWNlXvuJSv591/Sz4yz6x6kI/B81tfwAAgObD7QEqPT1dy5Yt07vvvqvWrVub5yxFRESoRYsWioiI0OTJk5WRkaG2bdsqPDxc999/vxwOhwYOHChJSklJUa9evTRhwgTNmzdPRUVFevTRR5Wenm4GoPvuu0/PP/+8Hn74Yf3yl7/Uxo0b9dZbb2nt2rXubgkAAAAAJDXCVfhefPFFlZSUaPjw4erYsaP5tWLFCnPMwoULdfPNN2vs2LEaNmyYYmJi9M4775jrAwMDtWbNGgUGBsrhcOgXv/iFJk6cqMcee8wcEx8fr7Vr1yonJ0d9+/bV/Pnz9corrzTKJcwBAAAAQGqkj/BdSGhoqLKyspSVlVXvmC5dulzwYgvDhw/Xnj17LrpG1O+KR+o+gmcPNDTv+ou/Hxb3vAIAAIA/adSr8KFu9YWUS0VIAQAAADyj0W+kCwAAAAD+giNQ8BnuPnLXlHGUEgAAoGniCBQAAAAAWESAAgAAAACLCFAAAAAAYBEBCgAAAAAsIkABAAAAgEUEKAAAAACwiAAFAAAAABYRoAAAAADAIgIUAAAAAFhEgAIAAAAAiwhQAAAAAGARAQoAAAAALCJAAQAAAIBFBCgAAAAAsIgABQAAAAAWEaAAAAAAwCICFAAAAABYRIACAAAAAIsIUAAAAABgEQEKAAAAACwiQAEAAACARQQoAAAAALCIAAUAAAAAFhGgAAAAAMAiAhQAAAAAWESAAgAAAACLCFAAAAAAYBEBCgAAAAAsIkABAAAAgEUEKAAAAACwiAAFAAAAABYRoAAAAADAIgIUAAAAAFhEgAIAAAAAiwhQAAAAAGARAQoAAAAALCJAAQAAAIBFbg9QW7Zs0S233KLY2FjZbDatWrXKZf3dd98tm83m8jVq1CiXMadOndL48eMVHh6uyMhITZ48WWVlZS5j9u7dq6FDhyo0NFRxcXGaN2+eu1sBAAAAABduD1Bnz55V3759lZWVVe+YUaNG6dixY+bX3/72N5f148eP14EDB5STk6M1a9Zoy5Ytuvfee831paWlSklJUZcuXZSfn6+nnnpKs2fP1ssvv+zudgAAAADAFOTuDY4ePVqjR49ucIzdbldMTEyd6z799FOtX79eH330kRITEyVJzz33nG666SY9/fTTio2N1ZtvvqmKigq99tprCgkJ0TXXXKOCggItWLDAJWgBAAAAgDu5PUBZsWnTJkVFRalNmza68cYb9fjjj6tdu3aSpLy8PEVGRprhSZKSk5MVEBCgnTt36qc//any8vI0bNgwhYSEmGNSU1P15JNP6ptvvlGbNm3qfN3y8nKVl5ebj0tLSyVJTqdTTqezzufULLcHGJfXdCOqr/ZLYQ+su8+a/i92P3iiNk9paB+4s0/J/b26q76a7Vxoe+7eHwAAAE2FxwPUqFGjdNtttyk+Pl6fffaZfv/732v06NHKy8tTYGCgioqKFBUV5VpkUJDatm2roqIiSVJRUZHi4+NdxkRHR5vr6gtQmZmZmjNnTq3l2dnZCgsLa7DuuYnVlnv0tHXr1rltW/Oub3j9xe4HT9bmKXXtA3f2Kbm/V3fXl5OT0+D6c+fOufX1AAAAmgqPB6hx48aZ/+7du7f69OmjK6+8Ups2bdKIESMa9bVnzJihjIwM83Fpaani4uKUkpKi8PDwOp/jdDqVk5OjP+wOUHm1rVHru1T7Z6e6bVvXzt5Q53J7gKG5idUXvR88UZunNLQP3Nmn5P5e3VVfze/DyJEjFRwcXO+4mqO7AAAA/sYrH+H7vq5du6p9+/Y6fPiwRowYoZiYGB0/ftxlTGVlpU6dOmWeNxUTE6Pi4mKXMTWP6zu3Svru3Cu73V5reXBwcINvBiWpvNqm8qqmGaAuVPvFuFCPF7sfPFmbp9S1D9zZp+T+Xt1d34V+Z9z9egAAAE2F1+8DdfToUZ08eVIdO3aUJDkcDp0+fVr5+fnmmI0bN6q6ulpJSUnmmC1btricZ5GTk6Pu3bvX+/E9AAAAALhcbg9QZWVlKigoUEFBgSTpyJEjKigoUGFhocrKyvTQQw9px44d+uKLL5Sbm6tbb71V3bp1U2rqdx8x6tmzp0aNGqUpU6Zo165d2r59u6ZNm6Zx48YpNjZWknTXXXcpJCREkydP1oEDB7RixQo9++yzLh/PAwAAAAB3c3uA2r17t/r376/+/ftLkjIyMtS/f3/NnDlTgYGB2rt3r37yk5/o6quv1uTJk5WQkKCtW7e6fLTuzTffVI8ePTRixAjddNNNGjJkiMs9niIiIpSdna0jR44oISFBv/3tbzVz5kwuYQ4AAACgUbn9HKjhw4fLMOq/BPOGDRc+Ob5t27ZatmxZg2P69OmjrVu3XnR9AAAAAHCpvH4OFAAAAAD4CgIUAAAAAFhEgAIAAAAAiwhQAAAAAGARAQoAAAAALCJAAQAAAIBFBCgAAAAAsIgABQAAAAAWEaAAAAAAwCICFAAAAABYRIACAAAAAIsIUAAAAABgUZC3CwDQ+K54ZK1btmMPNDTverdsCgAAwCdxBAoAAAAALCJAAQAAAIBFBCgAAAAAsIgABQAAAAAWEaAAAAAAwCICFAAAAABYRIACAAAAAIsIUAAAAABgEQEKAAAAACwiQAEAAACARQQoAAAAALCIAAUAAAAAFhGgAAAAAMAiAhQAAAAAWESAAgAAAACLCFAAAAAAYBEBCgAAAAAsIkABAAAAgEUEKAAAAACwiAAFAAAAABYRoAAAAADAIgIUAAAAAFhEgAIAAAAAiwhQAAAAAGARAQoAAAAALCJAAQAAAIBFbg9QW7Zs0S233KLY2FjZbDatWrXKZb1hGJo5c6Y6duyoFi1aKDk5WYcOHXIZc+rUKY0fP17h4eGKjIzU5MmTVVZW5jJm7969Gjp0qEJDQxUXF6d58+a5uxUAAAAAcOH2AHX27Fn17dtXWVlZda6fN2+eFi1apMWLF2vnzp1q2bKlUlNTdf78eXPM+PHjdeDAAeXk5GjNmjXasmWL7r33XnN9aWmpUlJS1KVLF+Xn5+upp57S7Nmz9fLLL7u7HQAAAAAwBbl7g6NHj9bo0aPrXGcYhp555hk9+uijuvXWWyVJb7zxhqKjo7Vq1SqNGzdOn376qdavX6+PPvpIiYmJkqTnnntON910k55++mnFxsbqzTffVEVFhV577TWFhITommuuUUFBgRYsWOAStAAAAADAndweoBpy5MgRFRUVKTk52VwWERGhpKQk5eXlady4ccrLy1NkZKQZniQpOTlZAQEB2rlzp376058qLy9Pw4YNU0hIiDkmNTVVTz75pL755hu1adOmztcvLy9XeXm5+bi0tFSS5HQ65XQ663xOzXJ7gHHpjTey+mq/FPbAuvus6f9i94MnavOUhvaBO/uUvN9rfWp6v1C/7t4fAAAATYVHA1RRUZEkKTo62mV5dHS0ua6oqEhRUVEu64OCgtS2bVuXMfHx8bW2UbOuvgCVmZmpOXPm1FqenZ2tsLCwBmufm1jd4HpvWrdundu2Ne/6htdf7H7wZG2eUtc+cGefUtPptT45OTkNrj937pyHKgEAAPAsjwYob5sxY4YyMjLMx6WlpYqLi1NKSorCw8PrfI7T6VROTo7+sDtA5dU2T5V6UfbPTnXbtq6dvaHO5fYAQ3MTqy96P3iiNk9paB+4s0/J+73Wp2YfjBw5UsHBwfWOqzm6CwAA4G88GqBiYmIkScXFxerYsaO5vLi4WP369TPHHD9+3OV5lZWVOnXqlPn8mJgYFRcXu4ypeVwzpi52u112u73W8uDg4AbfDEpSebVN5VVNM0BdqPaLcaEeL3Y/eLI2T6lrH7izT6np9FqfC/3OuHt/AAAANBUevQ9UfHy8YmJilJubay4rLS3Vzp075XA4JEkOh0OnT59Wfn6+OWbjxo2qrq5WUlKSOWbLli0u51nk5OSoe/fu9X58DwAAAAAul9sDVFlZmQoKClRQUCDpuwtHFBQUqLCwUDabTdOnT9fjjz+u1atXa9++fZo4caJiY2M1ZswYSVLPnj01atQoTZkyRbt27dL27ds1bdo0jRs3TrGxsZKku+66SyEhIZo8ebIOHDigFStW6Nlnn3X5eB4AAAAAuJvbP8K3e/du3XDDDebjmlAzadIkLV26VA8//LDOnj2re++9V6dPn9aQIUO0fv16hYaGms958803NW3aNI0YMUIBAQEaO3asFi1aZK6PiIhQdna20tPTlZCQoPbt22vmzJlcwhwAAABAo3J7gBo+fLgMo/5LMNtsNj322GN67LHH6h3Ttm1bLVu2rMHX6dOnj7Zu3XrJdQIAAADAxfLoOVAAAAAA4MsIUAAAAABgEQEKAAAAACwiQAEAAACARQQoAAAAALCIAAUAAAAAFhGgAAAAAMAiAhQAAAAAWESAAgAAAACLCFAAAAAAYBEBCgAAAAAsIkABAAAAgEUEKAAAAACwiAAFAAAAABYRoAAAAADAIgIUAAAAAFhEgAIAAAAAiwhQAAAAAGARAQoAAAAALCJAAQAAAIBFBCgAAAAAsIgABQAAAAAWEaAAAAAAwCICFAAAAABYRIACAAAAAIsIUAAAAABgEQEKAAAAACwiQAEAAACARQQoAAAAALCIAAUAAAAAFhGgAAAAAMAiAhQAAAAAWESAAgAAAACLCFAAAAAAYBEBCgAAAAAsIkABAAAAgEUEKAAAAACwiAAFAAAAABYRoAAAAADAIq8EqNmzZ8tms7l89ejRw1x//vx5paenq127dmrVqpXGjh2r4uJil20UFhYqLS1NYWFhioqK0kMPPaTKykpPtwIAAACgGQny1gtfc801ev/99/9bSNB/S3nggQe0du1avf3224qIiNC0adN02223afv27ZKkqqoqpaWlKSYmRh9++KGOHTumiRMnKjg4WH/605883gsAAACA5sFrASooKEgxMTG1lpeUlOjVV1/VsmXLdOONN0qSlixZop49e2rHjh0aOHCgsrOz9cknn+j9999XdHS0+vXrp7lz5+p3v/udZs+erZCQEE+3AwAAAKAZ8FqAOnTokGJjYxUaGiqHw6HMzEx17txZ+fn5cjqdSk5ONsf26NFDnTt3Vl5engYOHKi8vDz17t1b0dHR5pjU1FRNnTpVBw4cUP/+/et8zfLycpWXl5uPS0tLJUlOp1NOp7PO59QstwcYl91zY6mv9kthD6y7z5r+L3Y/eKI2T2loH7izT8n7vdanpvcL9evu/QEAANBUeCVAJSUlaenSperevbuOHTumOXPmaOjQodq/f7+KiooUEhKiyMhIl+dER0erqKhIklRUVOQSnmrW16yrT2ZmpubMmVNreXZ2tsLCwhqseW5itZXWvGLdunVu29a86xtef7H7wZO1eUpd+8CdfUpNp9f65OTkNLj+3LlzHqoEAADAs7wSoEaPHm3+u0+fPkpKSlKXLl301ltvqUWLFo32ujNmzFBGRob5uLS0VHFxcUpJSVF4eHidz3E6ncrJydEfdgeovNrWaLVdjv2zU922rWtnb6hzuT3A0NzE6oveD56ozVMa2gfu7FPyfq/1qdkHI0eOVHBwcL3jao7uAgAA+BuvfYTv+yIjI3X11Vfr8OHDGjlypCoqKnT69GmXo1DFxcXmOVMxMTHatWuXyzZqrtJX13lVNex2u+x2e63lwcHBDb4ZlKTyapvKq5pmgLpQ7RfjQj1e7H7wZG2eUtc+cGefUtPptT4X+p1x9/4AAABoKprEfaDKysr02WefqWPHjkpISFBwcLByc3PN9QcPHlRhYaEcDockyeFwaN++fTp+/Lg5JicnR+Hh4erVq5fH6wcAAADQPHjlCNSDDz6oW265RV26dNFXX32lWbNmKTAwUHfeeaciIiI0efJkZWRkqG3btgoPD9f9998vh8OhgQMHSpJSUlLUq1cvTZgwQfPmzVNRUZEeffRRpaen13mECQAAAADcwSsB6ujRo7rzzjt18uRJdejQQUOGDNGOHTvUoUMHSdLChQsVEBCgsWPHqry8XKmpqXrhhRfM5wcGBmrNmjWaOnWqHA6HWrZsqUmTJumxxx7zRjsAAAAAmgmvBKjly5c3uD40NFRZWVnKysqqd0yXLl3cfuUzAAAAAGhIkzgHCgAAAAB8AQEKAAAAACwiQAEAAACARQQoAAAAALCIAAUAAAAAFhGgAAAAAMAiAhQAAAAAWESAAgAAAACLCFAAAAAAYBEBCgAAAAAsIkABAAAAgEUEKAAAAACwiAAFAAAAABYRoAAAAADAIgIUAAAAAFhEgAIAAAAAiwhQAAAAAGARAQoAAAAALCJAAQAAAIBFBCgAAAAAsIgABQAAAAAWEaAAAAAAwCICFAAAAABYRIACAAAAAIsIUAAAAABgEQEKAAAAACwiQAEAAACARQQoAAAAALCIAAUAAAAAFhGgAAAAAMAiAhQAAAAAWESAAgAAAACLCFAAAAAAYBEBCgAAAAAsIkABAAAAgEUEKAAAAACwiAAFAAAAABYRoAAAAADAIgIUAAAAAFjk8wEqKytLV1xxhUJDQ5WUlKRdu3Z5uyQAAAAAfsqnA9SKFSuUkZGhWbNm6eOPP1bfvn2Vmpqq48ePe7s0AAAAAH7IpwPUggULNGXKFN1zzz3q1auXFi9erLCwML322mveLg0AAACAHwrydgGXqqKiQvn5+ZoxY4a5LCAgQMnJycrLy6vzOeXl5SovLzcfl5SUSJJOnTolp9NZ53OcTqfOnTunIGeAqqptbuzAfU6ePOm2bQVVnq17ebWhc+eqL3o/eKI2T2loH7izT8n7vdanZh+cPHlSwcHB9Y47c+aMJMkwDE+VBgAA4BE+G6BOnDihqqoqRUdHuyyPjo7Wv/71rzqfk5mZqTlz5tRaHh8f3yg1ekr7+Z55nbsu4Tmeqs1T6tsH/tZnQy7m5+DMmTOKiIhotFoAAAA8zWcD1KWYMWOGMjIyzMfV1dU6deqU2rVrJ5ut7qMqpaWliouL05dffqnw8HBPldrksB/YB5L1fWAYhs6cOaPY2FgPVgcAAND4fDZAtW/fXoGBgSouLnZZXlxcrJiYmDqfY7fbZbfbXZZFRkZaer3w8PBm+6b5+9gP7APJ2j7gyBMAAPBHPnsRiZCQECUkJCg3N9dcVl1drdzcXDkcDi9WBgAAAMBf+ewRKEnKyMjQpEmTlJiYqOuvv17PPPOMzp49q3vuucfbpQEAAADwQz4doO644w59/fXXmjlzpoqKitSvXz+tX7++1oUlLofdbtesWbNqffSvuWE/sA8k9gEAAIDN4DrDAAAAAGCJz54DBQAAAACeRoACAAAAAIsIUAAAAABgEQEKAAAAACwiQF1AVlaWrrjiCoWGhiopKUm7du3ydkkek5mZqQEDBqh169aKiorSmDFjdPDgQW+X5VVPPPGEbDabpk+f7u1SPO4///mPfvGLX6hdu3Zq0aKFevfurd27d3u7LAAAAI8iQDVgxYoVysjI0KxZs/Txxx+rb9++Sk1N1fHjx71dmkds3rxZ6enp2rFjh3JycuR0OpWSkqKzZ896uzSv+Oijj/TSSy+pT58+3i7F47755hsNHjxYwcHB+sc//qFPPvlE8+fPV5s2bbxdGgAAgEdxGfMGJCUlacCAAXr++eclSdXV1YqLi9P999+vRx55xMvVed7XX3+tqKgobd68WcOGDfN2OR5VVlam6667Ti+88IIef/xx9evXT88884y3y/KYRx55RNu3b9fWrVu9XQoAAIBXcQSqHhUVFcrPz1dycrK5LCAgQMnJycrLy/NiZd5TUlIiSWrbtq2XK/G89PR0paWlufw8NCerV69WYmKifv7znysqKkr9+/fXn//8Z2+XBQAA4HEEqHqcOHFCVVVVio6OdlkeHR2toqIiL1XlPdXV1Zo+fboGDx6sa6+91tvleNTy5cv18ccfKzMz09uleM3nn3+uF198UVdddZU2bNigqVOn6n//93/1+uuve7s0AAAAjwrydgHwDenp6dq/f7+2bdvm7VI86ssvv9RvfvMb5eTkKDQ01NvleE11dbUSExP1pz/9SZLUv39/7d+/X4sXL9akSZO8XB0AAIDncASqHu3bt1dgYKCKi4tdlhcXFysmJsZLVXnHtGnTtGbNGn3wwQfq1KmTt8vxqPz8fB0/flzXXXedgoKCFBQUpM2bN2vRokUKCgpSVVWVt0v0iI4dO6pXr14uy3r27KnCwkIvVQQAAOAdBKh6hISEKCEhQbm5ueay6upq5ebmyuFweLEyzzEMQ9OmTdPKlSu1ceNGxcfHe7skjxsxYoT27dungoIC8ysxMVHjx49XQUGBAgMDvV2iRwwePLjWJez//e9/q0uXLl6qCAAAwDv4CF8DMjIyNGnSJCUmJur666/XM888o7Nnz+qee+7xdmkekZ6ermXLlundd99V69atzXO/IiIi1KJFCy9X5xmtW7eudc5Xy5Yt1a5du2Z1LtgDDzygQYMG6U9/+pNuv/127dq1Sy+//LJefvllb5cGAADgUVzG/AKef/55PfXUUyoqKlK/fv20aNEiJSUlebssj7DZbHUuX7Jkie6++27PFtOEDB8+vNldxlyS1qxZoxkzZujQoUOKj49XRkaGpkyZ4u2yAAAAPIoABQAAAAAWcQ4UAAAAAFhEgAIAAAAAiwhQAAAAAGARAQoAAAAALCJAAQAAAIBFBCgAAAAAsIgABQAAAAAWEaAAAAAAwCICFAAAAABYRIACAAAAAIsIUAAAAABgEQEKAAAAACz6/3iTn/BEFYojAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 1000x1000 with 9 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "pd_flights.select_dtypes(include=np.number).hist(figsize=[10,10])\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 58,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 853
+    },
+    "execution": {
+     "iopub.execute_input": "2023-09-20T14:02:07.854642Z",
+     "iopub.status.busy": "2023-09-20T14:02:07.854304Z",
+     "iopub.status.idle": "2023-09-20T14:02:08.800706Z",
+     "shell.execute_reply": "2023-09-20T14:02:08.800146Z"
+    },
+    "id": "VylFZ0feNRFp",
+    "outputId": "c00faf49-2d41-4dac-dcfe-54d136dbe40e",
+    "pycharm": {
+     "is_executing": false
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA1AAAANECAYAAAC+XM68AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy81sbWrAAAACXBIWXMAAA9hAAAPYQGoP6dpAADRcElEQVR4nOzdeVhUdfs/8PeAzLDogKiAJCJiqSguoSK5ZIogkmlahppibmlQj/qkZrkAVqjlnsvTU0kL5FJmpqaMC664kaSimZrLUwnmAriOI/P5/eFvzteRxQPOCu/XdXnVnPOZc+77zMzN3HM2hRBCgIiIiIiIiB7JwdoBEBERERER2Qs2UERERERERDKxgSIiIiIiIpKJDRQREREREZFMbKCIiIiIiIhkYgNFREREREQkExsoIiIiIiIimdhAERERERERycQGioiIiIiISCY2UGRWDRo0wNChQ8v1nIyMDCgUCnz33XfmCcqEEhISoFAorB0GUYXw/Vu6Ll26oEuXLtLjc+fOQaFQICUlxWoxEdF9rF3yGL5PZWRkSNOGDh2KBg0aWC2myoINVCWyZMkSKBQKhIaGmm0dhg+jnH+2YsmSJSV+6Xk4FycnJzRs2BBDhgzBH3/8YflAiR5TSkqK0Xva2dkZvr6+iIyMxMKFC3H9+vXHXsfff/+NhIQEZGdnP37AFjZ06FBUr1692PQjR46gdu3aaNCgAc6dO2f5wEzoww8/xNq1a60dBlG5sHaVbejQoVAoFFCr1bh9+3ax+adOnZK23ccff2yFCKueatYOgEwnNTUVDRo0wIEDB3D69Gk0atTI5Oto2rQpvv76a6NpkydPRvXq1fHee+8VG3/y5Ek4OFi3T1+yZAlq165d6p6wt956C23btoVOp8Mvv/yCTz/9FBs2bMDRo0fh6+tb5rKnTJmCd955xwxRE1VcUlISAgICoNPpkJubi4yMDIwdOxZz587FunXr0KJFCwAVe//+/fffSExMRIMGDdCqVSszRG9Zx44dQ7du3eDm5obt27dLv8ymp6dbN7AK+vDDD/HSSy+hT58+1g6FqNxYu0pXrVo13Lp1Cz/99BP69+9vNC81NRXOzs64c+eO0fTOnTvj9u3bUCqVlgy1SmADVUmcPXsWe/fuxZo1a/D6668jNTUV06dPN/l6vL298eqrrxpNmzlzJmrXrl1sOgCoVCqTx2BqnTp1wksvvQQAeO211/DUU0/hrbfewpdffonJkyeX+JybN2/Czc0N1apVQ7Vq/BiRbYmKikKbNm2kx5MnT8a2bdvw/PPP44UXXsCJEyfg4uJS5d+/OTk56Nq1K1xcXLB9+3YEBARI8/iF4//cuXMHSqXS6j+GUeXH2lU6lUqFDh064Ntvvy3WQKWlpSE6Ohrff/+90XQHBwc4OztbMswqg9WwkkhNTUXNmjURHR2Nl156CampqQAAnU4HT09PvPbaa8WeU1hYCGdnZ7z99tvStPPnz+OFF16Am5sbvLy8MG7cOGzevLnYMbRylXQOVH5+PsaNG4cGDRpApVKhXr16GDJkCC5fvlzqcrRaLZ5//nm4u7tj7969AAC9Xo/58+ejWbNmcHZ2hre3N15//XVcu3bNaP05OTnYsWOHtHv7wfMaStK1a1cA95tS4P+OtT5+/DgGDhyImjVromPHjkbzHvbNN9+gXbt2cHV1Rc2aNdG5c+div2j//PPP6NSpE9zc3FCjRg1ER0cjJyenzNiIKqpr166YOnUqzp8/j2+++QZAye9fjUaDjh07wsPDA9WrV0fjxo3x7rvvArh/2Gvbtm0B3P+xwfCZMhwiu2vXLrz88suoX78+VCoV/Pz8MG7cuGKHnBgOpfvrr7/Qp08fVK9eHXXq1MHbb7+NoqIio7F6vR4LFixAcHAwnJ2dUadOHfTo0QOHDh0yGvfNN98gJCQELi4u8PT0RExMDP73v/+Vuj1OnDiBbt26QaVSYfv27WjYsKHR/IfPgSrNtm3bpM+xh4cHevfujRMnThiNMWzn33//Ha+++irc3d1Rp04dTJ06FUII/O9//0Pv3r2hVqvh4+ODOXPmFFuPVqvF9OnT0ahRI2nbTpw4EVqtVhqjUChw8+ZNfPnll9Jr82D9/euvvzBs2DB4e3tDpVKhWbNm+OKLL4zWYzi0ecWKFZgyZQqeeOIJuLq6orCwEDqdDomJiXjyySfh7OyMWrVqoWPHjtBoNI/cTkQVxdr1fwYOHIiff/4Z+fn50rSDBw/i1KlTGDhwYLHxJZ0DVRI536cA4NChQ4iMjETt2rXh4uKCgIAADBs2rMxlV1ZVq32vxFJTU9G3b18olUoMGDAAS5cuxcGDB9G2bVu8+OKLWLNmDf7zn/8Y/aq6du1aaLVaxMTEALi/V6Vr1664ePEi/vWvf8HHxwdpaWnYvn27yeK8ceMGOnXqhBMnTmDYsGF4+umncfnyZaxbtw5//vknateuXew5t2/fRu/evXHo0CFs2bJFKoKvv/46UlJS8Nprr+Gtt97C2bNn8cknn+Dw4cPYs2cPnJycMH/+fLz55ptGhxh6e3uXGeOZM2cAALVq1TKa/vLLL+PJJ5/Ehx9+CCFEqc9PTExEQkICnnnmGSQlJUGpVGL//v3Ytm0bIiIiAABff/01YmNjERkZiVmzZuHWrVtYunQpOnbsiMOHD/METzKLwYMH491330V6ejpGjhxZbH5OTg6ef/55tGjRAklJSVCpVDh9+jT27NkD4P4hvElJSZg2bRpGjRqFTp06AQCeeeYZAMDq1atx69YtjBkzBrVq1cKBAwewaNEi/Pnnn1i9erXRuoqKihAZGYnQ0FB8/PHH2LJlC+bMmYPAwECMGTNGGjd8+HCkpKQgKioKI0aMwL1797Br1y7s27dP+qX6gw8+wNSpU9G/f3+MGDEC//zzDxYtWoTOnTvj8OHD8PDwMFr3yZMn0bVrV1SrVg3bt29HYGBghbbnli1bEBUVhYYNGyIhIQG3b9/GokWL0KFDB/zyyy/FPsevvPIKmjZtipkzZ2LDhg14//334enpif/85z/o2rUrZs2ahdTUVLz99tto27YtOnfuDOD+l5sXXngBu3fvxqhRo9C0aVMcPXoU8+bNw++//y6d8/T1119jxIgRaNeuHUaNGgUAUm55eXlo3749FAoF4uPjUadOHfz8888YPnw4CgsLMXbsWKNYZ8yYAaVSibfffhtarRZKpRIJCQlITk6W1lFYWIhDhw7hl19+Qffu3Su0DYnkYO26r2/fvhg9ejTWrFkjNS5paWlo0qQJnn766QpvXznfpy5duoSIiAjUqVMH77zzDjw8PHDu3DmsWbOmwuu1a4Ls3qFDhwQAodFohBBC6PV6Ua9ePfGvf/1LCCHE5s2bBQDx008/GT2vZ8+eomHDhtLjOXPmCABi7dq10rTbt2+LJk2aCABi+/btJa6/WbNm4tlnny1xnr+/v4iNjZUeT5s2TQAQa9asKTZWr9cLIYTYvn27ACBWr14trl+/Lp599llRu3ZtcfjwYWnsrl27BACRmppqtIxNmzYVm15afIb1fPHFF+Kff/4Rf//9t9iwYYNo0KCBUCgU4uDBg0IIIaZPny4AiAEDBhRbhmGewalTp4SDg4N48cUXRVFRUYn5Xb9+XXh4eIiRI0cazc/NzRXu7u7FphPJtXz5cgFAeu+WxN3dXbRu3VoIUfz9O2/ePAFA/PPPP6U+/+DBgwKAWL58ebF5t27dKjYtOTlZKBQKcf78eWlabGysACCSkpKMxrZu3VqEhIRIj7dt2yYAiLfeeqvYcg2fp3PnzglHR0fxwQcfGM0/evSoqFatmtH02NhY4eTkJOrWrSt8fX3F77//Xmqezz77rFHdOHv2bLG8W7VqJby8vMSVK1ekab/++qtwcHAQQ4YMkaYZtvOoUaOkaffu3RP16tUTCoVCzJw5U5p+7do14eLiYlQ3v/76a+Hg4CB27dplFOOyZcsEALFnzx5pmpubm9FzDYYPHy7q1q0rLl++bDQ9JiZGuLu7S6+doS42bNiw2OvZsmVLER0dXcLWIno8rF3/p7Ta5ebmJoQQ4qWXXhLdunUTQghRVFQkfHx8RGJiolSjPvroI+l5hs/zg9/fYmNjhb+/v/RY7vepH3744ZGvUVXCQ/gqgdTUVHh7e+O5554DcP8wjldeeQUrVqxAUVERunbtitq1a2PlypXSc65duwaNRoNXXnlFmrZp0yY88cQTeOGFF6Rpzs7OJf7aU1Hff/89WrZsiRdffLHYvId3xxcUFCAiIgK//fYbMjIyjE76XL16Ndzd3dG9e3dcvnxZ+hcSEoLq1auXa6/ZsGHDUKdOHfj6+iI6Olo6BObB47ABYPTo0Y9c1tq1a6HX6zFt2rRi5wsY8tNoNMjPz8eAAQOMYnd0dERoaKhJ9/gRPax69eqlXtHK8Gvnjz/+CL1eX+5lu7i4SP9/8+ZNXL58Gc888wyEEDh8+HCx8Q9/pjp16mR0Bczvv/8eCoWixPM5DZ+nNWvWQK/Xo3///kafJx8fHzz55JPFPk9FRUW4fPkyPD09S9zjLdfFixeRnZ2NoUOHwtPTU5reokULdO/eHRs3biz2nBEjRkj/7+joiDZt2kAIgeHDh0vTPTw80LhxY6PtsHr1ajRt2hRNmjQxytFwuPGjaoYQAt9//z169eoFIYTRMiIjI1FQUIBffvnF6DmxsbFGr6chtpycHJw6dUrGFiIyrapeuwwGDhyIjIwM5ObmYtu2bcjNzS3x8D255H6fMmzj9evXQ6fTVXh9lQUP4bNzRUVFWLFiBZ577jnpnB0ACA0NxZw5c7B161ZERESgX79+SEtLg1arhUqlwpo1a6DT6YwaqPPnzyMwMLBYI2PKq/mdOXMG/fr1kzV27NixuHPnDg4fPoxmzZoZzTt16hQKCgrg5eVV4nMvXbokO6Zp06ahU6dOcHR0RO3atdG0adMST0598ATz0pw5cwYODg4ICgoqdYzhy4fhy8/D1Gq1zMiJyu/GjRulfm5eeeUVfPbZZxgxYgTeeecddOvWDX379sVLL70k6wICFy5cwLRp07Bu3bpix84XFBQYPTacE/CgmjVrGj3vzJkz8PX1NWpQHnbq1CkIIfDkk0+WON/JycnosYuLCz777DMMGjQI0dHR0Gg0cHNze2RuDzt//jwAoHHjxsXmNW3aFJs3b5YuNmNQv359o3Hu7u5wdnYu1si5u7vjypUr0uNTp07hxIkTxbaXwaPq3T///IP8/Hx8+umn+PTTT2Uto6R6l5SUhN69e+Opp55C8+bN0aNHDwwePFi6MhqROVX12mXQs2dP1KhRAytXrkR2djbatm2LRo0aVfgWDHK/Tz377LPo168fEhMTMW/ePHTp0gV9+vTBwIED7eKCYabGBsrObdu2DRcvXsSKFSuwYsWKYvNTU1MRERGBmJgY/Oc//8HPP/+MPn36YNWqVWjSpAlatmxphajl6d27N1asWIGZM2fiq6++MiqCer0eXl5e0sUyHlbaF42SBAcHIzw8/JHjHv41tqIMv459/fXX8PHxKTa/ql1ZiCznzz//REFBQak/iri4uGDnzp3Yvn07NmzYgE2bNmHlypXo2rUr0tPT4ejoWOqyi4qK0L17d1y9ehWTJk1CkyZN4Obmhr/++gtDhw4t9qtwWcsqD71eD4VCgZ9//rnEZZZ036eYmBhcu3YNb7zxBvr27YuffvrJIlfdKym+0raDeOA8S71ej+DgYMydO7fEsX5+fmWu17DtX331VcTGxpY45uEmqKR617lzZ5w5cwY//vgj0tPT8dlnn2HevHlYtmyZ0d41IlNj7fo/KpUKffv2xZdffok//vgDCQkJjx2HnO9TCoUC3333Hfbt24effvoJmzdvxrBhwzBnzhzs27ev1HgrK35Ts3Opqanw8vLC4sWLi81bs2YNfvjhByxbtgydO3dG3bp1sXLlSnTs2BHbtm0rdt8mf39/HD9+HEIIo71Qp0+fNlm8gYGBOHbsmKyxffr0QUREBIYOHYoaNWpg6dKlRsvZsmULOnTo8MjGxpI39Q0MDIRer8fx48dLvc+E4aRuLy8vWY0bkakY7uEWGRlZ6hgHBwd069YN3bp1w9y5c/Hhhx/ivffew/bt2xEeHl7q5+no0aP4/fff8eWXX2LIkCHS9Me5QltgYCA2b96Mq1evlvpLbmBgIIQQCAgIwFNPPSV72WPGjMHVq1cxZcoUvPrqq1ixYkW5LtPt7+8P4P4FKR7222+/oXbt2hXas1WSwMBA/Prrr+jWrdsj61lJ8+vUqYMaNWqgqKjosWuO4aqur732Gm7cuIHOnTsjISGBDRSZFWuXsYEDB+KLL76Ag4ODdCGwx4lV7vcpAGjfvj3at2+PDz74AGlpaRg0aBBWrFhR5WoAz4GyY7dv38aaNWvw/PPP46WXXir2Lz4+HtevX8e6devg4OCAl156CT/99BO+/vpr3Lt3z+jwPeB+Yfrrr7+wbt06adqdO3fw3//+12Qx9+vXD7/++it++OGHYvNECVe2GzJkCBYuXIhly5Zh0qRJ0vT+/fujqKgIM2bMKPace/fuGV3i083NzeixOfXp0wcODg5ISkoq9quVIb/IyEio1Wp8+OGHJR5H/M8//1gkVqpatm3bhhkzZiAgIACDBg0qcczVq1eLTTP8EGC4XLahKXj4M2X4BfXBz7EQAgsWLKhwzP369YMQAomJicXmGdbTt29fODo6IjExsVgNEUIYHQr3sPfeew/jxo3D6tWr8frrr5crtrp166JVq1b48ssvjbbFsWPHkJ6ejp49e5ZreWXp378//vrrrxJr8e3bt3Hz5k3pcUn1ztHREf369cP3339f4g9YcmvOw9uyevXqaNSokdGl1IlMjbWruOeeew4zZszAJ598UuKRLOUh9/vUtWvXisX58DauSrgHyo6tW7cO169fN7row4Pat2+POnXqIDU1Fa+88gpeeeUVLFq0CNOnT0dwcDCaNm1qNP7111/HJ598ggEDBuBf//oX6tatK93dGjDNnpwJEybgu+++w8svv4xhw4YhJCQEV69exbp167Bs2bISDymMj49HYWEh3nvvPbi7u+Pdd9/Fs88+i9dffx3JycnIzs5GREQEnJyccOrUKaxevRoLFiyQbo4bEhKCpUuX4v3330ejRo3g5eVV6vlHj6tRo0Z47733MGPGDHTq1Al9+/aFSqXCwYMH4evri+TkZKjVaixduhSDBw/G008/jZiYGNSpUwcXLlzAhg0b0KFDB3zyySdmiY+qhp9//hm//fYb7t27h7y8PGzbtg0ajQb+/v5Yt25dqTdWTEpKws6dOxEdHQ1/f39cunQJS5YsQb169aR7nwUGBsLDwwPLli1DjRo14ObmhtDQUDRp0gSBgYF4++238ddff0GtVuP7778vdj5BeTz33HMYPHgwFi5ciFOnTqFHjx7Q6/XYtWsXnnvuOcTHxyMwMBDvv/8+Jk+ejHPnzqFPnz6oUaMGzp49ix9++AGjRo0yutfdw+bMmYNr167hs88+g6enJ2bNmiU7vo8++ghRUVEICwvD8OHDpcuYu7u7P/ZhNQ8aPHgwVq1ahdGjR2P79u3o0KEDioqK8Ntvv2HVqlXYvHmzdNGbkJAQbNmyBXPnzoWvry8CAgIQGhqKmTNnYvv27QgNDcXIkSMRFBSEq1ev4pdffsGWLVtK/AL6sKCgIHTp0gUhISHw9PTEoUOH8N133yE+Pt5kuVLVxtolr3Y5ODhgypQpFY7vQXK/T3355ZdYsmQJXnzxRQQGBuL69ev473//C7VabdIfjOyGpS73R6bXq1cv4ezsLG7evFnqmKFDhwonJydx+fJlodfrhZ+fnwAg3n///RLH//HHHyI6Olq4uLiIOnXqiH//+9/i+++/FwDEvn37SnxOeS5jLoQQV65cEfHx8eKJJ54QSqVS1KtXT8TGxkqX133wMuYPmjhxogAgPvnkE2nap59+KkJCQoSLi4uoUaOGCA4OFhMnThR///23NCY3N1dER0eLGjVqCABSrKWt52GGy6WWdHnUhy+lavDFF1+I1q1bC5VKJWrWrCmeffZZ6TLzBtu3bxeRkZHC3d1dODs7i8DAQDF06FBx6NChMuMhKo3hUsCGf0qlUvj4+Iju3buLBQsWiMLCQqPxD79/t27dKnr37i18fX2FUqkUvr6+YsCAAcUu9/3jjz+KoKAgUa1aNaPLAh8/flyEh4eL6tWri9q1a4uRI0eKX3/9tdilgx+8JG9Z8Qhx/3LfH330kWjSpIlQKpWiTp06IioqSmRlZRmN+/7770XHjh2Fm5ubcHNzE02aNBFxcXHi5MmTj1zvvXv3RJ8+fQQAkZycLISQdxlzIYTYsmWL6NChg3BxcRFqtVr06tVLHD9+vMS8Hq4hpcXz7LPPimbNmhlNu3v3rpg1a5Zo1qyZVFdCQkJEYmKiKCgokMb99ttvonPnzsLFxUUAMKq/eXl5Ii4uTvj5+QknJyfh4+MjunXrJj799FNpTFl18f333xft2rUTHh4ewsXFRTRp0kR88MEH4u7du8XGEpUHa1fFateDKnoZc4NHfZ/65ZdfxIABA0T9+vWFSqUSXl5e4vnnn6+y31kUQpRxR1AiAPPnz8e4cePw559/4oknnrB2OEREREREVsMGiozcvn3b6CTCO3fuoHXr1igqKsLvv/9uxciIiIiIiKyP50CRkb59+6J+/fpo1aoVCgoK8M033+C3334r9fKWRERERERVCRsoMhIZGYnPPvsMqampKCoqQlBQEFasWFHsin1ERERERFURD+EjIiIiIiKSifeBIiIiIiIikokNFBERERERkUxV+hwovV6Pv//+GzVq1DDJTWKJ6D4hBK5fvw5fX184OFS932lYW4jMh/WF9YXIXOTWlyrdQP3999/w8/OzdhhEldb//vc/1KtXz9phWBxrC5H5sb4Qkbk8qr5U6QaqRo0aAO5vJLVabeVoAJ1Oh/T0dERERMDJycna4chibzHbW7yA/cWs0+mwdu1ajBgxQvqMVTVya4u9vbYlqQw5AJUjj6qSQ2FhIfz8/FhfqkB9sRZuu8djz9tPbn2p0g2UYde3Wq22mQbK1dUVarXabt5w9hazvcUL2F/MhngBVNnDS+TWFnt7bUtSGXIAKkceVS0H1pfKX1+shdvu8VSG7feo+lL1Dh4mIru1dOlStGjRQvriEBYWhp9//lmaf+fOHcTFxaFWrVqoXr06+vXrh7y8PKNlXLhwAdHR0XB1dYWXlxcmTJiAe/fuGY3JyMjA008/DZVKhUaNGiElJcUS6RGRFbG+EJFcbKCIyG7Uq1cPM2fORFZWFg4dOoSuXbuid+/eyMnJAQCMGzcOP/30E1avXo0dO3bg77//Rt++faXnFxUVITo6Gnfv3sXevXvx5ZdfIiUlBdOmTZPGnD17FtHR0XjuueeQnZ2NsWPHYsSIEdi8ebPF8yUiy2F9ISK5qvQhfERkX3r16mX0+IMPPsDSpUuxb98+1KtXD59//jnS0tLQtWtXAMDy5cvRtGlT7Nu3D+3bt0d6ejqOHz+OLVu2wNvbG61atcKMGTMwadIkJCQkQKlUYtmyZQgICMCcOXMAAE2bNsXu3bsxb948REZGWjxnIrIM1hcikosNFBHZpaKiIqxevRo3b95EWFgYsrKyoNPpEB4eLo1p0qQJ6tevj8zMTLRv3x6ZmZkIDg6Gt7e3NCYyMhJjxoxBTk4OWrdujczMTKNlGMaMHTu21Fi0Wi20Wq30uLCwEMD948B1Ol2pzzPMK2uMrasMOQCVI4+qkoMl8mN9qdq47R6PPW8/uTGzgSIiu3L06FGEhYXhzp07qF69On744QcEBQUhOzsbSqUSHh4eRuO9vb2Rm5sLAMjNzTX6cmOYb5hX1pjCwkLcvn0bLi4uxWJKTk5GYmJisenp6enSBTXKotFoHjnG1lWGHIDKkUdlz+HWrVtmWy/rCz2I2+7x2OP2k1tf2EARkV1p3LgxsrOzUVBQgO+++w6xsbHYsWOHVWOaPHkyxo8fLz02XAY1IiLikVfJ0mg06N69u91eqagy5ABUjjyqSg6GPTDmwPpCALfd47Ln7Se3vrCBIiK7olQq0ahRIwBASEgIDh48iAULFuCVV17B3bt3kZ+fb/QrcV5eHnx8fAAAPj4+OHDggNHyDFfRenDMw1fWysvLg1qtLvHXYQBQqVRQqVTFpjs5Ocn64yF3nC2rDDkAlSOPyp6DOXNjfaEHcds9HnvcfnLjZQNFVVaDdzaYbFnnZkabbFlUPnq9HlqtFiEhIXBycsLWrVvRr18/AMDJkydx4cIFhIWFAQDCwsLwwQcf4NKlS/Dy8gJw/xADtVqNoKAgaczGjRuN1qHRaKRlmEPzhM3QFpnmnjZ8LxKZDuuLMdYXovvYQBGR3Zg8eTKioqJQv359XL9+HWlpacjIyMDmzZvh7u6O4cOHY/z48fD09IRarcabb76JsLAwtG/fHgAQERGBoKAgDB48GLNnz0Zubi6mTJmCuLg46Rfe0aNH45NPPsHEiRMxbNgwbNu2DatWrcKGDaZruInI9rC+EJFcbKCIyG5cunQJQ4YMwcWLF+Hu7o4WLVpg8+bN6N69OwBg3rx5cHBwQL9+/aDVahEZGYklS5ZIz3d0dMT69esxZswYhIWFwc3NDbGxsUhKSpLGBAQEYMOGDRg3bhwWLFiAevXq4bPPPuMlhm2QKfcin5oRYbJlkX1ifSGD5gmbMbud6fbecc9d5cMGiojsxueff17mfGdnZyxevBiLFy8udYy/v3+xQ2ge1qVLFxw+fLhCMRKRfWJ9ISK5HKwdABERERERkb3gHiiyG6Y4XEflKKTd8oBpTqolIiIioqqDe6CIiIiIiIhkYgNFREREREQkExsoIiIiIiIimdhAERERERERycQGioiIiIiISCY2UERERERERDKxgSIiIiIiIpKJDRQREREREZFMbKCIiIiIiIhkqmbtAIgqgwbvbDDp8s7NjDbp8oiIiIjINLgHioiIiIiISCY2UERERERERDLxED4yK1Mf2kZEREREZE3cA0VERERERCQTGygiIiIiIiKZeAgfERFZBA/pJSJzMWV9UTmabFFUSXEPFBERERERkUxsoIiIiIiIiGRiA0VERERERCQTGygiIiIiIiKZ2EARERERERHJxAaKiOxGcnIy2rZtixo1asDLywt9+vTByZMnjcZ06dIFCoXC6N/o0aONxly4cAHR0dFwdXWFl5cXJkyYgHv37hmNycjIwNNPPw2VSoVGjRohJSXF3OkRkRWxvhCRXGygiMhu7NixA3Fxcdi3bx80Gg10Oh0iIiJw8+ZNo3EjR47ExYsXpX+zZ8+W5hUVFSE6Ohp3797F3r178eWXXyIlJQXTpk2Txpw9exbR0dF47rnnkJ2djbFjx2LEiBHYvHmzxXIlIstifSEiuXgfKCKyG5s2bTJ6nJKSAi8vL2RlZaFz587SdFdXV/j4+JS4jPT0dBw/fhxbtmyBt7c3WrVqhRkzZmDSpElISEiAUqnEsmXLEBAQgDlz5gAAmjZtit27d2PevHmIjIw0X4JEZDWsL0Qkl8n3QO3cuRO9evWCr68vFAoF1q5dazR/6NChxXZ/9+jRw2jM1atXMWjQIKjVanh4eGD48OG4ceOG0ZgjR46gU6dOcHZ2hp+fn9EvQERUNRQUFAAAPD09jaanpqaidu3aaN68OSZPnoxbt25J8zIzMxEcHAxvb29pWmRkJAoLC5GTkyONCQ8PN1pmZGQkMjMzzZUKEdkY1hciKo3J90DdvHkTLVu2xLBhw9C3b98Sx/To0QPLly+XHqtUKqP5gwYNwsWLF6Vd6K+99hpGjRqFtLQ0AEBhYSEiIiIQHh6OZcuW4ejRoxg2bBg8PDwwatQoU6dUpZT3Tt4qR4HZ7YDmCZuhLVKYKSqi4vR6PcaOHYsOHTqgefPm0vSBAwfC398fvr6+OHLkCCZNmoSTJ09izZo1AIDc3FyjLzcApMe5ublljiksLMTt27fh4uJiNE+r1UKr1UqPCwsLAQA6nQ46na7UHAzzVA6iXLmXpaz1mYNhfXLWq3I0XZ6mVp48bFVVycES+bG+lL1MW2TK+mLYZqbadra83czBnmuR3JhN3kBFRUUhKiqqzDEqlarU3d8nTpzApk2bcPDgQbRp0wYAsGjRIvTs2RMff/wxfH19kZqairt37+KLL76AUqlEs2bNkJ2djblz57KBIqoi4uLicOzYMezevdto+oM1IDg4GHXr1kW3bt1w5swZBAYGmiWW5ORkJCYmFpuenp4OV1fXRz5/Rhu9yWLZuHGjyZZVHhqN5pFjZrezQCAVZIhfTh62rrLn8OAeH3NhfSmZteqLHOaoL6badra83czJHmuR3PpilXOgMjIy4OXlhZo1a6Jr1654//33UatWLQD3d217eHhIzRMAhIeHw8HBAfv378eLL76IzMxMdO7cGUqlUhoTGRmJWbNm4dq1a6hZs6bFcyIiy4mPj8f69euxc+dO1KtXr8yxoaGhAIDTp08jMDAQPj4+OHDggNGYvLw8AJB+2PHx8ZGmPThGrVYX+3UYACZPnozx48dLjwsLC+Hn54eIiAio1epSY9PpdNBoNJh6yAFavWn24B5LsOw5FIYcunfvDicnpzLHNk+w3ZPkD7/XVXYetqo8r4WtkpODYQ+MubC+lM7S9aU8TFlfVA4CM9roTbbtbHm7mYM91yK59cXiDVSPHj3Qt29fBAQE4MyZM3j33XcRFRWFzMxMODo6Ijc3F15eXsZBVqsGT09Po93fAQEBRmMe3EVeWgNV0d3glmILuzzLuwvc1Lu5zc1e4n3wPWAL74vyMGecQgi8+eab+OGHH5CRkVGsDpQkOzsbAFC3bl0AQFhYGD744ANcunRJqjUajQZqtRpBQUHSmId/MdRoNAgLCytxHSqVqtihyADg5OQk64+HVq8w2SGw1vpjJSdXWz7M1xC73NfMllX2HMyVG+vLo9ny+8oc9cVU286Wt5s52WMtkhuvxRuomJgY6f+Dg4PRokULBAYGIiMjA926dTPruh93N7ilWHOXZ0V3gZvyEAFLsPV4S9rdb4+7wk0tLi4OaWlp+PHHH1GjRg3pRxV3d3e4uLjgzJkzSEtLQ8+ePVGrVi0cOXIE48aNQ+fOndGiRQsAQEREBIKCgjB48GDMnj0bubm5mDJlCuLi4qQvKaNHj8Ynn3yCiRMnYtiwYdi2bRtWrVqFDRvKd44gEdkP1hciksvqlzFv2LAhateujdOnT6Nbt27w8fHBpUuXjMbcu3cPV69efeTub8O80lR0N7il2MIuz/LuAjf1bm5zs5d4H9zdbwvvi/LQ6XT48ccfzbLspUuXArh/M8sHLV++HEOHDoVSqcSWLVswf/583Lx5E35+fujXrx+mTJkijXV0dMT69esxZswYhIWFwc3NDbGxsUhKSpLGBAQEYMOGDRg3bhwWLFiAevXq4bPPPuMlhokqMdYXIpLL6g3Un3/+iStXrhjt/s7Pz0dWVhZCQkIAANu2bYNer5eONQ4LC8N7770HnU4nfaHUaDRo3Lhxmec/Pe5ucEuxZjwV3VVtykMELMHW4y3p9be196k1CFH2oZd+fn7YsWPHI5fj7+//yJN6u3TpgsOHD5crPiKyX6wvRCSXye8DdePGDWRnZ0vHBZ89exbZ2dm4cOECbty4gQkTJmDfvn04d+4ctm7dit69e6NRo0bSLy9NmzZFjx49MHLkSBw4cAB79uxBfHw8YmJi4OvrC+D+ZUSVSiWGDx+OnJwcrFy5EgsWLDDau0RERERERGRqJm+gDh06hNatW6N169YAgPHjx6N169aYNm0aHB0dceTIEbzwwgt46qmnMHz4cISEhGDXrl1Ge4ZSU1PRpEkTdOvWDT179kTHjh3x6aefSvPd3d2Rnp6Os2fPIiQkBP/+978xbdo0XsKciIiIiIjMyuSH8HXp0qXM3eCbNz/6HBtPT0/pprmladGiBXbt2lXu+IiIiIiIiCrK5HugiIiIiIiIKis2UERERERERDJZ/Sp89PgavMN7RxARERERWQL3QBEREREREcnEBoqIiIiIiEgmNlBEREREREQysYEiIiIiIiKSiQ0UERERERGRTGygiIiIiIiIZGIDRUREREREJBMbKCIiIiIiIpnYQBEREREREcnEBoqIiIiIiEgmNlBEREREREQysYEiIiIiIiKSiQ0UERERERGRTGygiIiIiIiIZGIDRUREREREJBMbKCIiIiIiIpnYQBEREREREcnEBoqIiIiIiEgmNlBEZDeSk5PRtm1b1KhRA15eXujTpw9OnjxpNObOnTuIi4tDrVq1UL16dfTr1w95eXlGYy5cuIDo6Gi4urrCy8sLEyZMwL1794zGZGRk4Omnn4ZKpUKjRo2QkpJi7vSIyIpYX4hIrmrWDqAqavDOhhKnqxwFZrcDmidshrZIYeGoiGzfjh07EBcXh7Zt2+LevXt49913ERERgePHj8PNzQ0AMG7cOGzYsAGrV6+Gu7s74uPj0bdvX+zZswcAUFRUhOjoaPj4+GDv3r24ePEihgwZAicnJ3z44YcAgLNnzyI6OhqjR49Gamoqtm7dihEjRqBu3bqIjIy0Wv5EZD6sL0QkFxsoIrIbmzZtMnqckpICLy8vZGVloXPnzigoKMDnn3+OtLQ0dO3aFQCwfPlyNG3aFPv27UP79u2Rnp6O48ePY8uWLfD29karVq0wY8YMTJo0CQkJCVAqlVi2bBkCAgIwZ84cAEDTpk2xe/duzJs3j19wiCop1hcikosNFBHZrYKCAgCAp6cnACArKws6nQ7h4eHSmCZNmqB+/frIzMxE+/btkZmZieDgYHh7e0tjIiMjMWbMGOTk5KB169bIzMw0WoZhzNixY0uMQ6vVQqvVSo8LCwsBADqdDjqdrtT4DfNUDqIcWZetrPWZg2F9ctarcjRdnqZWnjxsVVXJwVL5sb6UvkxbZMr6Ythmptp2trzdzMGea5HcmNlAEZFd0uv1GDt2LDp06IDmzZsDAHJzc6FUKuHh4WE01tvbG7m5udKYB7/cGOYb5pU1prCwELdv34aLi4vRvOTkZCQmJhaLMT09Ha6uro/MZUYb/SPHyLVx40aTLas8NBrNI8fMbmeBQCrIEL+cPGxdZc/h1q1bZl8/60vJrFVf5DBHfTHVtrPl7WZO9liL5NYXNlBEZJfi4uJw7Ngx7N6929qhYPLkyRg/frz0uLCwEH5+foiIiIBarS71eTqdDhqNBlMPOUCrN815j8cSLHsIkCGH7t27w8nJqcyxzRM2Wyiq8jv8XlfZediq8rwWtkpODoY9MObE+lIyS9eX8jBlfVE5CMxoozfZtrPl7WYO9lyL5NYXNlBEZHfi4+Oxfv167Ny5E/Xq1ZOm+/j44O7du8jPzzf6lTgvLw8+Pj7SmAMHDhgtz3AVrQfHPHxlrby8PKjV6mK/DgOASqWCSqUqNt3JyUnWHw+tXmGyC8dY64+VnFxt+eI4htjlvma2rLLnYO7cWF9KZ8vvK3PUF1NtO1vebuZkj7VIbry8jDkR2Q0hBOLj4/HDDz9g27ZtCAgIMJofEhICJycnbN26VZp28uRJXLhwAWFhYQCAsLAwHD16FJcuXZLGaDQaqNVqBAUFSWMeXIZhjGEZRFT5sL4QkVzcA0VEdiMuLg5paWn48ccfUaNGDemcAnd3d7i4uMDd3R3Dhw/H+PHj4enpCbVajTfffBNhYWFo3749ACAiIgJBQUEYPHgwZs+ejdzcXEyZMgVxcXHSr7yjR4/GJ598gokTJ2LYsGHYtm0bVq1ahQ0bSr4FARHZP9YXIpKLe6CIyG4sXboUBQUF6NKlC+rWrSv9W7lypTRm3rx5eP7559GvXz907twZPj4+WLNmjTTf0dER69evh6OjI8LCwvDqq69iyJAhSEpKksYEBARgw4YN0Gg0aNmyJebMmYPPPvuMlxgmqsRYX4hILu6BIiK7IcSjLynr7OyMxYsXY/HixaWO8ff3f+RVkbp06YLDhw+XO0Yisk+sL0QkF/dAERERERERycQGioiIiIiISCY2UERERERERDKxgSIiIiIiIpKJDRQREREREZFMbKCIiIiIiIhkYgNFREREREQkExsoIiIiIiIimdhAERERERERycQGioiIiIiISCY2UERERERERDKxgSIiIiIiIpKJDRQREREREZFMbKCIiIiIiIhkMnkDtXPnTvTq1Qu+vr5QKBRYu3at0XwhBKZNm4a6devCxcUF4eHhOHXqlNGYq1evYtCgQVCr1fDw8MDw4cNx48YNozFHjhxBp06d4OzsDD8/P8yePdvUqRARERERERkxeQN18+ZNtGzZEosXLy5x/uzZs7Fw4UIsW7YM+/fvh5ubGyIjI3Hnzh1pzKBBg5CTkwONRoP169dj586dGDVqlDS/sLAQERER8Pf3R1ZWFj766CMkJCTg008/NXU6REREREREkmqmXmBUVBSioqJKnCeEwPz58zFlyhT07t0bAPDVV1/B29sba9euRUxMDE6cOIFNmzbh4MGDaNOmDQBg0aJF6NmzJz7++GP4+voiNTUVd+/exRdffAGlUolmzZohOzsbc+fONWq0iIiIiIiITMnkDVRZzp49i9zcXISHh0vT3N3dERoaiszMTMTExCAzMxMeHh5S8wQA4eHhcHBwwP79+/Hiiy8iMzMTnTt3hlKplMZERkZi1qxZuHbtGmrWrFni+rVaLbRarfS4sLAQAKDT6aDT6UydbqlUjqLk6Q7C6L/2wN5itpd4H3w/Gv7fku/Rx2EvcRIRERFVhEUbqNzcXACAt7e30XRvb29pXm5uLry8vIzmV6tWDZ6enkZjAgICii3DMK+0Bio5ORmJiYnFpqenp8PV1bUCGVXM7HZlz5/RRm+ZQEzI3mK29Xg3btxYbJpGo7FCJERERET0IIs2UNY2efJkjB8/XnpcWFgIPz8/REREQK1WWyyO5gmbS5yuchCY0UaPqYccoNUrLBbP47C3mO0l3mMJkdL/63Q6aDQadO/eHU5OTlaMSh6dTocff/zR2mEQERERmYVFGygfHx8AQF5eHurWrStNz8vLQ6tWraQxly5dMnrevXv3cPXqVen5Pj4+yMvLMxpjeGwYUxKVSgWVSlVsupOTk0W/mGqLyv7irtUrHjnG1thbzLYeb0nvR0u/T4mIiIioOIveByogIAA+Pj7YunWrNK2wsBD79+9HWFgYACAsLAz5+fnIysqSxmzbtg16vR6hoaHSmJ07dxqda6HRaNC4ceNSD98jIiIiIiJ6XCZvoG7cuIHs7GxkZ2cDuH/hiOzsbFy4cAEKhQJjx47F+++/j3Xr1uHo0aMYMmQIfH190adPHwBA06ZN0aNHD4wcORIHDhzAnj17EB8fj5iYGPj6+gIABg4cCKVSieHDhyMnJwcrV67EggULjA7PIyIiIiIiMjWTN1CHDh1C69at0bp1awDA+PHj0bp1a0ybNg0AMHHiRLz55psYNWoU2rZtixs3bmDTpk1wdnaWlpGamoomTZqgW7du6NmzJzp27Gh0jyd3d3ekp6fj7NmzCAkJwb///W9MmzaNlzAnquQedaPuoUOHQqFQGP3r0aOH0RjeqJuISsL6QkRymfwcqC5dukCI0i8RrVAokJSUhKSkpFLHeHp6Ii0trcz1tGjRArt27apwnERkfww36h42bBj69u1b4pgePXpg+fLl0uOHz3scNGgQLl68CI1GA51Oh9deew2jRo2Sao7hRt3h4eFYtmwZjh49imHDhsHDw4M/0hBVYqwvRCRXlboKHxHZt7Ju1G2gUqlKvZgMb9RNRKVhfSEiuSx6EQkiInPLyMiAl5cXGjdujDFjxuDKlSvSvEfdqNswpqQbdZ88eRLXrl2zXCJEZHNYX4gI4B4oIqpEevTogb59+yIgIABnzpzBu+++i6ioKGRmZsLR0dFsN+rWarXQarXS48LCQgD374n14NVCH2aYp3Io/bDn8iprfeZgWJ+c9aocTZenqZUnD1tVVXKwVn6sL7b93jJlfTFsM1NtO1vebuZgz7VIbsxsoIio0oiJiZH+Pzg4GC1atEBgYCAyMjLQrVs3s603OTkZiYmJxaanp6fD1dX1kc+f0UZvslg2btxosmWVh0ajeeSY2e0sEEgFGeKXk4etq+w53Lp1y4KR/B/WF+vVFznMUV9Mte1sebuZkz3WIrn1hQ0UEVVaDRs2RO3atXH69Gl069bNbDfqnjx5stFtFAoLC+Hn54eIiAio1epS49PpdNBoNJh6yAFavWlu7HwsIdIky5HLkEP37t0feaPn5gmbLRRV+R1+r6vsPGxVeV4LWyUnB8MeGGtjfbEtpqwvKgeBGW30Jtt2trzdzMGea5Hc+sIGiogqrT///BNXrlxB3bp1ARjfqDskJARAyTfqfu+996DT6aTC/6gbdatUqmJX4wIAJycnWX88tHoFtEWm+YJjrT9WcnI1VY7mYIhd7mtmyyp7DraSG+uLbTFHfTHVtrPl7WZO9liL5MbLi0gQkd0o60bdN27cwIQJE7Bv3z6cO3cOW7duRe/evdGoUSNERt7/9Y836iai0rC+EJFcbKCIyG6UdaNuR0dHHDlyBC+88AKeeuopDB8+HCEhIdi1a5fRr7e8UTcRlYT1hYjk4iF8RGQ3HnWj7s2bH30MPG/UTUQlYX0hIrm4B4qIiIiIiEgmNlBEREREREQysYEiIiIiIiKSiQ0UERERERGRTLyIhAwN3tlg7RCIiIiIiMgGcA8UERERERGRTNwDRUREVV7zhM2Y3e7+f7VFisde3rmZ0SaIiogqA1MfycT6Yn3cA0VERERERCQTGygiIiIiIiKZ2EARERERERHJxAaKiIiIiIhIJjZQREREREREMrGBIiIiIiIikokNFBERERERkUxsoIiIiIiIiGRiA0VERERERCRTNWsHQETFPXjXcpWjwOx2QPOEzdAWKSq0PN61nIiIiMg0uAeKiIiIiIhIJjZQREREREREMrGBIiIiIiIikokNFBERERERkUxsoIiIiIiIiGRiA0VERERERCQTGygiIiIiIiKZ2EARkd3YuXMnevXqBV9fXygUCqxdu9ZovhAC06ZNQ926deHi4oLw8HCcOnXKaMzVq1cxaNAgqNVqeHh4YPjw4bhx44bRmCNHjqBTp05wdnaGn58fZs+ebe7UiMjKWF+ISC42UERkN27evImWLVti8eLFJc6fPXs2Fi5ciGXLlmH//v1wc3NDZGQk7ty5I40ZNGgQcnJyoNFosH79euzcuROjRo2S5hcWFiIiIgL+/v7IysrCRx99hISEBHz66admz4+IrIf1hYjkqmbtAIiI5IqKikJUVFSJ84QQmD9/PqZMmYLevXsDAL766it4e3tj7dq1iImJwYkTJ7Bp0yYcPHgQbdq0AQAsWrQIPXv2xMcffwxfX1+kpqbi7t27+OKLL6BUKtGsWTNkZ2dj7ty5Rl+EiKhyYX0hIrnYQBFRpXD27Fnk5uYiPDxcmubu7o7Q0FBkZmYiJiYGmZmZ8PDwkL7cAEB4eDgcHBywf/9+vPjii8jMzETnzp2hVCqlMZGRkZg1axauXbuGmjVrFlu3VquFVquVHhcWFgIAdDoddDpdqTEb5qkcRMUTL2WZlmJYn5z1qhxNl6epGV4DU70Wln4dHlynNdZtKnJysEZ+rC/Gy7RFpqwvpq4HpmbLrwNg37VIbsxsoIioUsjNzQUAeHt7G0339vaW5uXm5sLLy8tofrVq1eDp6Wk0JiAgoNgyDPNK+oKTnJyMxMTEYtPT09Ph6ur6yNhntNE/coxcGzduNNmyykOj0TxyzOx2FgjkMZnqtbDW6wDIey1sXVk53Lp1y4KR3Mf6cp8139ePYo76YsptZ0q2/Do8yB5rkdz6wgaKiOgxTZ48GePHj5ceFxYWws/PDxEREVCr1aU+T6fTQaPRYOohB2j1CpPEciwh0iTLkcuQQ/fu3eHk5FTm2OYJmy0UVfmpHARmtNGb7LWw9OsAlO+1sFVycjDsgakqqnJ9KQ9T1hdT1wNTs+XXAbDvWiS3vrCBIqJKwcfHBwCQl5eHunXrStPz8vLQqlUracylS5eMnnfv3j1cvXpVer6Pjw/y8vKMxhgeG8Y8TKVSQaVSFZvu5OQk64+HVq+Atsg0f6St9cdKTq6mytGcTPVaWPNLg9z3nS0rKwdr5Mb68n/rtFXmqC+m3HamZMuvw4PssRbJjZdX4SOiSiEgIAA+Pj7YunWrNK2wsBD79+9HWFgYACAsLAz5+fnIysqSxmzbtg16vR6hoaHSmJ07dxodB63RaNC4ceMSD68hosqP9YWIHsQGiojsxo0bN5CdnY3s7GwA90/szs7OxoULF6BQKDB27Fi8//77WLduHY4ePYohQ4bA19cXffr0AQA0bdoUPXr0wMiRI3HgwAHs2bMH8fHxiImJga+vLwBg4MCBUCqVGD58OHJycrBy5UosWLDA6BAaIqp8WF+ISC4ewkdEduPQoUN47rnnpMeGLx2xsbFISUnBxIkTcfPmTYwaNQr5+fno2LEjNm3aBGdnZ+k5qampiI+PR7du3eDg4IB+/fph4cKF0nx3d3ekp6cjLi4OISEhqF27NqZNm8ZLDBNVcqwvRCQXGygishtdunSBEKVfVlahUCApKQlJSUmljvH09ERaWlqZ62nRogV27dpV4TiJyP6wvhCRXDyEj4iIiIiISCarNFAJCQlQKBRG/5o0aSLNv3PnDuLi4lCrVi1Ur14d/fr1K3bVmgsXLiA6Ohqurq7w8vLChAkTcO/ePUunQkREREREVYjVDuFr1qwZtmzZ8n+BVPu/UMaNG4cNGzZg9erVcHd3R3x8PPr27Ys9e/YAAIqKihAdHQ0fHx/s3bsXFy9exJAhQ+Dk5IQPP/zQ4rkQEREREVHVYLUGqlq1aiXe86CgoACff/450tLS0LVrVwDA8uXL0bRpU+zbtw/t27dHeno6jh8/ji1btsDb2xutWrXCjBkzMGnSJCQkJECpVFo6HSIiIiIiqgKsdg7UqVOn4Ovri4YNG2LQoEG4cOECACArKws6nQ7h4eHS2CZNmqB+/frIzMwEAGRmZiI4OBje3t7SmMjISBQWFiInJ8eyiRARERERUZVhlT1QoaGhSElJQePGjXHx4kUkJiaiU6dOOHbsGHJzc6FUKuHh4WH0HG9vb+Tm5gIAcnNzjZonw3zDvNJotVpotVrpcWFhIQBAp9MZ3dTuYSrH0q/KY0oqB2H0X3tgbzHbW7yAaWIu6/1tapZcFxEREZGlWaWBioqKkv6/RYsWCA0Nhb+/P1atWgUXFxezrTc5ORmJiYnFpqenp8PV1bXU581uZ7aQSjSjjd6yKzQBe4vZ3uIFHi/mjRs3mjASIiIioqrLJu4D5eHhgaeeegqnT59G9+7dcffuXeTn5xvthcrLy5POmfLx8cGBAweMlmG4Sl9J51UZTJ482ehu34WFhfDz80NERATUanWpz2uesLkiaZWbykFgRhs9ph5ygFavsMg6H5e9xWxv8QKmiflYQqSJoyqdTqfDjz/+aLH1EREREVmSTTRQN27cwJkzZzB48GCEhITAyckJW7duRb9+/QAAJ0+exIULFxAWFgYACAsLwwcffIBLly7By8sLAKDRaKBWqxEUFFTqelQqFVQqVbHpTk5OcHJyKvV52iLLftHW6hUWX+fjsreY7S1e4PFiLuv9TURERETyWaWBevvtt9GrVy/4+/vj77//xvTp0+Ho6IgBAwbA3d0dw4cPx/jx4+Hp6Qm1Wo0333wTYWFhaN++PQAgIiICQUFBGDx4MGbPno3c3FxMmTIFcXFxJTZIRERVRYN3NphsWedmRptsWURk/1hfiO6zSgP1559/YsCAAbhy5Qrq1KmDjh07Yt++fahTpw4AYN68eXBwcEC/fv2g1WoRGRmJJUuWSM93dHTE+vXrMWbMGISFhcHNzQ2xsbFISkqyRjpERERERFRFWKWBWrFiRZnznZ2dsXjxYixevLjUMf7+/jwxnoiIiIiILMpq94EiIiIiIiKyNzZxEQkiIrI9cs53UDkKzG53/2ql9nZhFiKyHlOeT0VkaWygiKoAnvhLREREZBo8hI+IiIiIiEgmNlBEREREREQysYEiIiIiIiKSiedAERERmRjPOyQic2F9sT7ugSIiIiIiIpKJDRQREREREZFMbKCIiIiIiIhkYgNFREREREQkExsoIqpUEhISoFAojP41adJEmn/nzh3ExcWhVq1aqF69Ovr164e8vDyjZVy4cAHR0dFwdXWFl5cXJkyYgHv37lk6FSKyIawtRGTAq/ARUaXTrFkzbNmyRXpcrdr/lbpx48Zhw4YNWL16Ndzd3REfH4++fftiz549AICioiJER0fDx8cHe/fuxcWLFzFkyBA4OTnhww8/tHguRGQ7WFuICGADRUSVULVq1eDj41NsekFBAT7//HOkpaWha9euAIDly5ejadOm2LdvH9q3b4/09HQcP34cW7Zsgbe3N1q1aoUZM2Zg0qRJSEhIgFKptHQ6RGQjWFuICGADRUSV0KlTp+Dr6wtnZ2eEhYUhOTkZ9evXR1ZWFnQ6HcLDw6WxTZo0Qf369ZGZmYn27dsjMzMTwcHB8Pb2lsZERkZizJgxyMnJQevWra2RElVhcu/5onIUmN0OaJ6wGdoiRanjeN+XimNtocrGlPeUAqpOfWEDRUSVSmhoKFJSUtC4cWNcvHgRiYmJ6NSpE44dO4bc3FwolUp4eHgYPcfb2xu5ubkAgNzcXKMvOIb5hnkl0Wq10Gq10uPCwkIAgE6ng06nKzVWwzyVgyhfkjbEELs95wBUjjzk5lDWe9LaDLHJ+dxYmjVqC1C164u1VIZ6YC0Pvi9tudaURm7MbKCIqFKJioqS/r9FixYIDQ2Fv78/Vq1aBRcXF7OsMzk5GYmJicWmp6enw9XV9ZHPn9FGb46wLKoy5ABUjjwelcPGjRstFEnFaTSaUufdunXLgpH8H2vUFoD1xZq47crvwfpS1ufYVsmtL2ygiKhS8/DwwFNPPYXTp0+je/fuuHv3LvLz841+Kc7Ly5POa/Dx8cGBAweMlmG4klZJ5z4AwOTJkzF+/HjpcWFhIfz8/BAREQG1Wl1qbDqdDhqNBlMPOUCrL/2QK1umchCY0UZv1zkAlSMPuTkcS4i0YFTlY/hMdO/eHU5OTiWOMeyBsTZL1BagatcXa6kM9cBajiVEyvoc2yq59YUNFBFVajdu3MCZM2cwePBghISEwMnJCVu3bkW/fv0AACdPnsSFCxcQFhYGAAgLC8MHH3yAS5cuwcvLC8D9X9HUajWCgoJKXIdKpYJKpSo23cnJSdYfD61eUeY5K/agMuQAVI48HpWDPXyhKeuzYyvxW6K2AKwv1sRtV34Pviflvkdtidx42UARUaXy9ttvo1evXvD398fff/+N6dOnw9HREQMGDIC7uzuGDx+O8ePHw9PTE2q1Gm+++SbCwsLQvn17AEBERASCgoIwePBgzJ49G7m5uZgyZQri4uJK/BJDRFUDawsRGbCBIqJK5c8//8SAAQNw5coV1KlTBx07dsS+fftQp04dAMC8efPg4OCAfv36QavVIjIyEkuWLJGe7+joiPXr12PMmDEICwuDm5sbYmNjkZSUZK2UiMgGsLYQkQEbKCKqVFasWFHmfGdnZyxevBiLFy8udYy/v79dnGhPVBGmvGxxVblkMcDaQiRHg3c2yL6lwqPYcn1xsHYARERERERE9oINFBERERERkUxsoIiIiIiIiGRiA0VERERERCQTGygiIiIiIiKZ2EARERERERHJxAaKiIiIiIhIJjZQREREREREMrGBIiIiIiIikokNFBERERERkUxsoIiIiIiIiGRiA0VERERERCQTGygiIiIiIiKZ2EARERERERHJxAaKiIiIiIhIJjZQREREREREMrGBIiIiIiIikokNFBERERERkUxsoIiIiIiIiGRiA0VERERERCQTGygiIiIiIiKZqlk7ACIiIrJPDd7ZYNLlnZoRYdLlEZH9MnV9OTcz2mTL4h4oIiIiIiIimdhAERERERERyWT3DdTixYvRoEEDODs7IzQ0FAcOHLB2SERUSbC+EJG5sL4Q2S+7bqBWrlyJ8ePHY/r06fjll1/QsmVLREZG4tKlS9YOjYjsHOsLEZkL6wuRfbPrBmru3LkYOXIkXnvtNQQFBWHZsmVwdXXFF198Ye3QiMjOsb4QkbmwvhDZN7u9Ct/du3eRlZWFyZMnS9McHBwQHh6OzMzMEp+j1Wqh1WqlxwUFBQCAq1evQqfTlbquavdumijqslXTC9y6pUc1nQOK9AqLrPNx2VvM9hYvYHsxX7lypcz5Op0Ot27dAgAIISwRksmVt75UtLYYtpWtvLYVYWvvz4qqDHlUhhyuXLmCW7du4cqVK3BycipxzPXr1wGwvlSF+mItleGzZE22uv0e9f0FkF9f7LaBunz5MoqKiuDt7W003dvbG7/99luJz0lOTkZiYmKx6QEBAWaJsSIGWjuACrC3mO0tXsC2Yq49R/7Y69evw93d3XzBmEl564s91BZzsqX35+OoDHnYew51WV+Kja/q9cVa7P2zZG22uP1M+f3Fbhuoipg8eTLGjx8vPdbr9bh69Spq1aoFhcL6HXJhYSH8/Pzwv//9D2q12trhyGJvMdtbvID9xWyI9/jx4/D19bV2OBZR0dpib69tSSpDDkDlyKOq5CCEwPXr11lfqkB9sRZuu8djz9tPbn2x2waqdu3acHR0RF5entH0vLw8+Pj4lPgclUoFlUplNM3Dw8NcIVaYWq22uzecvcVsb/EC9hfzE088AQcH+zzNsrz15XFri729tiWpDDkAlSOPqpCDPe55MmB9sR/cdo/HXrefnPpin99uACiVSoSEhGDr1q3SNL1ej61btyIsLMyKkRGRvWN9ISJzYX0hsn92uwcKAMaPH4/Y2Fi0adMG7dq1w/z583Hz5k289tpr1g6NiOwc6wsRmQvrC5F9s+sG6pVXXsE///yDadOmITc3F61atcKmTZuKnZhpL1QqFaZPn15sV70ts7eY7S1ewP5itrd4S2OJ+lIZtlVlyAGoHHkwB/vB+mLbuO0eT1XYfgphr9cBJSIiIiIisjC7PQeKiIiIiIjI0thAERERERERycQGioiIiIiISCY2UERERERERDKxgTKz5ORktG3bFjVq1ICXlxf69OmDkydPGo3p0qULFAqF0b/Ro0cbjblw4QKio6Ph6uoKLy8vTJgwAffu3TNLzAkJCcXiadKkiTT/zp07iIuLQ61atVC9enX069ev2A0BLRlvgwYNisWrUCgQFxcHwDa2786dO9GrVy/4+vpCoVBg7dq1RvOFEJg2bRrq1q0LFxcXhIeH49SpU0Zjrl69ikGDBkGtVsPDwwPDhw/HjRs3jMYcOXIEnTp1grOzM/z8/DB79myTx6vT6TBp0iQEBwfDzc0Nvr6+GDJkCP7++2+jZZT0usycOdMs8dqrxYsXo0GDBnB2dkZoaCgOHDhglTgs9ZnPyMjA008/DZVKhUaNGiElJaXCMdvSZ2r16tVo0qQJnJ2dERwcjI0bN5osj6FDhxZ7bXr06GEzecj5G2fJ94+tfKZsQVXfFvZY16ylstRTixJkVpGRkWL58uXi2LFjIjs7W/Ts2VPUr19f3LhxQxrz7LPPipEjR4qLFy9K/woKCqT59+7dE82bNxfh4eHi8OHDYuPGjaJ27dpi8uTJZol5+vTpolmzZkbx/PPPP9L80aNHCz8/P7F161Zx6NAh0b59e/HMM89YLd5Lly4ZxarRaAQAsX37diGEbWzfjRs3ivfee0+sWbNGABA//PCD0fyZM2cKd3d3sXbtWvHrr7+KF154QQQEBIjbt29LY3r06CFatmwp9u3bJ3bt2iUaNWokBgwYIM0vKCgQ3t7eYtCgQeLYsWPi22+/FS4uLuI///mPSePNz88X4eHhYuXKleK3334TmZmZol27diIkJMRoGf7+/iIpKclouz/4vjdlvPZoxYoVQqlUii+++ELk5OSIkSNHCg8PD5GXl2fxWCzxmf/jjz+Eq6urGD9+vDh+/LhYtGiRcHR0FJs2bapQzLbymdqzZ49wdHQUs2fPFsePHxdTpkwRTk5O4ujRoybJIzY2VvTo0cPotbl69arRGGvmIedvnKXeP7b0mbI2bgv7rGvWUlnqqSWxgbKwS5cuCQBix44d0rRnn31W/Otf/yr1ORs3bhQODg4iNzdXmrZ06VKhVquFVqs1eYzTp08XLVu2LHFefn6+cHJyEqtXr5amnThxQgAQmZmZVon3Yf/6179EYGCg0Ov1Qgjb274PFye9Xi98fHzERx99JE3Lz88XKpVKfPvtt0IIIY4fPy4AiIMHD0pjfv75Z6FQKMRff/0lhBBiyZIlombNmkYxT5o0STRu3Nik8ZbkwIEDAoA4f/68NM3f31/Mmzev1OeYK1570a5dOxEXFyc9LioqEr6+viI5OdnisVjiMz9x4kTRrFkzo2W/8sorIjIy8rHjt+Znqn///iI6OtoontDQUPH6668/dh5C3G+gevfuXepzbC2Ph//GWfL9Y0ufKWvjtrD/umYtlaWemhsP4bOwgoICAICnp6fR9NTUVNSuXRvNmzfH5MmTcevWLWleZmYmgoODjW6wFxkZicLCQuTk5JglzlOnTsHX1xcNGzbEoEGDcOHCBQBAVlYWdDodwsPDpbFNmjRB/fr1kZmZabV4De7evYtvvvkGw4YNg0KhkKbb2vZ90NmzZ5Gbm2u0Td3d3REaGmq0TT08PNCmTRtpTHh4OBwcHLB//35pTOfOnaFUKo3yOHnyJK5du2bWHAoKCqBQKODh4WE0febMmahVqxZat26Njz76yOjQB2vGa213795FVlaW0Wvu4OCA8PBw6TW3NHN/5jMzM42WYRhjjnwt+ZmyRF4ZGRnw8vJC48aNMWbMGFy5ckWaZ2t5PPw3zlLvH1v8TFkLt8X/qUx1zVoqWz01lWrWDqAq0ev1GDt2LDp06IDmzZtL0wcOHAh/f3/4+vriyJEjmDRpEk6ePIk1a9YAAHJzc4vdndzwODc31+RxhoaGIiUlBY0bN8bFixeRmJiITp064dixY8jNzYVSqSz2Rdnb21uKxdLxPmjt2rXIz8/H0KFDpWm2tn0fZlhHSTE8uE29vLyM5lerVg2enp5GYwICAootwzCvZs2aZon/zp07mDRpEgYMGAC1Wi1Nf+utt/D000/D09MTe/fuxeTJk3Hx4kXMnTvXqvHagsuXL6OoqKjE1/y3336zeDyW+MyXNqawsBC3b9+Gi4uLyfKx5GeqtLxMVTt69OiBvn37IiAgAGfOnMG7776LqKgoZGZmwtHR0abyKOlvnKXeP9euXbOpz5Q12Vp9sZbKVtespTLVU1NiA2VBcXFxOHbsGHbv3m00fdSoUdL/BwcHo27duujWrRvOnDmDwMBAS4eJqKgo6f9btGiB0NBQ+Pv7Y9WqVTZfDD7//HNERUXB19dXmmZr27cy0el06N+/P4QQWLp0qdG88ePHS//fokULKJVKvP7660hOToZKpbJ0qFQGe/7MV3YxMTHS/wcHB6NFixYIDAxERkYGunXrZsXIiivtbxyRNbCukTnxED4LiY+Px/r167F9+3bUq1evzLGhoaEAgNOnTwMAfHx8il0ZxvDYx8fHDNEa8/DwwFNPPYXTp0/Dx8cHd+/eRX5+frF4DLFYK97z589jy5YtGDFiRJnjbG37GtZRUgwPbtNLly4Zzb937x6uXr1qte1uaJ7Onz8PjUZjtPepJKGhobh37x7OnTtnlXhtSe3ateHo6Fjma25N5vjMlzZGrVab/MuMJT9TpY0x1+vYsGFD1K5d26h+2UIepf2Ns9T7x9Y/U5bEbVEye69r1lKZ6+njYANlZkIIxMfH44cffsC2bduK7b4sSXZ2NgCgbt26AICwsDAcPXrU6M1p+MIaFBRklrgfdOPGDZw5cwZ169ZFSEgInJycsHXrVmn+yZMnceHCBYSFhVk13uXLl8PLywvR0dFljrO17RsQEAAfHx+jbVpYWIj9+/cbbdP8/HxkZWVJY7Zt2wa9Xi81hGFhYdi5cyd0Op1RHo0bNzb54XCG5unUqVPYsmULatWq9cjnZGdnw8HBQdrNb8l4bY1SqURISIjRa67X67F161bpNbcmc3zmw8LCjJZhGGOOfC35mbJkXgDw559/4sqVK0b1y5p5POpvnKXeP7b+mbIkbouS2Xtds5bKXE8fi5UvYlHpjRkzRri7u4uMjAyjS2neunVLCCHE6dOnRVJSkjh06JA4e/as+PHHH0XDhg1F586dpWUYLqUZEREhsrOzxaZNm0SdOnXMdlnwf//73yIjI0OcPXtW7NmzR4SHh4vatWuLS5cuCSHuX/qzfv36Ytu2beLQoUMiLCxMhIWFWS1eIe5fYah+/fpi0qRJRtNtZftev35dHD58WBw+fFgAEHPnzhWHDx+Wrlo3c+ZM4eHhIX788Udx5MgR0bt37xIvEdq6dWuxf/9+sXv3bvHkk08aXSI0Pz9feHt7i8GDB4tjx46JFStWCFdX1wpdFryseO/evSteeOEFUa9ePZGdnW30vjZcXWfv3r1i3rx5Ijs7W5w5c0Z88803ok6dOmLIkCFmidcerVixQqhUKpGSkiKOHz8uRo0aJTw8PIyu+GQplvjMGy73O2HCBHHixAmxePHix7rcr618pvbs2SOqVasmPv74Y3HixAkxffr0cl12t6w8rl+/Lt5++22RmZkpzp49K7Zs2SKefvpp8eSTT4o7d+7YRB6P+hsnhOXeP7b0mbI2bgv7rGvWUlnqqSWxgTIzACX+W758uRBCiAsXLojOnTsLT09PoVKpRKNGjcSECROM7lMkhBDnzp0TUVFRwsXFRdSuXVv8+9//Fjqdziwxv/LKK6Ju3bpCqVSKJ554Qrzyyivi9OnT0vzbt2+LN954Q9SsWVO4urqKF198UVy8eNFq8QohxObNmwUAcfLkSaPptrJ9t2/fXuL7IDY2Vghx/zKhU6dOFd7e3kKlUolu3boVy+XKlStiwIABonr16kKtVovXXntNXL9+3WjMr7/+Kjp27ChUKpV44oknxMyZM00e79mzZ0t9XxvuvZWVlSVCQ0OFu7u7cHZ2Fk2bNhUffvih0Zc+U8ZrrxYtWiTq168vlEqlaNeundi3b59V4rDUZ3779u2iVatWQqlUioYNG0p1sCJs6TO1atUq8dRTTwmlUimaNWsmNmzYYJI8bt26JSIiIkSdOnWEk5OT8Pf3FyNHjiz2JdiaeTzqb5wQln3/2MpnyhZU9W1hj3XNWipLPbUkhRBCmHy3FhERERERUSXEc6CIiIiIiIhkYgNFREREREQkExsoIiIiIiIimdhAERERERERycQGioiIiIiISCY2UERERERERDKxgSIiIiIiIpKJDRQREREREZFMbKCIiIiIiIhkYgNFREREREQkExsoIiIiIiIimdhAERERERERycQGioiIiIiISCY2UERERERERDKxgSIiIiIiIpKJDRQREREREZFMbKCIiIiIiIhkYgNFREREREQkExsoIiIiIiIimdhAERERERERycQGqpJr0KABhg4dKj3OyMiAQqFARkZGuZdleO53331nugBNTKFQICEhwdphlMiWYyMqD3utKykpKVAoFDh37pzZ10VEpsOaY1kPb28qjg2UHTN8MEv6984771g1trS0NMyfP7/Y9HPnzhnF6eTkhNq1a+OZZ57Bu+++iwsXLlg+2HJ4cJvv3r272HwhBPz8/KBQKPD8889bIUKix2NvdaVLly6lxvvgP2v/ePGoL21Dhw5F9erVLRwVkfWx5piHoeYoFAp88803JY7p0KEDFAoFmjdvbuHo7F81awdAjy8pKQkBAQFG00r7MHTu3Bm3b9+GUqk0a0xpaWk4duwYxo4dW+L8AQMGoGfPntDr9bh27RoOHjyI+fPnY8GCBfj8888RExNj1vgel7OzM9LS0tCxY0ej6Tt27MCff/4JlUpV7Dm3b99GtWr8yJF9sJe68t5772HEiBHS44MHD2LhwoV499130bRpU2l6ixYt0KxZM8TExJT4+SQi62LNMQ/D95VXX33VaPq5c+ewd+9eODs7F3vOyZMn4eDAfSxl4be5SiAqKgpt2rSRNdbBwaHED4ulPf3008U+zOfPn0dERARiY2PRtGlTtGzZ0krRPVrPnj2xevVqLFy40KgpSktLQ0hICC5fvlzsObaw3Ynkspe60r17d6PHzs7OWLhwIbp3744uXboUG+/o6GihyOzDnTt3oFQq+WWJrI41xzx69uyJdevW4fLly6hdu7Y0PS0tDd7e3njyySdx7do1o+fwR6ZHY8WsYko7bnjx4sVo2LAhXFxc0K5dO+zatQtdunQpsRjo9Xp88MEHqFevHpydndGtWzecPn1amt+lSxds2LAB58+fl3YfN2jQ4JGx+fv7IyUlBXfv3sXs2bON5uXn52Ps2LHw8/ODSqVCo0aNMGvWLOj1+jKXef78ebzxxhto3LgxXFxcUKtWLbz88stGxyP/8ccfUCgUmDdvXrHn7927FwqFAt9++63R9AEDBuDKlSvQaDTStLt37+K7777DwIEDS4zl4V36CQkJUCgUOH36NIYOHQoPDw+4u7vjtddew61bt8rMi8iW2HJdeVBJ5yM0aNAAzz//PDIyMtCmTRu4uLggODhYymXNmjUIDg6Gs7MzQkJCcPjw4WLL/e233/DSSy/B09MTzs7OaNOmDdatW1eu2EqzZMkSNGvWDCqVCr6+voiLi0N+fr7RmNLOV3h4WxtepxUrVmDKlCl44okn4OrqisLCQpPESmQprDnya07v3r2hUqmwevVqo+lpaWno379/iQ3ewzXFkMeePXswfvx41KlTB25ubnjxxRfxzz//lGubVBbcA1UJFBQUFNvj8eCvDI+ydOlSxMfHo1OnThg3bhzOnTuHPn36oGbNmqhXr16x8TNnzoSDgwPefvttFBQUYPbs2Rg0aBD2798P4P7u7YKCAvz5559SUyL32P6wsDAEBgYaNSa3bt3Cs88+i7/++guvv/466tevj71792Ly5Mm4ePFiiedaGRw8eBB79+5FTEwM6tWrh3PnzmHp0qXo0qULjh8/DldXVzRs2BAdOnRAamoqxo0bZ/T81NRU1KhRA7179zaa3qBBA4SFheHbb79FVFQUAODnn39GQUEBYmJisHDhQln5AkD//v0REBCA5ORk/PLLL/jss8/g5eWFWbNmyV4GkalVprryKKdPn8bAgQPx+uuv49VXX8XHH3+MXr16YdmyZXj33XfxxhtvAACSk5PRv39/o8NbcnJy0KFDBzzxxBN455134ObmhlWrVqFPnz74/vvv8eKLLxqt6/r16yXuodZqtcWmJSQkIDExEeHh4RgzZgxOnjyJpUuX4uDBg9izZw+cnJwqlO+MGTOgVCrx9ttvQ6vVmv0wKCI5WHPMU3NcXV3Ru3dvfPvttxgzZgwA4Ndff0VOTg4+++wzHDlyRHbcb775JmrWrInp06fj3LlzmD9/PuLj47Fy5UqTbBe7IshuLV++XAAo8Z+Bv7+/iI2NlR5v375dABDbt28XQgih1WpFrVq1RNu2bYVOp5PGpaSkCADi2WefLfbcpk2bCq1WK01fsGCBACCOHj0qTYuOjhb+/v7FYj579qwAID766KNS8+rdu7cAIAoKCoQQQsyYMUO4ubmJ33//3WjcO++8IxwdHcWFCxekaQDE9OnTpce3bt0qtvzMzEwBQHz11VfStP/85z8CgDhx4oQ07e7du6J27dpG28+wzQ8ePCg++eQTUaNGDWkdL7/8snjuueeEEPe3e3R0tNF6H45t+vTpAoAYNmyY0bgXX3xR1KpVq9TtQ2RO9lhXHrR69WqjWErK7ezZs0a5ABB79+6Vpm3evFkAEC4uLuL8+fPSdEOdeHDZ3bp1E8HBweLOnTvSNL1eL5555hnx5JNPFsuzrH9ubm7S+EuXLgmlUikiIiJEUVGRNP2TTz4RAMQXX3xhlMODr4fBs88+W+K2btiwYYm1kcgaWHPMW3NWr14t1q9fLxQKhfR9acKECaJhw4ZCiPt1olmzZkZxP7y9DXmEh4cLvV4vTR83bpxwdHQU+fn5ZW6jyoiH8FUCixcvhkajMfon16FDh3DlyhWMHDnS6FyeQYMGoWbNmiU+57XXXjP6xbJTp04A7h8KZwqGX3iuX78OAFi9ejU6deqEmjVr4vLly9K/8PBwFBUVYefOnaUuy8XFRfp/nU6HK1euoFGjRvDw8MAvv/wizevfvz+cnZ2RmpoqTdu8eTMuX75c7FytB59z+/ZtrF+/HtevX8f69etLPXyvLKNHjzZ63KlTJ1y5coWH1ZBVVba6UpagoCCEhYVJj0NDQwEAXbt2Rf369YtNN8R09epVbNu2Df3795f2LF2+fBlXrlxBZGQkTp06hb/++stoXdOmTSu2XTUaDSIiIozGbdmyBXfv3sXYsWONzk8aOXIk1Go1NmzYUOF8Y2NjjWojkS1gzTFPzQGAiIgIeHp6YsWKFRBCYMWKFRgwYEC54x41ahQUCoX0uFOnTigqKsL58+fLvSx7x0P4KoF27drJPvHyYYY3faNGjYymV6tWrdRjfR/8cAOQitPDJyFW1I0bNwAANWrUAACcOnUKR44cQZ06dUocf+nSpVKXdfv2bSQnJ2P58uX466+/IISQ5hUUFEj/7+HhgV69eiEtLQ0zZswAcP/wvSeeeAJdu3Ytcdl16tRBeHg40tLScOvWLRQVFeGll14qX7Ioe3uq1epyL4/IFCpbXSnLw+t2d3cHAPj5+ZU43RDT6dOnIYTA1KlTMXXq1BKXfenSJTzxxBPS4+DgYISHhxcb9/Blhg3bsHHjxkbTlUolGjZs+FhfWB6+0hmRLWDNMU/NAQAnJye8/PLLSEtLQ7t27fC///2vQj/4WnOb2Ro2UFRupV1R5sHm5HEcO3YMXl5eUvOg1+vRvXt3TJw4scTxTz31VKnLevPNN7F8+XKMHTsWYWFhcHd3h0KhQExMTLELUAwZMgSrV6/G3r17ERwcjHXr1uGNN94o8+pUAwcOxMiRI5Gbm4uoqCh4eHiUO19zb08ie2DNz0Fp635UTIYa8vbbbyMyMrLEsQ9/oTOHB38RflBRUVGJOXDvE1HVqzkDBw7EsmXLkJCQgJYtWyIoKKi8YfP7ygPYQFVx/v7+AO7/qvHcc89J0+/du4dz586hRYsWFVpuaX/QHyUzMxNnzpwxOmwuMDAQN27cKPFX20f57rvvEBsbizlz5kjT7ty5U+wqVgDQo0cP1KlTB6mpqQgNDcWtW7cwePDgMpf/4osv4vXXX8e+ffuq5kmURCWwtbpiLg0bNgRw/9fditSnshi24cmTJ6X1APev9nn27Fmj9dWsWbPEmnb+/Hmj5xJVVqw5j9axY0fUr18fGRkZvEiVCfAcqCquTZs2qFWrFv773//i3r170vTU1NTH2iXr5uZmdIicHOfPn8fQoUOhVCoxYcIEaXr//v2RmZmJzZs3F3tOfn6+UdwPc3R0LPbLyKJFi1BUVFRsbLVq1TBgwACsWrUKKSkpCA4OfmTRrV69OpYuXYqEhAT06tXrUSkSVQm2VFfMycvLC126dMF//vMfXLx4sdj8x7m8b3h4OJRKJRYuXGhUwz7//HMUFBQgOjpamhYYGIh9+/bh7t270rT169fjf//7X4XXT2RPWHPuK6vmKBQKLFy4ENOnT3/kj8P0aNwDVcUplUokJCTgzTffRNeuXdG/f3+cO3cOKSkpCAwMrPCvLyEhIVi5ciXGjx+Ptm3bonr16kYNxi+//IJvvvkGer0e+fn5OHjwIL7//nsoFAp8/fXXRo3LhAkTsG7dOjz//PMYOnQoQkJCcPPmTRw9ehTfffcdzp07V+qlTp9//nl8/fXXcHd3R1BQEDIzM7FlyxbUqlWrxPFDhgzBwoULsX37dtm/0MTGxpZjyxBVftaqK9awePFidOzYEcHBwRg5ciQaNmyIvLw8ZGZm4s8//8Svv/5aoeXWqVMHkydPRmJiInr06IEXXngBJ0+exJIlS9C2bVujvfQjRozAd999hx49eqB///44c+YMvvnmGwQGBpoqTSKbxpojr+b07t272G1ZqGLYQBHi4+MhhMCcOXPw9ttvo2XLlli3bh3eeuutCt/p+4033kB2djaWL1+OefPmwd/f36jofPvtt/j2229RrVo1qNVqPPnkkxg7dixGjx5d7CRFV1dX7NixAx9++CFWr16Nr776Cmq1Gk899RQSExOlkyxLsmDBAjg6OiI1NRV37txBhw4dsGXLllKPHQ4JCUGzZs1w4sQJDBo0qEK5E5F16oo1BAUF4dChQ0hMTERKSgquXLkCLy8vtG7dGtOmTXusZSckJKBOnTr45JNPMG7cOHh6emLUqFH48MMPje4BFRkZiTlz5mDu3LkYO3Ys2rRpg/Xr1+Pf//7346ZHZDdYcx6/5pB8ClEVz/yiR9Lr9ahTpw769u2L//73v9YOx6Jat24NT09PbN261dqhEFUqVbmuEJHlseaQufAcKMKdO3eKnSf01Vdf4erVq+jSpYt1grKSQ4cOITs7G0OGDLF2KER2jXWFiCyJNYcsiXugCBkZGRg3bhxefvll1KpVC7/88gs+//xzNG3aFFlZWUY3mqusjh07hqysLMyZMweXL1/GH3/8UeFd/kTEukJElsWaQ5bEc6AIDRo0gJ+fHxYuXIirV6/C09MTQ4YMwcyZM6tMwfnuu++QlJSExo0b49tvv2XzRPSYWFeIyJJYc8iSuAeKiIiIiIhIJp4DRUREREREJBMbKCIiIiIiIpmq9DlQer0ef//9N2rUqFHhm6wRUXFCCFy/fh2+vr5wcKh6v9OwthCZD+sL6wuRucitL1W6gfr777/h5+dn7TCIKq3//e9/qFevnrXDsDjWFiLzY30hInN5VH2p0g1UjRo1ANzfSGq1usQxOp0O6enpiIiIMLrze2VQWXNjXtZXWFgIPz8/6TNW1cipLYB9vaamxLyrTt7myJn1pWrWl8qUD3OxXXLrS5VuoAy7vtVqdZkNlKurK9RqdaV4YzyosubGvGxHVT28RE5tAezzNTUF5l118jZnzqwvVau+VKZ8mIvte1R9qXoHDxMREREREVUQGygiIiIiIiKZ2EARERERERHJxAaKiIiIiIhIpnI3UDt37kSvXr3g6+sLhUKBtWvXGs0XQmDatGmoW7cuXFxcEB4ejlOnThmNuXr1KgYNGgS1Wg0PDw8MHz4cN27cMBpz5MgRdOrUCc7OzvDz88Ps2bOLxbJ69Wo0adIEzs7OCA4OxsaNG8ubDhERERERkWzlbqBu3ryJli1bYvHixSXOnz17NhYuXIhly5Zh//79cHNzQ2RkJO7cuSONGTRoEHJycqDRaLB+/Xrs3LkTo0aNkuYXFhYiIiIC/v7+yMrKwkcffYSEhAR8+umn0pi9e/diwIABGD58OA4fPow+ffqgT58+OHbsWHlTIiIiIiIikqXclzGPiopCVFRUifOEEJg/fz6mTJmC3r17AwC++uoreHt7Y+3atYiJicGJEyewadMmHDx4EG3atAEALFq0CD179sTHH38MX19fpKam4u7du/jiiy+gVCrRrFkzZGdnY+7cuVKjtWDBAvTo0QMTJkwAAMyYMQMajQaffPIJli1bVqGNQUREREREVBaTngN19uxZ5ObmIjw8XJrm7u6O0NBQZGZmAgAyMzPh4eEhNU8AEB4eDgcHB+zfv18a07lzZyiVSmlMZGQkTp48iWvXrkljHlyPYYxhPURERERERKZm0hvp5ubmAgC8vb2Npnt7e0vzcnNz4eXlZRxEtWrw9PQ0GhMQEFBsGYZ5NWvWRG5ubpnrKYlWq4VWq5UeFxYWArh/EzCdTlficwzTQ5I2Qas3zU37jiVEmmQ5j8uQW2m52yvmZX32ECM9WoN3Nph0eedmRpt0eURkv8pbX1SOArPbAc0TNkNbVPz7GOsLWZJJGyhbl5ycjMTExGLT09PT4erqWuZzZ7TRmywOW7vYhUajsXYIZsG8rOfWrVvWDoGIiIjILEzaQPn4+AAA8vLyULduXWl6Xl4eWrVqJY25dOmS0fPu3buHq1evSs/38fFBXl6e0RjD40eNMcwvyeTJkzF+/HjpcWFhIfz8/BAREQG1Wl3ic3Q6HTQaDaYecqiUe6A0Gg26d+8OJycna4djMszL+gx7d4mIiIgqG5M2UAEBAfDx8cHWrVulhqmwsBD79+/HmDFjAABhYWHIz89HVlYWQkJCAADbtm2DXq9HaGioNOa9996DTqeTvihqNBo0btwYNWvWlMZs3boVY8eOldav0WgQFhZWanwqlQoqlarYdCcnp0d+IdXqFSXuMq4IW/vyKyd/e8S8rMfW4yMiIiKqqHJfROLGjRvIzs5GdnY2gPsXjsjOzsaFCxegUCgwduxYvP/++1i3bh2OHj2KIUOGwNfXF3369AEANG3aFD169MDIkSNx4MAB7NmzB/Hx8YiJiYGvry8AYODAgVAqlRg+fDhycnKwcuVKLFiwwGjv0b/+9S9s2rQJc+bMwW+//YaEhAQcOnQI8fHxj79ViIiIiIiISlDuPVCHDh3Cc889Jz02NDWxsbFISUnBxIkTcfPmTYwaNQr5+fno2LEjNm3aBGdnZ+k5qampiI+PR7du3eDg4IB+/fph4cKF0nx3d3ekp6cjLi4OISEhqF27NqZNm2Z0r6hnnnkGaWlpmDJlCt599108+eSTWLt2LZo3b16hDUFERERERPQo5W6gunTpAiFEqfMVCgWSkpKQlJRU6hhPT0+kpaWVuZ4WLVpg165dZY55+eWX8fLLL5cdMBERERERkYmY9D5QRERERERElRkbKCIiIiIiIpnYQBGR3Vi6dClatGgBtVoNtVqNsLAw/Pzzz9L8O3fuIC4uDrVq1UL16tXRr1+/Yrc7uHDhAqKjo+Hq6govLy9MmDAB9+7dMxqTkZGBp59+GiqVCo0aNUJKSool0iMiK2J9ISK52EARkd2oV68eZs6ciaysLBw6dAhdu3ZF7969kZOTAwAYN24cfvrpJ6xevRo7duzA33//jb59+0rPLyoqQnR0NO7evYu9e/fiyy+/REpKCqZNmyaNOXv2LKKjo/Hcc88hOzsbY8eOxYgRI7B582aL50tElsP6QkRymfQ+UERE5tSrVy+jxx988AGWLl2Kffv2oV69evj888+RlpaGrl27AgCWL1+Opk2bYt++fWjfvj3S09Nx/PhxbNmyBd7e3mjVqhVmzJiBSZMmISEhAUqlEsuWLUNAQADmzJkD4P6tF3bv3o158+YhMtI2boJNRKbH+kJEcrGBIiK7VFRUhNWrV+PmzZsICwtDVlYWdDodwsPDpTFNmjRB/fr1kZmZifbt2yMzMxPBwcHw9vaWxkRGRmLMmDHIyclB69atkZmZabQMw5gHb9r9MK1WC61WKz0uLCwEAOh0Ouh0ulKfZ5hX1hhrUjmWfsXVing4X1vN21yqYt7myNkS24/1xfzKW19UDsLovw+z1TxLYuuvTXlUplwA+XmwgSIiu3L06FGEhYXhzp07qF69On744QcEBQUhOzsbSqUSHh4eRuO9vb2Rm5sLAMjNzTX6cmOYb5hX1pjCwkLcvn0bLi4uxWJKTk5GYmJisenp6elwdXV9ZE4ajeaRY6xhdjvTLm/jxo1Gj201b3OrinmbMudbt26ZbFkPY32xnIrWlxlt9CVOf7i+2ANbfW0qorLkIre+sIEiIrvSuHFjZGdno6CgAN999x1iY2OxY8cOq8Y0efJk6abiwP1fiP38/BAREQG1Wl3q83Q6HTQaDbp37w4nJydLhFouzRNMe17GsYT7hyjZet7mUhXzNkfOhj0w5sD6YjnlrS8qB4EZbfSYesgBWr2i2HxDfbEHtv7alEdlygWQX1/YQBGRXVEqlWjUqBEAICQkBAcPHsSCBQvwyiuv4O7du8jPzzf6lTgvLw8+Pj4AAB8fHxw4cMBoeYaraD045uEra+Xl5UGtVpf46zAAqFQqqFSqYtOdnJxk/UGRO87StEXFv6Q8jodztNW8za0q5m3KnM257VhfLKei9UWrV5T4XFvM8VFs9bWpiMqSi9wceBU+IrJrer0eWq0WISEhcHJywtatW6V5J0+exIULFxAWFgYACAsLw9GjR3Hp0iVpjEajgVqtRlBQkDTmwWUYxhiWQURVB+sLEZWEe6CIyG5MnjwZUVFRqF+/Pq5fv460tDRkZGRg8+bNcHd3x/DhwzF+/Hh4enpCrVbjzTffRFhYGNq3bw8AiIiIQFBQEAYPHozZs2cjNzcXU6ZMQVxcnPQL7+jRo/HJJ59g4sSJGDZsGLZt24ZVq1Zhw4YN1kydiMyM9YWI5GIDRUR249KlSxgyZAguXrwId3d3tGjRAps3b0b37t0BAPPmzYODgwP69esHrVaLyMhILFmyRHq+o6Mj1q9fjzFjxiAsLAxubm6IjY1FUlKSNCYgIAAbNmzAuHHjsGDBAtSrVw+fffYZLzFMVMmxvhCRXGygiMhufP7552XOd3Z2xuLFi7F48eJSx/j7+z/yak1dunTB4cOHKxQjEdkn1hcikovnQBEREREREcnEBoqIiIiIiEgmNlBEREREREQy8RwoIiIra56w2WT3XDo3M9okyyGiyoH1hcj0uAeKiIiIiIhIJjZQREREREREMrGBIiIiIiIikokNFBERERERkUxsoIiIiIiIiGRiA0VERERERCQTGygiIiIiIiKZ2EARERERERHJxAaKiIiIiIhIJjZQREREREREMrGBIiIiIiIikokNFBERERERkUxsoIiIiIiIiGQyeQNVVFSEqVOnIiAgAC4uLggMDMSMGTMghJDGCCEwbdo01K1bFy4uLggPD8epU6eMlnP16lUMGjQIarUaHh4eGD58OG7cuGE05siRI+jUqROcnZ3h5+eH2bNnmzodIiIiIiIiickbqFmzZmHp0qX45JNPcOLECcyaNQuzZ8/GokWLpDGzZ8/GwoULsWzZMuzfvx9ubm6IjIzEnTt3pDGDBg1CTk4ONBoN1q9fj507d2LUqFHS/MLCQkRERMDf3x9ZWVn46KOPkJCQgE8//dTUKREREREREQEAqpl6gXv37kXv3r0RHR0NAGjQoAG+/fZbHDhwAMD9vU/z58/HlClT0Lt3bwDAV199BW9vb6xduxYxMTE4ceIENm3ahIMHD6JNmzYAgEWLFqFnz574+OOP4evri9TUVNy9exdffPEFlEolmjVrhuzsbMydO9eo0SIiIiIiIjIVkzdQzzzzDD799FP8/vvveOqpp/Drr79i9+7dmDt3LgDg7NmzyM3NRXh4uPQcd3d3hIaGIjMzEzExMcjMzISHh4fUPAFAeHg4HBwcsH//frz44ovIzMxE586doVQqpTGRkZGYNWsWrl27hpo1axaLTavVQqvVSo8LCwsBADqdDjqdrsR8DNNVDqLE+RVR2roszRCHrcRjKszL+uwhRiIiIqKKMHkD9c4776CwsBBNmjSBo6MjioqK8MEHH2DQoEEAgNzcXACAt7e30fO8vb2lebm5ufDy8jIOtFo1eHp6Go0JCAgotgzDvJIaqOTkZCQmJhabnp6eDldX1zLzmtFGX+b88ti4caPJlmUKGo3G2iGYBfOynlu3bpllucnJyVizZg1+++03uLi44JlnnsGsWbPQuHFjaUyXLl2wY8cOo+e9/vrrWLZsmfT4woULGDNmDLZv347q1asjNjYWycnJqFbt/0piRkYGxo8fj5ycHPj5+WHKlCkYOnSoWfKqKhq8swEAoHIUmN0OaJ6wGdoiRYWXd25mtKlCI2J9sXOG+mIKrC30KCZvoFatWoXU1FSkpaVJh9WNHTsWvr6+iI2NNfXqymXy5MkYP3689LiwsBB+fn6IiIiAWq0u8Tk6nQ4ajQZTDzlAq6/4H/oHHUuINMlyHpcht+7du8PJycna4ZgM87I+w95dU9uxYwfi4uLQtm1b3Lt3D++++y4iIiJw/PhxuLm5SeNGjhyJpKQk6fGDP5AUFRUhOjoaPj4+2Lt3Ly5evIghQ4bAyckJH374IYD7e8qjo6MxevRopKamYuvWrRgxYgTq1q2LyEjb+PwSkWmxvhCRXCZvoCZMmIB33nkHMTExAIDg4GCcP38eycnJiI2NhY+PDwAgLy8PdevWlZ6Xl5eHVq1aAQB8fHxw6dIlo+Xeu3cPV69elZ7v4+ODvLw8ozGGx4YxD1OpVFCpVMWmOzk5PfILqVaveKxfSh9eny2Rk789Yl7WY674Nm3aZPQ4JSUFXl5eyMrKQufOnaXprq6updaB9PR0HD9+HFu2bIG3tzdatWqFGTNmYNKkSUhISIBSqcSyZcsQEBCAOXPmAACaNm2K3bt3Y968efyCQ1RJsb4QkVwmb6Bu3boFBwfji/s5OjpCr79/CFxAQAB8fHywdetWqWEqLCzE/v37MWbMGABAWFgY8vPzkZWVhZCQEADAtm3boNfrERoaKo157733oNPppC9rGo0GjRs3LvHwPSKqfAoKCgAAnp6eRtNTU1PxzTffwMfHB7169cLUqVOlX4kzMzMRHBxsdBhxZGQkxowZg5ycHLRu3RqZmZlG52kaxowdO7bEOCpyfqVhPmC751iqHE0Xl9Fy/3++j5u3vZ1rZ0/nMZqKOXK21PZjfSl9maZQ3vpiqrohh7nfY5WpFlSmXAD5eZi8gerVqxc++OAD1K9fH82aNcPhw4cxd+5cDBs2DACgUCgwduxYvP/++3jyyScREBCAqVOnwtfXF3369AFw/9eYHj16YOTIkVi2bBl0Oh3i4+MRExMDX19fAMDAgQORmJiI4cOHY9KkSTh27BgWLFiAefPmmTolIrJBer0eY8eORYcOHdC8eXNp+sCBA+Hv7w9fX18cOXIEkyZNwsmTJ7FmzRoA98+RLOkcTMO8ssYUFhbi9u3bcHFxMZr3OOdXArZ7juXsdiZbVIkeN29bO59ULns4j9HUTJmzuc6xfBDrS8lsob6YMp/SWKq2VKZaUFlykVtfTN5ALVq0CFOnTsUbb7yBS5cuwdfXF6+//jqmTZsmjZk4cSJu3ryJUaNGIT8/Hx07dsSmTZvg7OwsjUlNTUV8fDy6desGBwcH9OvXDwsXLpTmu7u7Iz09HXFxcQgJCUHt2rUxbdo0XsKcqIqIi4vDsWPHsHv3bqPpD9aA4OBg1K1bF926dcOZM2cQGBhollgqcn4lYPvnWDZP2GyyZT1I5SAwo43+sfO2lfNJ5bKn8xhNxRw5m+scywexvpTMmvXFVHVDDnPXlspUCypTLoD8+mLyBqpGjRqYP38+5s+fX+oYhUKBpKQko5MwH+bp6Ym0tLQy19WiRQvs2rWroqESkZ2Kj4+XbrBdr169MscaDvs9ffo0AgMD4ePjI92XzuDh8ydLO8dSrVYX+3UYeLzzKwHbPcfSVDGVuvzHzNte/1jbw3mMpmbKnM297VhfSmcL9cWU+ZTGUp/PylQLKksucnNwePQQIiLbIIRAfHw8fvjhB2zbtq3YrQxKkp2dDQDSRWvCwsJw9OhRowvVaDQaqNVqBAUFSWO2bt1qtByNRoOwsDATZUJEtob1hYjkYgNFRHYjLi4O33zzDdLS0lCjRg3k5uYiNzcXt2/fBgCcOXMGM2bMQFZWFs6dO4d169ZhyJAh6Ny5M1q0aAEAiIiIQFBQEAYPHoxff/0VmzdvxpQpUxAXFyf9yjt69Gj88ccfmDhxIn777TcsWbIEq1atwrhx46yWOxGZF+sLEcnFBoqI7MbSpUtRUFCALl26oG7dutK/lStXAgCUSiW2bNmCiIgINGnSBP/+97/Rr18//PTTT9IyHB0dsX79ejg6OiIsLAyvvvoqhgwZYnRIcUBAADZs2ACNRoOWLVtizpw5+Oyzz3iJYaJKjPWFiOQy+TlQRETmIkTZl6/18/PDjh07Hrkcf3//R15lqUuXLjh8+HC54iMi+8X6QkRycQ8UERERERGRTGygiIiIiIiIZGIDRUREREREJBMbKCIiIiIiIpnYQBEREREREcnEBoqIiIiIiEgmNlBEREREREQysYEiIiIiIiKSiQ0UERERERGRTGygiIiIiIiIZGIDRUREREREJBMbKCIiIiIiIpnYQBEREREREcnEBoqIiIiIiEgmNlBEREREREQysYEiIiIiIiKSiQ0UERERERGRTGygiIiIiIiIZGIDRUREREREJBMbKCIiIiIiIpnYQBGR3UhOTkbbtm1Ro0YNeHl5oU+fPjh58qTRmDt37iAuLg61atVC9erV0a9fP+Tl5RmNuXDhAqKjo+Hq6govLy9MmDAB9+7dMxqTkZGBp59+GiqVCo0aNUJKSoq50yMiK2J9ISK52EARkd3YsWMH4uLisG/fPmg0Guh0OkRERODmzZvSmHHjxuGnn37C6tWrsWPHDvz999/o27evNL+oqAjR0dG4e/cu9u7diy+//BIpKSmYNm2aNObs2bOIjo7Gc889h+zsbIwdOxYjRozA5s2bLZovEVkO6wsRyVXN2gEQEcm1adMmo8cpKSnw8vJCVlYWOnfujIKCAnz++edIS0tD165dAQDLly9H06ZNsW/fPrRv3x7p6ek4fvw4tmzZAm9vb7Rq1QozZszApEmTkJCQAKVSiWXLliEgIABz5swBADRt2hS7d+/GvHnzEBkZafG8icj8WF+ISC7ugSIiu1VQUAAA8PT0BABkZWVBp9MhPDxcGtOkSRPUr18fmZmZAIDMzEwEBwfD29tbGhMZGYnCwkLk5ORIYx5chmGMYRlEVPmxvhBRabgHiojskl6vx9ixY9GhQwc0b94cAJCbmwulUgkPDw+jsd7e3sjNzZXGPPjlxjDfMK+sMYWFhbh9+zZcXFyM5mm1Wmi1WulxYWEhAECn00Gn05Wag2GeykHIylmOstZXXipH08VltNz/n+/j5m3KXC3BEK+9xf04zJGzJbYf60vZyzSF8tYXU9UNOcz9HqtMtaAy5QLIz8MsDdRff/2FSZMm4eeff8atW7fQqFEjLF++HG3atAEACCEwffp0/Pe//0V+fj46dOiApUuX4sknn5SWcfXqVbz55pv46aef4ODggH79+mHBggWoXr26NObIkSOIi4vDwYMHUadOHbz55puYOHGiOVIiIhsTFxeHY8eOYffu3dYOBcnJyUhMTCw2PT09Ha6uro98/ow2epPFsnHjRpMta3Y7ky2qRI+btylztSSNRmPtECzOlDnfunXLZMsqDetLyWyhvpgyn9JYqrZUplpQWXKRW19M3kBdu3YNHTp0wHPPPYeff/4ZderUwalTp1CzZk1pzOzZs7Fw4UJ8+eWXCAgIwNSpUxEZGYnjx4/D2dkZADBo0CBcvHhROpHztddew6hRo5CWlgbg/i8wERERCA8Px7Jly3D06FEMGzYMHh4eGDVqlKnTIiIbEh8fj/Xr12Pnzp2oV6+eNN3Hxwd3795Ffn6+0a/EeXl58PHxkcYcOHDAaHmGq2g9OObhK2vl5eVBrVYX+3UYACZPnozx48dLjwsLC+Hn54eIiAio1epS89DpdNBoNJh6yAFavUJm9mU7lmC6cyiaJ5jnpHaVg8CMNvrHztuUuVqC4fXu3r07nJycrB2ORZgjZ8MeGHNhfSmdNeuLqeqGHOauLZWpFlSmXAD59cXkDdSsWbPg5+eH5cuXS9MCAgKk/xdCYP78+ZgyZQp69+4NAPjqq6/g7e2NtWvXIiYmBidOnMCmTZtw8OBBaa/VokWL0LNnT3z88cfw9fVFamoq7t69iy+++AJKpRLNmjVDdnY25s6dywaKqJISQuDNN9/EDz/8gIyMDKPaAgAhISFwcnLC1q1b0a9fPwDAyZMnceHCBYSFhQEAwsLC8MEHH+DSpUvw8vICcP+XM7VajaCgIGnMw79AajQaaRkPU6lUUKlUxaY7OTnJ+oOi1SugLTLNFwJT/gEzVUylLv8x87bXP9Zy3xeViSlzNte2Y315NFuoL6bMpzSW+nxWplpQWXKRm4PJLyKxbt06tGnTBi+//DK8vLzQunVr/Pe//5Xmnz17Frm5uUYnULq7uyM0NNToJEwPDw+peQKA8PBwODg4YP/+/dKYzp07Q6lUSmMiIyNx8uRJXLt2zdRpEZENiIuLwzfffIO0tDTUqFEDubm5yM3Nxe3btwHcryXDhw/H+PHjsX37dmRlZeG1115DWFgY2rdvDwCIiIhAUFAQBg8ejF9//RWbN2/GlClTEBcXJ31JGT16NP744w9MnDgRv/32G5YsWYJVq1Zh3LhxVsudiMyL9YWI5DL5Hqg//vgDS5cuxfjx4/Huu+/i4MGDeOutt6BUKhEbGyudRFnSCZQPnmBp+OVGCrRaNXh6ehqNefjXoQdP1HzwkEGDipyIaesnYT6OynbinwHzsj5zxbh06VIAQJcuXYymL1++HEOHDgUAzJs3TzpvUqvVIjIyEkuWLJHGOjo6Yv369RgzZgzCwsLg5uaG2NhYJCUlSWMCAgKwYcMGjBs3DgsWLEC9evXw2Wef8RLDRJUY6wsRyWXyBkqv16NNmzb48MMPAQCtW7fGsWPHsGzZMsTGxpp6deXyOCdi2upJmKZQWU78exjzsh5zneQtxKN/yHB2dsbixYuxePHiUsf4+/s/8nPYpUsXHD58uNwxEpF9Yn0hIrlM3kDVrVtXOs7XoGnTpvj+++8B/N9JlHl5eahbt640Ji8vD61atZLGXLp0yWgZ9+7dw9WrVx95EuaD63hYRU7EtPWTMB9HZTvxz4B5WZ+5T/ImIiIishaTN1AdOnTAyZMnjab9/vvv8Pf3B3B/17WPjw+2bt0qNUyFhYXYv38/xowZA+D+CZb5+fnIyspCSEgIAGDbtm3Q6/UIDQ2Vxrz33nvQ6XTSl0mNRoPGjRuXePge8HgnYtrqSZimUFlO/HsY87IeW4+PiIiIqKJMfhGJcePGYd++ffjwww9x+vRppKWl4dNPP0VcXBwAQKFQYOzYsXj//fexbt06HD16FEOGDIGvry/69OkD4P4eqx49emDkyJE4cOAA9uzZg/j4eMTExMDX1xcAMHDgQCiVSgwfPhw5OTlYuXIlFixYYLSHiYiIiIiIyJRMvgeqbdu2+OGHHzB58mQkJSUhICAA8+fPx6BBg6QxEydOxM2bNzFq1Cjk5+ejY8eO2LRpk3QPKABITU1FfHw8unXrJp2wuXDhQmm+u7s70tPTERcXh5CQENSuXRvTpk3jJcyJiIiIiMhsTN5AAcDzzz+P559/vtT5CoUCSUlJRleleZinp6d009zStGjRArt27apwnEREREREROVh8kP4iIiIiIiIKis2UERERERERDKxgSIiIiIiIpKJDRQREREREZFMbKCIiIiIiIhkYgNFREREREQkExsoIiIiIiIimdhAERERERERycQGioiIiIiISCY2UERERERERDKxgSIiIiIiIpKJDRQREREREZFM1awdABERmU6DdzZYOwQiqqRYX4ju4x4oIiIiIiIimdhAERERERERycQGioiIiIiISCY2UERkN3bu3IlevXrB19cXCoUCa9euNZo/dOhQKBQKo389evQwGnP16lUMGjQIarUaHh4eGD58OG7cuGE05siRI+jUqROcnZ3h5+eH2bNnmzs1IrIy1hcikosNFBHZjZs3b6Jly5ZYvHhxqWN69OiBixcvSv++/fZbo/mDBg1CTk4ONBoN1q9fj507d2LUqFHS/MLCQkRERMDf3x9ZWVn46KOPkJCQgE8//dRseRGR9bG+EJFcvAofEdmNqKgoREVFlTlGpVLBx8enxHknTpzApk2bcPDgQbRp0wYAsGjRIvTs2RMff/wxfH19kZqairt37+KLL76AUqlEs2bNkJ2djblz5xp9ESLrM+UVwc7NjDbZssg+sb6QgamvNsj6UvmwgSKiSiUjIwNeXl6oWbMmunbtivfffx+1atUCAGRmZsLDw0P6cgMA4eHhcHBwwP79+/Hiiy8iMzMTnTt3hlKplMZERkZi1qxZuHbtGmrWrFlsnVqtFlqtVnpcWFgIANDpdNDpdKXGapinchCPl7SdMeRrS3mX9TqZeh2WWJetMEfO1tx+rC/WY4t1Q66HX6fKVAsqUy6A/DzYQBFRpdGjRw/07dsXAQEBOHPmDN59911ERUUhMzMTjo6OyM3NhZeXl9FzqlWrBk9PT+Tm5gIAcnNzERAQYDTG29tbmlfSF5zk5GQkJiYWm56eng5XV9dHxj2jjV52jpWJLeW9ceNGi61Lo9FYbF22wpQ537p1y2TLKg/WF9tgj/mUVl8qUy2oLLnIrS9soIio0oiJiZH+Pzg4GC1atEBgYCAyMjLQrVs3s6138uTJGD9+vPS4sLAQfn5+iIiIgFqtLvV5Op0OGo0GUw85QKtXmC0+W6NyEJjRRm9TeR9LiDT7Ogyvd/fu3eHk5GT29dkCc+Rs2ANjaawv1mWLdUOuh+tLZaoFlSkXQH59YQNF/6+9e4+Oor7/P/7a3DYESMItCSkBgygX5WaCYbkVJSRgtFJpFaWAluJXGvwWU7XSn+UitlEUUDSKVgVtpaA9gggUEoNcDSCRlIuWguI3UkkQkISAJJtkfn94MnXNhQE2u9nN83FOzmFnPjv7fk+ST/bF7MwAfqtr165q3769Dh8+rBEjRigmJkbHjx93GVNZWalTp06Z5zXExMSouLjYZUzN4/rOfbDb7bLb7bWWBwcHW/qDUl5tU3mVb70hcIem1Lcn//Bb/bnwJ+7suansO+YX7/DFfur7PvnTXOAvvVjtgavwAfBbR48e1cmTJ9WxY0dJksPh0OnTp5Wfn2+O2bhxo6qrq5WUlGSO2bJli8vnoHNyctS9e/c6P14DoHlifgGaLwIUAJ9RVlamgoICFRQUSJKOHDmigoICFRYWqqysTA899JB27NihL774Qrm5ubr11lvVrVs3paZ+9/GJnj17atSoUZoyZYp27dql7du3a9q0aRo3bpxiY2MlSXfddZdCQkI0efJkHThwQCtWrNCzzz7r8hEaAP6H+QWAVQQoAD5j9+7d6t+/v/r37y9JysjIUP/+/TVz5kwFBgZq7969+slPfqKrr75akydPVkJCgrZu3ery8Zc333xTPXr00IgRI3TTTTdpyJAhLvdgiYiIUHZ2to4cOaKEhAT99re/1cyZM7nEMODnmF8AWMU5UAB8xvDhw2UY9V/CdsOGDRfcRtu2bbVs2bIGx/Tp00dbt2696PoA+C7mFwBWcQQKAAAAACwiQAEAAACARQQoAAAAALCo0QPUE088IZvNpunTp5vLzp8/r/T0dLVr106tWrXS2LFja90XobCwUGlpaQoLC1NUVJQeeughVVZWuozZtGmTrrvuOtntdnXr1k1Lly5t7HYAAAAANGONGqA++ugjvfTSS+rTp4/L8gceeEDvvfee3n77bW3evFlfffWVbrvtNnN9VVWV0tLSVFFRoQ8//FCvv/66li5dqpkzZ5pjjhw5orS0NN1www0qKCjQ9OnT9atf/crSSZ4AAAAAcCkaLUCVlZVp/Pjx+vOf/+xyc7iSkhK9+uqrWrBggW688UYlJCRoyZIl+vDDD7Vjxw5JUnZ2tj755BP99a9/Vb9+/TR69GjNnTtXWVlZqqiokCQtXrxY8fHxmj9/vnr27Klp06bpZz/7mRYuXNhYLQEAAABo5hrtMubp6elKS0tTcnKyHn/8cXN5fn6+nE6nkpOTzWU9evRQ586dlZeXp4EDByovL0+9e/dWdHS0OSY1NVVTp07VgQMH1L9/f+Xl5blso2bM9z8q+EPl5eUqLy83H5eWlkqSnE6ny13Bv69muT2g/kubXqz6XsvTaupoKvW4C315ny/UCAAAcCkaJUAtX75cH3/8sT766KNa64qKihQSEqLIyEiX5dHR0SoqKjLHfD881ayvWdfQmNLSUn377bdq0aJFrdfOzMzUnDlzai3Pzs5WWFhYgz3NTaxucP3FWLdundu25Q45OTneLqFR0Jf3nDt3ztslAAAANAq3B6gvv/xSv/nNb5STk6PQ0FB3b/6yzJgxQxkZGebj0tJSxcXFKSUlReHh4XU+x+l0KicnR3/YHaDyaptb6tg/O9Ut27lcNb2NHDlSwcHB3i7HbejL+2qO7gIAAPgbtweo/Px8HT9+XNddd525rKqqSlu2bNHzzz+vDRs2qKKiQqdPn3Y5ClVcXKyYmBhJUkxMjHbt2uWy3Zqr9H1/zA+v3FdcXKzw8PA6jz5Jkt1ul91ur7U8ODj4gm9Iy6ttKq9yT4Bqam9+rfTvi+jLe5p6fQAAAJfK7ReRGDFihPbt26eCggLzKzExUePHjzf/HRwcrNzcXPM5Bw8eVGFhoRwOhyTJ4XBo3759On78uDkmJydH4eHh6tWrlznm+9uoGVOzDQAAAABwN7cfgWrdurWuvfZal2UtW7ZUu3btzOWTJ09WRkaG2rZtq/DwcN1///1yOBwaOHCgJCklJUW9evXShAkTNG/ePBUVFenRRx9Venq6eQTpvvvu0/PPP6+HH35Yv/zlL7Vx40a99dZbWrt2rbtbAgAAAABJjXgVvoYsXLhQAQEBGjt2rMrLy5WamqoXXnjBXB8YGKg1a9Zo6tSpcjgcatmypSZNmqTHHnvMHBMfH6+1a9fqgQce0LPPPqtOnTrplVdeUWpq0zi/CAAAAID/8UiA2rRpk8vj0NBQZWVlKSsrq97ndOnS5YJXqxs+fLj27NnjjhIBAAAA4IIa7Ua6AAAAAOBvCFAAAAAAYBEBCgAAAAAsIkABAAAAgEUEKAAAAACwiAAFAAAAABYRoAAAAADAIgIUAJ+xZcsW3XLLLYqNjZXNZtOqVatc1huGoZkzZ6pjx45q0aKFkpOTdejQIZcxp06d0vjx4xUeHq7IyEhNnjxZZWVlLmP27t2roUOHKjQ0VHFxcZo3b15jtwbAy5hfAFhFgALgM86ePau+ffvWexPuefPmadGiRVq8eLF27typli1bKjU1VefPnzfHjB8/XgcOHFBOTo7WrFmjLVu26N577zXXl5aWKiUlRV26dFF+fr6eeuopzZ49Wy+//HKj9wfAe5hfAFgV5O0CAMCq0aNHa/To0XWuMwxDzzzzjB599FHdeuutkqQ33nhD0dHRWrVqlcaNG6dPP/1U69ev10cffaTExERJ0nPPPaebbrpJTz/9tGJjY/Xmm2+qoqJCr732mkJCQnTNNdeooKBACxYscHkjBMC/ML8AsIoABcAvHDlyREVFRUpOTjaXRUREKCkpSXl5eRo3bpzy8vIUGRlpvrmRpOTkZAUEBGjnzp366U9/qry8PA0bNkwhISHmmNTUVD355JP65ptv1KZNm1qvXV5ervLycvNxaWmpJMnpdMrpdNZbc806e4Bx6Y37oJp+m1LfDX2f3P0annitpqIxevbG/mN+8b6mOG9Y9cPvkz/NBf7Ui2S9DwIUAL9QVFQkSYqOjnZZHh0dba4rKipSVFSUy/qgoCC1bdvWZUx8fHytbdSsq+sNTmZmpubMmVNreXZ2tsLCwi5Y+9zE6guO8UdNqe9169Z57LVycnI89lpNhTt7PnfunNu2ZRXzS9Phi/3UN7/401zgL71YnV8IUABwmWbMmKGMjAzzcWlpqeLi4pSSkqLw8PB6n+d0OpWTk6M/7A5QebXNE6U2CfYAQ3MTq5tU3/tnpzb6a9R8v0eOHKng4OBGf72moDF6rjkC01wwv3ynKc4bVv1wfvGnucCfepGszy8EKAB+ISYmRpJUXFysjh07msuLi4vVr18/c8zx48ddnldZWalTp06Zz4+JiVFxcbHLmJrHNWN+yG63y26311oeHBxs6Q9KebVN5VW+9YbAHZpS3578w2/158KfuLNnb+w75pemwxf7qe/75E9zgb/0YrUHrsIHwC/Ex8crJiZGubm55rLS0lLt3LlTDodDkuRwOHT69Gnl5+ebYzZu3Kjq6molJSWZY7Zs2eLyOeicnBx17969zo/XAPB/zC8Avo8ABcBnlJWVqaCgQAUFBZK+O7G7oKBAhYWFstlsmj59uh5//HGtXr1a+/bt08SJExUbG6sxY8ZIknr27KlRo0ZpypQp2rVrl7Zv365p06Zp3Lhxio2NlSTdddddCgkJ0eTJk3XgwAGtWLFCzz77rMtHaAD4H+YXAFbxET4APmP37t264YYbzMc1bzomTZqkpUuX6uGHH9bZs2d177336vTp0xoyZIjWr1+v0NBQ8zlvvvmmpk2bphEjRiggIEBjx47VokWLzPURERHKzs5Wenq6EhIS1L59e82cOZNLDAN+jvkFgFUEKAA+Y/jw4TKM+i9ha7PZ9Nhjj+mxxx6rd0zbtm21bNmyBl+nT58+2rp16yXXCcD3ML8AsIqP8AEAAACARQQoAAAAALCIAAUAAAAAFhGgAAAAAMAiAhQAAAAAWESAAgAAAACLCFAAAAAAYBEBCgAAAAAsIkABAAAAgEUEKAAAAACwKMjbBQAA4G1XPLLWrdv74ok0t24PgO/64fxiDzQ073rp2tkbVF5lu+jtMb94n9uPQGVmZmrAgAFq3bq1oqKiNGbMGB08eNBlzPnz55Wenq527dqpVatWGjt2rIqLi13GFBYWKi0tTWFhYYqKitJDDz2kyspKlzGbNm3SddddJ7vdrm7dumnp0qXubgcAAAAATG4PUJs3b1Z6erp27NihnJwcOZ1OpaSk6OzZs+aYBx54QO+9957efvttbd68WV999ZVuu+02c31VVZXS0tJUUVGhDz/8UK+//rqWLl2qmTNnmmOOHDmitLQ03XDDDSooKND06dP1q1/9Shs2bHB3SwAAAAAgqRE+wrd+/XqXx0uXLlVUVJTy8/M1bNgwlZSU6NVXX9WyZct04403SpKWLFminj17aseOHRo4cKCys7P1ySef6P3331d0dLT69eunuXPn6ne/+51mz56tkJAQLV68WPHx8Zo/f74kqWfPntq2bZsWLlyo1NRUd7cFAAAAAI1/EYmSkhJJUtu2bSVJ+fn5cjqdSk5ONsf06NFDnTt3Vl5eniQpLy9PvXv3VnR0tDkmNTVVpaWlOnDggDnm+9uoGVOzDQAAAABwt0a9iER1dbWmT5+uwYMH69prr5UkFRUVKSQkRJGRkS5jo6OjVVRUZI75fniqWV+zrqExpaWl+vbbb9WiRYta9ZSXl6u8vNx8XFpaKklyOp1yOp119lCz3B5gWOrZivpey9Nq6mgq9bgLfXmfL9QIAABwKRo1QKWnp2v//v3atm1bY76MZZmZmZozZ06t5dnZ2QoLC2vwuXMTq91Wx7p169y2LXfIycnxdgmNgr6859y5c94uAQAAoFE0WoCaNm2a1qxZoy1btqhTp07m8piYGFVUVOj06dMuR6GKi4sVExNjjtm1a5fL9mqu0vf9MT+8cl9xcbHCw8PrPPokSTNmzFBGRob5uLS0VHFxcUpJSVF4eHidz3E6ncrJydEfdgeovPriLzVZl/2zm8Y5WjW9jRw5UsHBwd4ux23oy/tqju4CAAD4G7cHKMMwdP/992vlypXatGmT4uPjXdYnJCQoODhYubm5Gjt2rCTp4MGDKiwslMPhkCQ5HA798Y9/1PHjxxUVFSXpu/91Dw8PV69evcwxPzySk5OTY26jLna7XXa7vdby4ODgC74hLa+2XdK1+uvS1N78WunfF9GX9zT1+gAAAC6V2wNUenq6li1bpnfffVetW7c2z1mKiIhQixYtFBERocmTJysjI0Nt27ZVeHi47r//fjkcDg0cOFCSlJKSol69emnChAmaN2+eioqK9Oijjyo9Pd0MQPfdd5+ef/55Pfzww/rlL3+pjRs36q233tLate69GSIAAAAA1HD7VfhefPFFlZSUaPjw4erYsaP5tWLFCnPMwoULdfPNN2vs2LEaNmyYYmJi9M4775jrAwMDtWbNGgUGBsrhcOgXv/iFJk6cqMcee8wcEx8fr7Vr1yonJ0d9+/bV/Pnz9corr3AJc6CZmz17tmw2m8tXjx49zPXuupE3gOaFuQVAjUb5CN+FhIaGKisrS1lZWfWO6dKlywUvtjB8+HDt2bPnomsE4N+uueYavf/+++bjoKD/TnUPPPCA1q5dq7ffflsRERGaNm2abrvtNm3fvl3Sf2/kHRMTow8//FDHjh3TxIkTFRwcrD/96U8e7wVA08HcAkBq5KvwAYA3BAUFmRec+T533cgbQPPE3AJA8sCNdAHA0w4dOqTY2Fh17dpV48ePV2FhoST33cgbQPPE3AJA4ggUAD+TlJSkpUuXqnv37jp27JjmzJmjoUOHav/+/W67kfcPXcpNumvWS+69UbcvqOnXn/uu6/vuSzfDdpfG6Nlb+88bc4vE/FLDn+aNy+2lKc0h/javWe2DAAXAr4wePdr8d58+fZSUlKQuXbrorbfeqvcecZfrcm7SLbn3Rt2+xJ/7bugcXl+4Gba7ubNnb92o2xtzi8T88kP+1M+l9nKhawR4g7/Ma1bnFwIUAL8WGRmpq6++WocPH9bIkSPdciPvH7qUm3RLjXOjbl9gDzA0N7Har/uu64bpvnQzbHdpjJ6byo26PTG3SMwvNfxp3rjcXuqaX7zF3+Y1q/MLAQqAXysrK9Nnn32mCRMmuO1G3j90OTfpltx7o25f4s99N/R994WbYbubO3tuKvvOE3OLxPzyQ/7Uz6X20lR+B77PX+Y1qz0QoAD4lQcffFC33HKLunTpoq+++kqzZs1SYGCg7rzzTrfdyBtA88PcAqAGAQqAXzl69KjuvPNOnTx5Uh06dNCQIUO0Y8cOdejQQdJ3N/IOCAjQ2LFjVV5ertTUVL3wwgvm82tu5D116lQ5HA61bNlSkyZNcrmRN4Dmh7kFQA0CFAC/snz58gbXu+tG3gCaF+YWADW4DxQAAAAAWESAAgAAAACLCFAAAAAAYBEBCgAAAAAsIkABAAAAgEUEKAAAAACwiMuYAwDgZlc8srbWMnugoXnXS9fO3qDyKpvlbX3xRJo7SwPg4+qaXy4V88ul4QgUAAAAAFhEgAIAAAAAiwhQAAAAAGARAQoAAAAALCJAAQAAAIBFBCgAAAAAsIgABQAAAAAWEaAAAAAAwCJupAsAQBPmzptmStw4E8B/Xe788sMbhDeX+YUABbgBb3AAAACaBwKUH7jUN+8//F8DqWm/cbfaZ1191aUp9+pu7gx4zWm/AQAA/BDnQAEAAACARRyBQrPl7o/dAQAAwP8RoLygKb9xb8q1NSd1fR+sfjQRAAAAjcfnP8KXlZWlK664QqGhoUpKStKuXbu8XRIAP8H8AqCxML8Avsunj0CtWLFCGRkZWrx4sZKSkvTMM88oNTVVBw8eVFRUlLfLA+DDmF/gr7iojPcxv8BfNZf5xaePQC1YsEBTpkzRPffco169emnx4sUKCwvTa6+95u3SAPg45hcAjYX5BfBtPnsEqqKiQvn5+ZoxY4a5LCAgQMnJycrLy6vzOeXl5SovLzcfl5SUSJJOnTolp9NZ53OcTqfOnTunIGeAqqr967yToGpD585V+11v9NW4Tp48ecExZ86ckSQZhtHY5TSKi51fLmVukfx7fmlIU/lZ9jR/7PtC80HNz/jJkycVHBzsltdkfmme84s//f7QizVW3m+4m9X5xWcD1IkTJ1RVVaXo6GiX5dHR0frXv/5V53MyMzM1Z86cWsvj4+MbpUZfcJe3C2gk9NV42s+3PvbMmTOKiIhovGIaycXOL8wtF68p/Cx7g7/1fTHzgbsxvzS/+cWffn/o5cKa8vziswHqUsyYMUMZGRnm4+rqap06dUrt2rWTzVZ3ai4tLVVcXJy+/PJLhYeHe6pUj/DX3ujL+wzD0JkzZxQbG+vtUjziUuYWybe+p+5E382n78bomfmlec4v/tQPvTRdVucXnw1Q7du3V2BgoIqLi12WFxcXKyYmps7n2O122e12l2WRkZGWXi88PNwvfjDq4q+90Zd3+eL/DNe42PnlcuYWyXe+p+5G382Hu3tmfom0/Hr+9vPmT/3QS9NkZX7x2YtIhISEKCEhQbm5ueay6upq5ebmyuFweLEyAL6O+QVAY2F+AXyfzx6BkqSMjAxNmjRJiYmJuv766/XMM8/o7Nmzuueee7xdGgAfx/wCoLEwvwC+zacD1B133KGvv/5aM2fOVFFRkfr166f169fXOjHzctjtds2aNavW4XN/4K+90Rfcgfml8dB38+m7OfZsBfPLxfOnfujF99kMX70OKAAAAAB4mM+eAwUAAAAAnkaAAgAAAACLCFAAAAAAYBEBCgAAAAAsIkBdQFZWlq644gqFhoYqKSlJu3bt8nZJDdqyZYtuueUWxcbGymazadWqVS7rDcPQzJkz1bFjR7Vo0ULJyck6dOiQy5hTp05p/PjxCg8PV2RkpCZPnqyysjIPdlFbZmamBgwYoNatWysqKkpjxozRwYMHXcacP39e6enpateunVq1aqWxY8fWulFhYWGh0tLSFBYWpqioKD300EOqrKz0ZCsuXnzxRfXp08e8AZ3D4dA//vEPc70v9gTrfG1+uVjumI98jbvmKl/jjrkM7tXU55fZs2fLZrO5fPXo0cNc39T//nnq/dbevXs1dOhQhYaGKi4uTvPmzfN4L3fffXet79WoUaOaZC8eY6Bey5cvN0JCQozXXnvNOHDggDFlyhQjMjLSKC4u9nZp9Vq3bp3x//7f/zPeeecdQ5KxcuVKl/VPPPGEERERYaxatcr45z//afzkJz8x4uPjjW+//dYcM2rUKKNv377Gjh07jK1btxrdunUz7rzzTg934io1NdVYsmSJsX//fqOgoMC46aabjM6dOxtlZWXmmPvuu8+Ii4szcnNzjd27dxsDBw40Bg0aZK6vrKw0rr32WiM5OdnYs2ePsW7dOqN9+/bGjBkzvNGSYRiGsXr1amPt2rXGv//9b+PgwYPG73//eyM4ONjYv3+/YRi+2ROs8cX55WK5Yz7yNe6Yq3zR5c5lcC9fmF9mzZplXHPNNcaxY8fMr6+//tpc39T//nni/VZJSYkRHR1tjB8/3ti/f7/xt7/9zWjRooXx0ksvebSXSZMmGaNGjXL5Xp06dcplTFPpxVMIUA24/vrrjfT0dPNxVVWVERsba2RmZnqxKut++EtQXV1txMTEGE899ZS57PTp04bdbjf+9re/GYZhGJ988okhyfjoo4/MMf/4xz8Mm81m/Oc///FY7Rdy/PhxQ5KxefNmwzC+6yM4ONh4++23zTGffvqpIcnIy8szDOO7CSIgIMAoKioyx7z44otGeHi4UV5e7tkGGtCmTRvjlVde8aueUJuvzy8X61LmI39wKXOVv7iYuQzu5Qvzy6xZs4y+ffvWuc7X/v411vutF154wWjTpo1LP7/73e+M7t27e6wXw/guQN166631Pqep9tKY+AhfPSoqKpSfn6/k5GRzWUBAgJKTk5WXl+fFyi7dkSNHVFRU5NJTRESEkpKSzJ7y8vIUGRmpxMREc0xycrICAgK0c+dOj9dcn5KSEklS27ZtJUn5+flyOp0uvfXo0UOdO3d26a13794uNypMTU1VaWmpDhw44MHq61ZVVaXly5fr7NmzcjgcftET6uaP88vFsjIf+YNLmat83aXMZXAfX5pfDh06pNjYWHXt2lXjx49XYWGhJN//m+6u91t5eXkaNmyYQkJCzDGpqak6ePCgvvnmGw91851NmzYpKipK3bt319SpU3Xy5Elzna/14g4EqHqcOHFCVVVVte4KHh0draKiIi9VdXlq6m6op6KiIkVFRbmsDwoKUtu2bZtM39XV1Zo+fboGDx6sa6+9VtJ3dYeEhCgyMtJl7A97q6v3mnXesm/fPrVq1Up2u1333XefVq5cqV69evl0T2iYP84vF8vKfOTrLnWu8lWXM5fBfXxlfklKStLSpUu1fv16vfjiizpy5IiGDh2qM2fO+PzfP3e932oqPY4aNUpvvPGGcnNz9eSTT2rz5s0aPXq0qqqqzFp8pRd3CfJ2AcDFSk9P1/79+7Vt2zZvl+IW3bt3V0FBgUpKSvT3v/9dkyZN0ubNm71dFoDL5G9z1YUwl+FijB492vx3nz59lJSUpC5duuitt95SixYtvFgZfmjcuHHmv3v37q0+ffroyiuv1KZNmzRixAgvVuY9HIGqR/v27RUYGFjrii/FxcWKiYnxUlWXp6buhnqKiYnR8ePHXdZXVlbq1KlTTaLvadOmac2aNfrggw/UqVMnc3lMTIwqKip0+vRpl/E/7K2u3mvWeUtISIi6deumhIQEZWZmqm/fvnr22Wd9uic0zB/nl4tlZT7yZZczV/mqy5nL4D6+Or9ERkbq6quv1uHDh33+75+73m811R67du2q9u3b6/Dhw2YtvtrLpSJA1SMkJEQJCQnKzc01l1VXVys3N1cOh8OLlV26+Ph4xcTEuPRUWlqqnTt3mj05HA6dPn1a+fn55piNGzequrpaSUlJHq+5hmEYmjZtmlauXKmNGzcqPj7eZX1CQoKCg4Ndejt48KAKCwtdetu3b5/LL3lOTo7Cw8PVq1cvzzRiQXV1tcrLy/2qJ7jyx/nlYlmZj3yRO+Yqf3Excxncx1fnl7KyMn322Wfq2LGjz//9c9f7LYfDoS1btsjpdJpjcnJy1L17d7Vp08ZD3dR29OhRnTx5Uh07dpTk271cMm9fxaIpW758uWG3242lS5can3zyiXHvvfcakZGRLld8aWrOnDlj7Nmzx9izZ48hyViwYIGxZ88e4//+7/8Mw/juspqRkZHGu+++a+zdu9e49dZb67ysZv/+/Y2dO3ca27ZtM6666iqvX8Z86tSpRkREhLFp0yaXy2ieO3fOHHPfffcZnTt3NjZu3Gjs3r3bcDgchsPhMNfXXPI0JSXFKCgoMNavX2906NDBq5f8fuSRR4zNmzcbR44cMfbu3Ws88sgjhs1mM7Kzsw3D8M2eYI0vzi8Xyx3zka9xx1zliy53LoN7+cL88tvf/tbYtGmTceTIEWP79u1GcnKy0b59e+P48eOGYTT9v3+eeL91+vRpIzo62pgwYYKxf/9+Y/ny5UZYWJjbL/3dUC9nzpwxHnzwQSMvL884cuSI8f777xvXXXedcdVVVxnnz59vcr14CgHqAp577jmjc+fORkhIiHH99dcbO3bs8HZJDfrggw8MSbW+Jk2aZBjGd5fW/MMf/mBER0cbdrvdGDFihHHw4EGXbZw8edK48847jVatWhnh4eHGPffcY5w5c8YL3fxXXT1JMpYsWWKO+fbbb41f//rXRps2bYywsDDjpz/9qXHs2DGX7XzxxRfG6NGjjRYtWhjt27c3fvvb3xpOp9PD3fzXL3/5S6NLly5GSEiI0aFDB2PEiBHmGw7D8M2eYJ2vzS8Xyx3zka9x11zla9wxl8G9mvr8cscddxgdO3Y0QkJCjB/96EfGHXfcYRw+fNhc39T//nnq/dY///lPY8iQIYbdbjd+9KMfGU888YRHezl37pyRkpJidOjQwQgODja6dOliTJkypVYYbyq9eIrNMAyjcY9xAQAAAIB/4BwoAAAAALCIAAUAAAAAFhGgAAAAAMAiAhQAAAAAWESAAgAAAACLCFAAAAAAYBEBCgAAAAAsIkABAAAAgEUEKAAAAACwiAAFAAAAABYRoAAAAADAIgIUAAAAAFhEgAIAAAAAiwhQAAAAAGARAQoAAAAALCJAAQAAAIBFBCgAAAAAsIgABQAAAAAWEaAAAAAAwCICFAAAAABYRICCi9mzZ8tms3m7DBeVlZV6+OGHFRcXp4CAAI0ZM8bbJdXyxRdfyGaz6emnn/Z2KQAAAGhEBCh4nNPp1KJFizRgwAC1bt1arVq10oABA7Ro0SI5nc5a41977TU99dRT+tnPfqbXX39dDzzwgMLDw3XrrbfWGrtw4ULZbDZNmjSp1rqZM2fKZrPp3//+d6P0BQAAAP8X5O0C0LycPXtWaWlp2rx5s26++WbdfffdCggI0Pr16/Wb3/xG77zzjtauXauWLVuaz9m4caN+9KMfaeHCheaygQMH6sMPP6y1/e3btysoKEjbt2+vc11UVJSuvvrqxmkOAAAAfo8jUPCojIwMbd68Wc8995zee+89paena+rUqXr33Xf1/PPPa/PmzXrwwQddnnP8+HFFRka6LBsyZIhOnDihTz/91GX59u3bdfvtt+uzzz5TUVGRubyyslI7d+7U4MGDG603AAAA+D8CVDO2bds2DRgwQKGhobryyiv10ksv1RqzZMkS3XjjjYqKipLdblevXr304osvuoyZNGmS2rdvX+fH71JSUtS9e3dJ0tGjR/Xqq6/qxhtv1LRp02qNTU9P1w033KBXXnlFR48eNc8r+uCDD3TgwAHZbDbZbDZt2rRJQ4YMkSSXI02ff/65ioqKNG3aNIWGhrqsKygo0NmzZ83nSdK//vUv/exnP1Pbtm0VGhqqxMRErV69ulZdp0+f1vTp0xUXFye73a5u3brpySefVHV1dYP71zAM3XvvvQoJCdE777zT4FgAAAD4BgJUM7Vv3z6lpKTo+PHjmj17tu655x7NmjVLK1eudBn34osvqkuXLvr973+v+fPnKy4uTr/+9a+VlZVljpkwYYJOnjypDRs2uDy3qKhIGzdu1C9+8QtJ0j/+8Q9VVVVp4sSJ9dY1ceJEVVZWav369erQoYP+8pe/qEePHurUqZP+8pe/6C9/+Yt69uypgQMHKigoSNu2bTOfu337drVs2VIDBgxQYmKiS4Cq+XdNgDpw4IAGDhyoTz/9VI888ojmz5+vli1basyYMS774Ny5c/rxj3+sv/71r5o4caIWLVqkwYMHa8aMGcrIyKi3j6qqKt1999164403tHLlSt122231jgUAAIAPMdAsjRkzxggNDTX+7//+z1z2ySefGIGBgcb3fyzOnTtX67mpqalG165dzcdVVVVGp06djDvuuMNl3IIFCwybzWZ8/vnnhmEYxvTp0w1Jxp49e+qt6+OPPzYkGRkZGeayH//4x8Y111xTa+yAAQOMK6+80nz8P//zP8YNN9xgGIZhPPzww8aAAQPMdT/72c+MsLAww+l0GoZhGCNGjDB69+5tnD9/3hxTXV1tDBo0yLjqqqvMZXPnzjVatmxp/Pvf/3Z57UceecQIDAw0CgsLDcMwjCNHjhiSjKeeespwOp3GHXfcYbRo0cLYsGFDvb0CAADA93AEqhmqqqrShg0bNGbMGHXu3Nlc3rNnT6WmprqMbdGihfnvkpISnThxQj/+8Y/1+eefq6SkRJIUEBCg8ePHa/Xq1Tpz5ow5/s0339SgQYMUHx8vSea61q1b11tbzbrS0tIL9jFkyBCXc522b9+uQYMGSZIGDx6sPXv26Ny5c+a6pKQkBQUF6dSpU9q4caNuv/12nTlzRidOnNCJEyd08uRJpaam6tChQ/rPf/4jSXr77bc1dOhQtWnTxhx34sQJJScnq6qqSlu2bHGpqaKiQj//+c+1Zs0arVu3TikpKRfsAwAAAL6DANUMff311/r222911VVX1VpXc75Sje3btys5OVktW7ZUZGSkOnTooN///veSZAYo6buP3n377bfmx98OHjyo/Px8TZgwwRxTE46+H7J+yErIqvH986BOnz6tAwcOmBeJGDRokCorK7Vr1y4dOXJEx44dM8cfPnxYhmHoD3/4gzp06ODyNWvWLEnfXbhCkg4dOmR+nPD7X8nJyS7jamRmZmrVqlX6+9//ruHDh1+wBwAAAPgWLmOOen322WcaMWKEevTooQULFiguLk4hISFat26dFi5c6HIRhV69eikhIcE8V+ivf/2rQkJCdPvtt5tjevbsKUnau3ev+vXrV+dr7t2719zehdQEom3btiksLEyS5HA4JEnt27fXVVddpW3btunLL790GV9T94MPPljriFuNbt26mWNHjhyphx9+uM5xP7wkempqqtavX6958+Zp+PDhCg0NvWAfAAAA8B0EqGaoQ4cOatGihQ4dOlRr3cGDB81/v/feeyovL9fq1atdPur3wQcf1LndiRMnKiMjQ8eOHdOyZcuUlpamNm3amOtHjx6twMBA/eUvf6n3QhJvvPGGgoKCNGrUqAv2ERUVZYakli1bqlevXi6XOx80aJC2b9+uo0ePKjAw0AxXXbt2lSQFBwebR5Lqc+WVV6qsrOyC42oMHDhQ9913n26++Wb9/Oc/18qVKxUUxK8ZAACAv+AjfM1QYGCgUlNTtWrVKhUWFprLP/30U5cr6QUGBkr67nLcNUpKSrRkyZI6t3vnnXfKZrPpN7/5jT7//HPz6ns14uLidM899+j999+vdSl0SVq8eLE2btyoyZMnq1OnTpZ6GTJkiAoKCpSdnW2e/1Rj0KBBysvL09atW9WnTx/zY4FRUVEaPny4XnrpJR07dqzWNr/++mvz37fffrvy8vJqXWFQ+u7y5pWVlbWWJycna/ny5Vq/fr0mTJhwwcudAwAAwHfwX+PN1Jw5c7R+/XoNHTpUv/71r1VZWannnntO11xzjfkxupSUFIWEhOiWW27R//zP/6isrEx//vOfFRUVVWfw6NChg0aNGqW3335bkZGRSktLqzVm4cKF+te//qVf//rXWr9+vXmkacOGDXr33Xf14x//WPPnz7fcx5AhQ7RkyRJ99NFHSk9Pd1k3aNAglZSUqKSkRPfff7/LuqysLA0ZMkS9e/fWlClT1LVrVxUXFysvL09Hjx7VP//5T0nSQw89pNWrV+vmm2/W3XffrYSEBJ09e1b79u3T3//+d33xxRdq3759rbrGjBmjJUuWaOLEiQoPD6/zHlsAAADwQd6+DCC8Z/PmzUZCQoIREhJidO3a1Vi8eLExa9Ysl8uYr1692ujTp48RGhpqXHHFFcaTTz5pvPbaa4Yk48iRI7W2+dZbbxmSjHvvvbfe1y0vLzcWLlxoJCQkGC1btjTCwsKM6667znjmmWeMioqKWuPru4y5YRjGwYMHDUmGpFqXGq+urjYiIyMNScaKFStqPfezzz4zJk6caMTExBjBwcHGj370I+Pmm282/v73v7uMO3PmjDFjxgyjW7duRkhIiNG+fXtj0KBBxtNPP23W+/3LmH/fCy+8YEgyHnzwwXr3BwAAAHyHzTC+9/ks4DK9++67GjNmjLZs2aKhQ4d6uxwAAADArQhQcKubb75Zn376qQ4fPiybzebtcgAAAAC34hwouMXy5cu1d+9erV27Vs8++yzhCQAAAH6JI1BwC5vNplatWumOO+7Q4sWLuXQ3AAAA/BLvcuEW5HAAAAA0B9wHCgAAAAAsIkABAAAAgEXN+iN81dXV+uqrr9S6dWsuegC4kWEYOnPmjGJjYxUQwP/TAAAA/9GsA9RXX32luLg4b5cB+K0vv/xSnTp18nYZAAAAbtOsA1Tr1q0lffcmLzw8vM4xTqdT2dnZSklJUXBwsCfLa1LYD+wDyfo+KC0tVVxcnPk7BgAA4C+adYCq+dheeHh4gwEqLCxM4eHhzfZNs8R+kNgH0sXvAz4aCwAA/A0nJwAAAACARQQoAAAAALCIAAUAAAAAFhGgAAAAAMAiAhQAAAAAWESAAgAAAACL3B6gMjMzNWDAALVu3VpRUVEaM2aMDh486DLm/PnzSk9PV7t27dSqVSuNHTtWxcXFLmMKCwuVlpamsLAwRUVF6aGHHlJlZaXLmE2bNum6666T3W5Xt27dtHTpUne3AwAAAAAmtweozZs3Kz09XTt27FBOTo6cTqdSUlJ09uxZc8wDDzyg9957T2+//bY2b96sr776Srfddpu5vqqqSmlpaaqoqNCHH36o119/XUuXLtXMmTPNMUeOHFFaWppuuOEGFRQUaPr06frVr36lDRs2uLslAAAAAJDUCDfSXb9+vcvjpUuXKioqSvn5+Ro2bJhKSkr06quvatmyZbrxxhslSUuWLFHPnj21Y8cODRw4UNnZ2frkk0/0/vvvKzo6Wv369dPcuXP1u9/9TrNnz1ZISIgWL16s+Ph4zZ8/X5LUs2dPbdu2TQsXLlRqaqq729K1szeovMo9NwX94ok0t2wHAAAAgGc1+jlQJSUlkqS2bdtKkvLz8+V0OpWcnGyO6dGjhzp37qy8vDxJUl5ennr37q3o6GhzTGpqqkpLS3XgwAFzzPe3UTOmZhsAAAAA4G5uPwL1fdXV1Zo+fboGDx6sa6+9VpJUVFSkkJAQRUZGuoyNjo5WUVGROeb74almfc26hsaUlpbq22+/VYsWLWrVU15ervLycvNxaWmpJMnpdMrpdNbZQ81ye4BhqWcr6nutpqymZl+s3V3YB9b3QXPeRwAAwL81aoBKT0/X/v37tW3btsZ8GcsyMzM1Z86cWsuzs7MVFhbW4HPnJla7rY5169a5bVuelpOT4+0SvI59cOF9cO7cOQ9VAgAA4FmNFqCmTZumNWvWaMuWLerUqZO5PCYmRhUVFTp9+rTLUaji4mLFxMSYY3bt2uWyvZqr9H1/zA+v3FdcXKzw8PA6jz5J0owZM5SRkWE+Li0tVVxcnFJSUhQeHl7nc5xOp3JycvSH3QEqr3bPOVD7Z7v/HK3GVrMfRo4cqeDgYG+X4xbXzr64C47YAwzNTayu82fBF7+nl8Lqz0HN0V0AAAB/4/YAZRiG7r//fq1cuVKbNm1SfHy8y/qEhAQFBwcrNzdXY8eOlSQdPHhQhYWFcjgckiSHw6E//vGPOn78uKKioiR99z/e4eHh6tWrlznmh0dycnJyzG3UxW63y26311oeHBx8wVBQXm1z20UkfDmAWNlXvuJSv591/Sz4yz6x6kI/B81tfwAAgObD7QEqPT1dy5Yt07vvvqvWrVub5yxFRESoRYsWioiI0OTJk5WRkaG2bdsqPDxc999/vxwOhwYOHChJSklJUa9evTRhwgTNmzdPRUVFevTRR5Wenm4GoPvuu0/PP/+8Hn74Yf3yl7/Uxo0b9dZbb2nt2rXubgkAAAAAJDXCVfhefPFFlZSUaPjw4erYsaP5tWLFCnPMwoULdfPNN2vs2LEaNmyYYmJi9M4775jrAwMDtWbNGgUGBsrhcOgXv/iFJk6cqMcee8wcEx8fr7Vr1yonJ0d9+/bV/Pnz9corrzTKJcwBAAAAQGqkj/BdSGhoqLKyspSVlVXvmC5dulzwYgvDhw/Xnj17LrpG1O+KR+o+gmcPNDTv+ou/Hxb3vAIAAIA/adSr8KFu9YWUS0VIAQAAADyj0W+kCwAAAAD+giNQ8BnuPnLXlHGUEgAAoGniCBQAAAAAWESAAgAAAACLCFAAAAAAYBEBCgAAAAAsIkABAAAAgEUEKAAAAACwiAAFAAAAABYRoAAAAADAIgIUAAAAAFhEgAIAAAAAiwhQAAAAAGARAQoAAAAALCJAAQAAAIBFBCgAAAAAsIgABQAAAAAWEaAAAAAAwCICFAAAAABYRIACAAAAAIsIUAAAAABgEQEKAAAAACwiQAEAAACARQQoAAAAALCIAAUAAAAAFhGgAAAAAMAiAhQAAAAAWESAAgAAAACLCFAAAAAAYBEBCgAAAAAsIkABAAAAgEUEKAAAAACwiAAFAAAAABYRoAAAAADAIgIUAAAAAFhEgAIAAAAAiwhQAAAAAGARAQoAAAAALCJAAQAAAIBFbg9QW7Zs0S233KLY2FjZbDatWrXKZf3dd98tm83m8jVq1CiXMadOndL48eMVHh6uyMhITZ48WWVlZS5j9u7dq6FDhyo0NFRxcXGaN2+eu1sBAAAAABduD1Bnz55V3759lZWVVe+YUaNG6dixY+bX3/72N5f148eP14EDB5STk6M1a9Zoy5Ytuvfee831paWlSklJUZcuXZSfn6+nnnpKs2fP1ssvv+zudgAAAADAFOTuDY4ePVqjR49ucIzdbldMTEyd6z799FOtX79eH330kRITEyVJzz33nG666SY9/fTTio2N1ZtvvqmKigq99tprCgkJ0TXXXKOCggItWLDAJWgBAAAAgDu5PUBZsWnTJkVFRalNmza68cYb9fjjj6tdu3aSpLy8PEVGRprhSZKSk5MVEBCgnTt36qc//any8vI0bNgwhYSEmGNSU1P15JNP6ptvvlGbNm3qfN3y8nKVl5ebj0tLSyVJTqdTTqezzufULLcHGJfXdCOqr/ZLYQ+su8+a/i92P3iiNk9paB+4s0/J/b26q76a7Vxoe+7eHwAAAE2FxwPUqFGjdNtttyk+Pl6fffaZfv/732v06NHKy8tTYGCgioqKFBUV5VpkUJDatm2roqIiSVJRUZHi4+NdxkRHR5vr6gtQmZmZmjNnTq3l2dnZCgsLa7DuuYnVlnv0tHXr1rltW/Oub3j9xe4HT9bmKXXtA3f2Kbm/V3fXl5OT0+D6c+fOufX1AAAAmgqPB6hx48aZ/+7du7f69OmjK6+8Ups2bdKIESMa9bVnzJihjIwM83Fpaani4uKUkpKi8PDwOp/jdDqVk5OjP+wOUHm1rVHru1T7Z6e6bVvXzt5Q53J7gKG5idUXvR88UZunNLQP3Nmn5P5e3VVfze/DyJEjFRwcXO+4mqO7AAAA/sYrH+H7vq5du6p9+/Y6fPiwRowYoZiYGB0/ftxlTGVlpU6dOmWeNxUTE6Pi4mKXMTWP6zu3Svru3Cu73V5reXBwcINvBiWpvNqm8qqmGaAuVPvFuFCPF7sfPFmbp9S1D9zZp+T+Xt1d34V+Z9z9egAAAE2F1+8DdfToUZ08eVIdO3aUJDkcDp0+fVr5+fnmmI0bN6q6ulpJSUnmmC1btricZ5GTk6Pu3bvX+/E9AAAAALhcbg9QZWVlKigoUEFBgSTpyJEjKigoUGFhocrKyvTQQw9px44d+uKLL5Sbm6tbb71V3bp1U2rqdx8x6tmzp0aNGqUpU6Zo165d2r59u6ZNm6Zx48YpNjZWknTXXXcpJCREkydP1oEDB7RixQo9++yzLh/PAwAAAAB3c3uA2r17t/r376/+/ftLkjIyMtS/f3/NnDlTgYGB2rt3r37yk5/o6quv1uTJk5WQkKCtW7e6fLTuzTffVI8ePTRixAjddNNNGjJkiMs9niIiIpSdna0jR44oISFBv/3tbzVz5kwuYQ4AAACgUbn9HKjhw4fLMOq/BPOGDRc+Ob5t27ZatmxZg2P69OmjrVu3XnR9AAAAAHCpvH4OFAAAAAD4CgIUAAAAAFhEgAIAAAAAiwhQAAAAAGARAQoAAAAALCJAAQAAAIBFBCgAAAAAsIgABQAAAAAWEaAAAAAAwCICFAAAAABYRIACAAAAAIsIUAAAAABgUZC3CwDQ+K54ZK1btmMPNDTverdsCgAAwCdxBAoAAAAALCJAAQAAAIBFBCgAAAAAsIgABQAAAAAWEaAAAAAAwCICFAAAAABYRIACAAAAAIsIUAAAAABgEQEKAAAAACwiQAEAAACARQQoAAAAALCIAAUAAAAAFhGgAAAAAMAiAhQAAAAAWESAAgAAAACLCFAAAAAAYBEBCgAAAAAsIkABAAAAgEUEKAAAAACwiAAFAAAAABYRoAAAAADAIgIUAAAAAFhEgAIAAAAAiwhQAAAAAGARAQoAAAAALCJAAQAAAIBFbg9QW7Zs0S233KLY2FjZbDatWrXKZb1hGJo5c6Y6duyoFi1aKDk5WYcOHXIZc+rUKY0fP17h4eGKjIzU5MmTVVZW5jJm7969Gjp0qEJDQxUXF6d58+a5uxUAAAAAcOH2AHX27Fn17dtXWVlZda6fN2+eFi1apMWLF2vnzp1q2bKlUlNTdf78eXPM+PHjdeDAAeXk5GjNmjXasmWL7r33XnN9aWmpUlJS1KVLF+Xn5+upp57S7Nmz9fLLL7u7HQAAAAAwBbl7g6NHj9bo0aPrXGcYhp555hk9+uijuvXWWyVJb7zxhqKjo7Vq1SqNGzdOn376qdavX6+PPvpIiYmJkqTnnntON910k55++mnFxsbqzTffVEVFhV577TWFhITommuuUUFBgRYsWOAStAAAAADAndweoBpy5MgRFRUVKTk52VwWERGhpKQk5eXlady4ccrLy1NkZKQZniQpOTlZAQEB2rlzp376058qLy9Pw4YNU0hIiDkmNTVVTz75pL755hu1adOmztcvLy9XeXm5+bi0tFSS5HQ65XQ663xOzXJ7gHHpjTey+mq/FPbAuvus6f9i94MnavOUhvaBO/uUvN9rfWp6v1C/7t4fAAAATYVHA1RRUZEkKTo62mV5dHS0ua6oqEhRUVEu64OCgtS2bVuXMfHx8bW2UbOuvgCVmZmpOXPm1FqenZ2tsLCwBmufm1jd4HpvWrdundu2Ne/6htdf7H7wZG2eUtc+cGefUtPptT45OTkNrj937pyHKgEAAPAsjwYob5sxY4YyMjLMx6WlpYqLi1NKSorCw8PrfI7T6VROTo7+sDtA5dU2T5V6UfbPTnXbtq6dvaHO5fYAQ3MTqy96P3iiNk9paB+4s0/J+73Wp2YfjBw5UsHBwfWOqzm6CwAA4G88GqBiYmIkScXFxerYsaO5vLi4WP369TPHHD9+3OV5lZWVOnXqlPn8mJgYFRcXu4ypeVwzpi52u112u73W8uDg4AbfDEpSebVN5VVNM0BdqPaLcaEeL3Y/eLI2T6lrH7izT6np9FqfC/3OuHt/AAAANBUevQ9UfHy8YmJilJubay4rLS3Vzp075XA4JEkOh0OnT59Wfn6+OWbjxo2qrq5WUlKSOWbLli0u51nk5OSoe/fu9X58DwAAAAAul9sDVFlZmQoKClRQUCDpuwtHFBQUqLCwUDabTdOnT9fjjz+u1atXa9++fZo4caJiY2M1ZswYSVLPnj01atQoTZkyRbt27dL27ds1bdo0jRs3TrGxsZKku+66SyEhIZo8ebIOHDigFStW6Nlnn3X5eB4AAAAAuJvbP8K3e/du3XDDDebjmlAzadIkLV26VA8//LDOnj2re++9V6dPn9aQIUO0fv16hYaGms958803NW3aNI0YMUIBAQEaO3asFi1aZK6PiIhQdna20tPTlZCQoPbt22vmzJlcwhwAAABAo3J7gBo+fLgMo/5LMNtsNj322GN67LHH6h3Ttm1bLVu2rMHX6dOnj7Zu3XrJdQIAAADAxfLoOVAAAAAA4MsIUAAAAABgEQEKAAAAACwiQAEAAACARQQoAAAAALCIAAUAAAAAFhGgAAAAAMAiAhQAAAAAWESAAgAAAACLCFAAAAAAYBEBCgAAAAAsIkABAAAAgEUEKAAAAACwiAAFAAAAABYRoAAAAADAIgIUAAAAAFhEgAIAAAAAiwhQAAAAAGARAQoAAAAALCJAAQAAAIBFBCgAAAAAsIgABQAAAAAWEaAAAAAAwCICFAAAAABYRIACAAAAAIsIUAAAAABgEQEKAAAAACwiQAEAAACARQQoAAAAALCIAAUAAAAAFhGgAAAAAMAiAhQAAAAAWESAAgAAAACLCFAAAAAAYBEBCgAAAAAsIkABAAAAgEUEKAAAAACwiAAFAAAAABYRoAAAAADAIq8EqNmzZ8tms7l89ejRw1x//vx5paenq127dmrVqpXGjh2r4uJil20UFhYqLS1NYWFhioqK0kMPPaTKykpPtwIAAACgGQny1gtfc801ev/99/9bSNB/S3nggQe0du1avf3224qIiNC0adN02223afv27ZKkqqoqpaWlKSYmRh9++KGOHTumiRMnKjg4WH/605883gsAAACA5sFrASooKEgxMTG1lpeUlOjVV1/VsmXLdOONN0qSlixZop49e2rHjh0aOHCgsrOz9cknn+j9999XdHS0+vXrp7lz5+p3v/udZs+erZCQEE+3AwAAAKAZ8FqAOnTokGJjYxUaGiqHw6HMzEx17txZ+fn5cjqdSk5ONsf26NFDnTt3Vl5engYOHKi8vDz17t1b0dHR5pjU1FRNnTpVBw4cUP/+/et8zfLycpWXl5uPS0tLJUlOp1NOp7PO59QstwcYl91zY6mv9kthD6y7z5r+L3Y/eKI2T2loH7izT8n7vdanpvcL9evu/QEAANBUeCVAJSUlaenSperevbuOHTumOXPmaOjQodq/f7+KiooUEhKiyMhIl+dER0erqKhIklRUVOQSnmrW16yrT2ZmpubMmVNreXZ2tsLCwhqseW5itZXWvGLdunVu29a86xtef7H7wZO1eUpd+8CdfUpNp9f65OTkNLj+3LlzHqoEAADAs7wSoEaPHm3+u0+fPkpKSlKXLl301ltvqUWLFo32ujNmzFBGRob5uLS0VHFxcUpJSVF4eHidz3E6ncrJydEfdgeovNrWaLVdjv2zU922rWtnb6hzuT3A0NzE6oveD56ozVMa2gfu7FPyfq/1qdkHI0eOVHBwcL3jao7uAgAA+BuvfYTv+yIjI3X11Vfr8OHDGjlypCoqKnT69GmXo1DFxcXmOVMxMTHatWuXyzZqrtJX13lVNex2u+x2e63lwcHBDb4ZlKTyapvKq5pmgLpQ7RfjQj1e7H7wZG2eUtc+cGefUtPptT4X+p1x9/4AAABoKprEfaDKysr02WefqWPHjkpISFBwcLByc3PN9QcPHlRhYaEcDockyeFwaN++fTp+/Lg5JicnR+Hh4erVq5fH6wcAAADQPHjlCNSDDz6oW265RV26dNFXX32lWbNmKTAwUHfeeaciIiI0efJkZWRkqG3btgoPD9f9998vh8OhgQMHSpJSUlLUq1cvTZgwQfPmzVNRUZEeffRRpaen13mECQAAAADcwSsB6ujRo7rzzjt18uRJdejQQUOGDNGOHTvUoUMHSdLChQsVEBCgsWPHqry8XKmpqXrhhRfM5wcGBmrNmjWaOnWqHA6HWrZsqUmTJumxxx7zRjsAAAAAmgmvBKjly5c3uD40NFRZWVnKysqqd0yXLl3cfuUzAAAAAGhIkzgHCgAAAAB8AQEKAAAAACwiQAEAAACARQQoAAAAALCIAAUAAAAAFhGgAAAAAMAiAhQAAAAAWESAAgAAAACLCFAAAAAAYBEBCgAAAAAsIkABAAAAgEUEKAAAAACwiAAFAAAAABYRoAAAAADAIgIUAAAAAFhEgAIAAAAAiwhQAAAAAGARAQoAAAAALCJAAQAAAIBFBCgAAAAAsIgABQAAAAAWEaAAAAAAwCICFAAAAABYRIACAAAAAIsIUAAAAABgEQEKAAAAACwiQAEAAACARQQoAAAAALCIAAUAAAAAFhGgAAAAAMAiAhQAAAAAWESAAgAAAACLCFAAAAAAYBEBCgAAAAAsIkABAAAAgEUEKAAAAACwiAAFAAAAABYRoAAAAADAIgIUAAAAAFjk8wEqKytLV1xxhUJDQ5WUlKRdu3Z5uyQAAAAAfsqnA9SKFSuUkZGhWbNm6eOPP1bfvn2Vmpqq48ePe7s0AAAAAH7IpwPUggULNGXKFN1zzz3q1auXFi9erLCwML322mveLg0AAACAHwrydgGXqqKiQvn5+ZoxY4a5LCAgQMnJycrLy6vzOeXl5SovLzcfl5SUSJJOnTolp9NZ53OcTqfOnTunIGeAqqptbuzAfU6ePOm2bQVVnq17ebWhc+eqL3o/eKI2T2loH7izT8n7vdanZh+cPHlSwcHB9Y47c+aMJMkwDE+VBgAA4BE+G6BOnDihqqoqRUdHuyyPjo7Wv/71rzqfk5mZqTlz5tRaHh8f3yg1ekr7+Z55nbsu4Tmeqs1T6tsH/tZnQy7m5+DMmTOKiIhotFoAAAA8zWcD1KWYMWOGMjIyzMfV1dU6deqU2rVrJ5ut7qMqpaWliouL05dffqnw8HBPldrksB/YB5L1fWAYhs6cOaPY2FgPVgcAAND4fDZAtW/fXoGBgSouLnZZXlxcrJiYmDqfY7fbZbfbXZZFRkZaer3w8PBm+6b5+9gP7APJ2j7gyBMAAPBHPnsRiZCQECUkJCg3N9dcVl1drdzcXDkcDi9WBgAAAMBf+ewRKEnKyMjQpEmTlJiYqOuvv17PPPOMzp49q3vuucfbpQEAAADwQz4doO644w59/fXXmjlzpoqKitSvXz+tX7++1oUlLofdbtesWbNqffSvuWE/sA8k9gEAAIDN4DrDAAAAAGCJz54DBQAAAACeRoACAAAAAIsIUAAAAABgEQEKAAAAACwiQF1AVlaWrrjiCoWGhiopKUm7du3ydkkek5mZqQEDBqh169aKiorSmDFjdPDgQW+X5VVPPPGEbDabpk+f7u1SPO4///mPfvGLX6hdu3Zq0aKFevfurd27d3u7LAAAAI8iQDVgxYoVysjI0KxZs/Txxx+rb9++Sk1N1fHjx71dmkds3rxZ6enp2rFjh3JycuR0OpWSkqKzZ896uzSv+Oijj/TSSy+pT58+3i7F47755hsNHjxYwcHB+sc//qFPPvlE8+fPV5s2bbxdGgAAgEdxGfMGJCUlacCAAXr++eclSdXV1YqLi9P999+vRx55xMvVed7XX3+tqKgobd68WcOGDfN2OR5VVlam6667Ti+88IIef/xx9evXT88884y3y/KYRx55RNu3b9fWrVu9XQoAAIBXcQSqHhUVFcrPz1dycrK5LCAgQMnJycrLy/NiZd5TUlIiSWrbtq2XK/G89PR0paWlufw8NCerV69WYmKifv7znysqKkr9+/fXn//8Z2+XBQAA4HEEqHqcOHFCVVVVio6OdlkeHR2toqIiL1XlPdXV1Zo+fboGDx6sa6+91tvleNTy5cv18ccfKzMz09uleM3nn3+uF198UVdddZU2bNigqVOn6n//93/1+uuve7s0AAAAjwrydgHwDenp6dq/f7+2bdvm7VI86ssvv9RvfvMb5eTkKDQ01NvleE11dbUSExP1pz/9SZLUv39/7d+/X4sXL9akSZO8XB0AAIDncASqHu3bt1dgYKCKi4tdlhcXFysmJsZLVXnHtGnTtGbNGn3wwQfq1KmTt8vxqPz8fB0/flzXXXedgoKCFBQUpM2bN2vRokUKCgpSVVWVt0v0iI4dO6pXr14uy3r27KnCwkIvVQQAAOAdBKh6hISEKCEhQbm5ueay6upq5ebmyuFweLEyzzEMQ9OmTdPKlSu1ceNGxcfHe7skjxsxYoT27dungoIC8ysxMVHjx49XQUGBAgMDvV2iRwwePLjWJez//e9/q0uXLl6qCAAAwDv4CF8DMjIyNGnSJCUmJur666/XM888o7Nnz+qee+7xdmkekZ6ermXLlundd99V69atzXO/IiIi1KJFCy9X5xmtW7eudc5Xy5Yt1a5du2Z1LtgDDzygQYMG6U9/+pNuv/127dq1Sy+//LJefvllb5cGAADgUVzG/AKef/55PfXUUyoqKlK/fv20aNEiJSUlebssj7DZbHUuX7Jkie6++27PFtOEDB8+vNldxlyS1qxZoxkzZujQoUOKj49XRkaGpkyZ4u2yAAAAPIoABQAAAAAWcQ4UAAAAAFhEgAIAAAAAiwhQAAAAAGARAQoAAAAALCJAAQAAAIBFBCgAAAAAsIgABQAAAAAWEaAAAAAAwCICFAAAAABYRIACAAAAAIsIUAAAAABgEQEKAAAAACz6/3iTn/BEFYojAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 1000x1000 with 9 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "ed_flights.select_dtypes(include=np.number).hist(figsize=[10,10])\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "dCy_h-vONRFq"
+   },
+   "source": [
+    "### Elasticsearch utilities"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 59,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-09-20T14:02:08.803080Z",
+     "iopub.status.busy": "2023-09-20T14:02:08.802875Z",
+     "iopub.status.idle": "2023-09-20T14:02:08.812787Z",
+     "shell.execute_reply": "2023-09-20T14:02:08.812291Z"
+    },
+    "id": "IYKn-Uz2NRFr",
+    "pycharm": {
+     "is_executing": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "ed_flights2 = ed_flights[(ed_flights.OriginAirportID == 'AMS') & (ed_flights.FlightDelayMin > 60)]\n",
+    "ed_flights2 = ed_flights2[['timestamp', 'OriginAirportID', 'DestAirportID', 'FlightDelayMin']]\n",
+    "ed_flights2 = ed_flights2.tail()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 60,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "execution": {
+     "iopub.execute_input": "2023-09-20T14:02:08.815167Z",
+     "iopub.status.busy": "2023-09-20T14:02:08.814975Z",
+     "iopub.status.idle": "2023-09-20T14:02:08.820513Z",
+     "shell.execute_reply": "2023-09-20T14:02:08.820065Z"
+    },
+    "id": "hks1CjV0NRFr",
+    "outputId": "f7c37cb8-44e5-4335-e860-4cf48a848a78",
+    "pycharm": {
+     "is_executing": false
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "es_index_pattern: flights\n",
+      "Index:\n",
+      " es_index_field: _id\n",
+      " is_source_field: False\n",
+      "Mappings:\n",
+      " capabilities:\n",
+      "                   es_field_name  is_source es_dtype                  es_date_format        pd_dtype  is_searchable  is_aggregatable  is_scripted aggregatable_es_field_name\n",
+      "timestamp              timestamp       True     date  strict_date_hour_minute_second  datetime64[ns]           True             True        False                  timestamp\n",
+      "OriginAirportID  OriginAirportID       True  keyword                            None          object           True             True        False            OriginAirportID\n",
+      "DestAirportID      DestAirportID       True  keyword                            None          object           True             True        False              DestAirportID\n",
+      "FlightDelayMin    FlightDelayMin       True  integer                            None           int64           True             True        False             FlightDelayMin\n",
+      "Operations:\n",
+      " tasks: [('boolean_filter': ('boolean_filter': {'bool': {'must': [{'term': {'OriginAirportID': 'AMS'}}, {'range': {'FlightDelayMin': {'gt': 60}}}]}})), ('tail': ('sort_field': '_doc', 'count': 5))]\n",
+      " size: 5\n",
+      " sort_params: {'_doc': 'desc'}\n",
+      " _source: ['timestamp', 'OriginAirportID', 'DestAirportID', 'FlightDelayMin']\n",
+      " body: {'query': {'bool': {'must': [{'term': {'OriginAirportID': 'AMS'}}, {'range': {'FlightDelayMin': {'gt': 60}}}]}}}\n",
+      " post_processing: [('sort_index')]\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(ed_flights2.es_info())"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.13"
+  },
+  "pycharm": {
+   "stem_cell": {
+    "cell_type": "raw",
+    "metadata": {
+     "collapsed": false
+    },
+    "source": []
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
 }

--- a/docs/sphinx/reference/api/eland.pandas_to_es.rst
+++ b/docs/sphinx/reference/api/eland.pandas_to_es.rst
@@ -1,0 +1,6 @@
+﻿eland.pandas\_to\_es
+====================
+
+.. currentmodule:: eland
+
+.. autofunction:: pandas_to_es

--- a/docs/sphinx/reference/io.rst
+++ b/docs/sphinx/reference/io.rst
@@ -11,3 +11,6 @@ Flat File
    :toctree: api/
 
     csv_to_eland
+    eland_to_pandas
+    pandas_to_eland
+    pandas_to_es

--- a/eland/__init__.py
+++ b/eland/__init__.py
@@ -27,6 +27,7 @@ from ._version import (  # noqa: F401
 )
 from .common import SortOrder
 from .dataframe import DataFrame
+from .dataload import pandas_to_es
 from .etl import csv_to_eland, eland_to_pandas, pandas_to_eland
 from .index import Index
 from .ndframe import NDFrame
@@ -40,5 +41,6 @@ __all__ = [
     "pandas_to_eland",
     "eland_to_pandas",
     "csv_to_eland",
+    "pandas_to_es",
     "SortOrder",
 ]

--- a/eland/dataload.py
+++ b/eland/dataload.py
@@ -1,0 +1,192 @@
+#  Licensed to Elasticsearch B.V. under one or more contributor
+#  license agreements. See the NOTICE file distributed with
+#  this work for additional information regarding copyright
+#  ownership. Elasticsearch B.V. licenses this file to you under
+#  the Apache License, Version 2.0 (the "License"); you may
+#  not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+# 	http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+
+from typing import TYPE_CHECKING, Any, Dict
+
+from elasticsearch import helpers
+
+if TYPE_CHECKING:
+    import pandas as pd  # type: ignore
+    from elasticsearch import Elasticsearch
+
+FLIGHTS_INDEX_NAME = "flights"
+FLIGHTS_MAPPING = {
+    "mappings": {
+        "properties": {
+            "AvgTicketPrice": {"type": "float"},
+            "Cancelled": {"type": "boolean"},
+            "Carrier": {"type": "keyword"},
+            "Dest": {"type": "keyword"},
+            "DestAirportID": {"type": "keyword"},
+            "DestCityName": {"type": "keyword"},
+            "DestCountry": {"type": "keyword"},
+            "DestLocation": {"type": "geo_point"},
+            "DestRegion": {"type": "keyword"},
+            "DestWeather": {"type": "keyword"},
+            "DistanceKilometers": {"type": "float"},
+            "DistanceMiles": {"type": "float"},
+            "FlightDelay": {"type": "boolean"},
+            "FlightDelayMin": {"type": "integer"},
+            "FlightDelayType": {"type": "keyword"},
+            "FlightNum": {"type": "keyword"},
+            "FlightTimeHour": {"type": "float"},
+            "FlightTimeMin": {"type": "float"},
+            "Origin": {"type": "keyword"},
+            "OriginAirportID": {"type": "keyword"},
+            "OriginCityName": {"type": "keyword"},
+            "OriginCountry": {"type": "keyword"},
+            "OriginLocation": {"type": "geo_point"},
+            "OriginRegion": {"type": "keyword"},
+            "OriginWeather": {"type": "keyword"},
+            "dayOfWeek": {"type": "byte"},
+            "timestamp": {"type": "date", "format": "strict_date_hour_minute_second"},
+        }
+    }
+}
+
+
+ECOMMERCE_INDEX_NAME = "ecommerce"
+ECOMMERCE_MAPPING = {
+    "mappings": {
+        "properties": {
+            "category": {"type": "text", "fields": {"keyword": {"type": "keyword"}}},
+            "currency": {"type": "keyword"},
+            "customer_birth_date": {"type": "date"},
+            "customer_first_name": {
+                "type": "text",
+                "fields": {"keyword": {"type": "keyword", "ignore_above": 256}},
+            },
+            "customer_full_name": {
+                "type": "text",
+                "fields": {"keyword": {"type": "keyword", "ignore_above": 256}},
+            },
+            "customer_gender": {"type": "text"},
+            "customer_id": {"type": "keyword"},
+            "customer_last_name": {
+                "type": "text",
+                "fields": {"keyword": {"type": "keyword", "ignore_above": 256}},
+            },
+            "customer_phone": {"type": "keyword"},
+            "day_of_week": {"type": "keyword"},
+            "day_of_week_i": {"type": "integer"},
+            "email": {"type": "keyword"},
+            "geoip": {
+                "properties": {
+                    "city_name": {"type": "keyword"},
+                    "continent_name": {"type": "keyword"},
+                    "country_iso_code": {"type": "keyword"},
+                    "location": {"type": "geo_point"},
+                    "region_name": {"type": "keyword"},
+                }
+            },
+            "manufacturer": {
+                "type": "text",
+                "fields": {"keyword": {"type": "keyword"}},
+            },
+            "order_date": {"type": "date"},
+            "order_id": {"type": "keyword"},
+            "products": {
+                "properties": {
+                    "_id": {
+                        "type": "text",
+                        "fields": {"keyword": {"type": "keyword", "ignore_above": 256}},
+                    },
+                    "base_price": {"type": "half_float"},
+                    "base_unit_price": {"type": "half_float"},
+                    "category": {
+                        "type": "text",
+                        "fields": {"keyword": {"type": "keyword"}},
+                    },
+                    "created_on": {"type": "date"},
+                    "discount_amount": {"type": "half_float"},
+                    "discount_percentage": {"type": "half_float"},
+                    "manufacturer": {
+                        "type": "text",
+                        "fields": {"keyword": {"type": "keyword"}},
+                    },
+                    "min_price": {"type": "half_float"},
+                    "price": {"type": "half_float"},
+                    "product_id": {"type": "long"},
+                    "product_name": {
+                        "type": "text",
+                        "fields": {"keyword": {"type": "keyword"}},
+                        "analyzer": "english",
+                    },
+                    "quantity": {"type": "integer"},
+                    "sku": {"type": "keyword"},
+                    "tax_amount": {"type": "half_float"},
+                    "taxful_price": {"type": "half_float"},
+                    "taxless_price": {"type": "half_float"},
+                    "unit_discount_amount": {"type": "half_float"},
+                }
+            },
+            "sku": {"type": "keyword"},
+            "taxful_total_price": {"type": "float"},
+            "taxless_total_price": {"type": "float"},
+            "total_quantity": {"type": "integer"},
+            "total_unique_products": {"type": "integer"},
+            "type": {"type": "keyword"},
+            "user": {"type": "keyword"},
+        }
+    }
+}
+
+
+def pandas_to_es(
+    pd_df: "pd.DataFrame",
+    es_client: "Elasticsearch",
+    es_index_name: str,
+    es_mapping: Dict[str, Any],
+) -> None:
+    """Read df and index records into Elasticsearch
+
+    Parameters
+    ----------
+    pd_f: Pandas DataFrame
+        Data to index into Elasticsearch
+    es_client: Elasticsearch
+        elasticsearch-py Elasticsearch client
+    es_index_name: str
+        Name of Elasticsearch index to be appended to
+    es_mapping: Dict
+        Elasticsearch mapping definition
+    """
+    print("Deleting index:", es_index_name)
+    es_client.options(ignore_status=[400, 404]).indices.delete(index=es_index_name)
+    print("Creating index:", es_index_name)
+    es_client.indices.create(index=es_index_name, **es_mapping)
+
+    actions = []
+    n = 0
+
+    print("Adding", pd_df.shape[0], "items to index:", es_index_name)
+    for index, row in pd_df.iterrows():
+        values = row.to_dict()
+
+        # Use integer as id field for repeatable results
+        action = {"_index": es_index_name, "_source": values, "_id": str(n)}
+        actions.append(action)
+
+        n = n + 1
+        if n % 10000 == 0:
+            helpers.bulk(es_client, actions)
+            actions = []
+
+    helpers.bulk(es_client, actions)
+    del actions
+
+    print("Done", es_index_name)

--- a/noxfile.py
+++ b/noxfile.py
@@ -31,6 +31,7 @@ TYPED_FILES = (
     "eland/actions.py",
     "eland/arithmetics.py",
     "eland/common.py",
+    "eland/dataload.py",
     "eland/etl.py",
     "eland/filter.py",
     "eland/index.py",
@@ -184,6 +185,7 @@ def docs(session):
                     "--inplace",
                     "--execute",
                     str(BASE_DIR / "docs/sphinx/examples" / filename),
+                    env={"DOCS_BUILD": "1"},
                 )
 
     session.cd("docs")

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -21,6 +21,12 @@ import pandas as pd
 from elasticsearch import Elasticsearch
 
 from eland.common import es_version
+from eland.dataload import (
+    ECOMMERCE_INDEX_NAME,
+    ECOMMERCE_MAPPING,
+    FLIGHTS_INDEX_NAME,
+    FLIGHTS_MAPPING,
+)
 
 ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
 
@@ -34,40 +40,6 @@ ES_TEST_CLIENT = Elasticsearch(ELASTICSEARCH_HOST)
 
 ES_VERSION = es_version(ES_TEST_CLIENT)
 
-FLIGHTS_INDEX_NAME = "flights"
-FLIGHTS_MAPPING = {
-    "mappings": {
-        "properties": {
-            "AvgTicketPrice": {"type": "float"},
-            "Cancelled": {"type": "boolean"},
-            "Carrier": {"type": "keyword"},
-            "Dest": {"type": "keyword"},
-            "DestAirportID": {"type": "keyword"},
-            "DestCityName": {"type": "keyword"},
-            "DestCountry": {"type": "keyword"},
-            "DestLocation": {"type": "geo_point"},
-            "DestRegion": {"type": "keyword"},
-            "DestWeather": {"type": "keyword"},
-            "DistanceKilometers": {"type": "float"},
-            "DistanceMiles": {"type": "float"},
-            "FlightDelay": {"type": "boolean"},
-            "FlightDelayMin": {"type": "integer"},
-            "FlightDelayType": {"type": "keyword"},
-            "FlightNum": {"type": "keyword"},
-            "FlightTimeHour": {"type": "float"},
-            "FlightTimeMin": {"type": "float"},
-            "Origin": {"type": "keyword"},
-            "OriginAirportID": {"type": "keyword"},
-            "OriginCityName": {"type": "keyword"},
-            "OriginCountry": {"type": "keyword"},
-            "OriginLocation": {"type": "geo_point"},
-            "OriginRegion": {"type": "keyword"},
-            "OriginWeather": {"type": "keyword"},
-            "dayOfWeek": {"type": "byte"},
-            "timestamp": {"type": "date", "format": "strict_date_hour_minute_second"},
-        }
-    }
-}
 FLIGHTS_FILE_NAME = ROOT_DIR + "/flights.json.gz"
 FLIGHTS_DF_FILE_NAME = ROOT_DIR + "/flights_df.json.gz"
 
@@ -75,91 +47,6 @@ FLIGHTS_SMALL_INDEX_NAME = "flights_small"
 FLIGHTS_SMALL_MAPPING = FLIGHTS_MAPPING
 FLIGHTS_SMALL_FILE_NAME = ROOT_DIR + "/flights_small.json.gz"
 
-ECOMMERCE_INDEX_NAME = "ecommerce"
-ECOMMERCE_MAPPING = {
-    "mappings": {
-        "properties": {
-            "category": {"type": "text", "fields": {"keyword": {"type": "keyword"}}},
-            "currency": {"type": "keyword"},
-            "customer_birth_date": {"type": "date"},
-            "customer_first_name": {
-                "type": "text",
-                "fields": {"keyword": {"type": "keyword", "ignore_above": 256}},
-            },
-            "customer_full_name": {
-                "type": "text",
-                "fields": {"keyword": {"type": "keyword", "ignore_above": 256}},
-            },
-            "customer_gender": {"type": "text"},
-            "customer_id": {"type": "keyword"},
-            "customer_last_name": {
-                "type": "text",
-                "fields": {"keyword": {"type": "keyword", "ignore_above": 256}},
-            },
-            "customer_phone": {"type": "keyword"},
-            "day_of_week": {"type": "keyword"},
-            "day_of_week_i": {"type": "integer"},
-            "email": {"type": "keyword"},
-            "geoip": {
-                "properties": {
-                    "city_name": {"type": "keyword"},
-                    "continent_name": {"type": "keyword"},
-                    "country_iso_code": {"type": "keyword"},
-                    "location": {"type": "geo_point"},
-                    "region_name": {"type": "keyword"},
-                }
-            },
-            "manufacturer": {
-                "type": "text",
-                "fields": {"keyword": {"type": "keyword"}},
-            },
-            "order_date": {"type": "date"},
-            "order_id": {"type": "keyword"},
-            "products": {
-                "properties": {
-                    "_id": {
-                        "type": "text",
-                        "fields": {"keyword": {"type": "keyword", "ignore_above": 256}},
-                    },
-                    "base_price": {"type": "half_float"},
-                    "base_unit_price": {"type": "half_float"},
-                    "category": {
-                        "type": "text",
-                        "fields": {"keyword": {"type": "keyword"}},
-                    },
-                    "created_on": {"type": "date"},
-                    "discount_amount": {"type": "half_float"},
-                    "discount_percentage": {"type": "half_float"},
-                    "manufacturer": {
-                        "type": "text",
-                        "fields": {"keyword": {"type": "keyword"}},
-                    },
-                    "min_price": {"type": "half_float"},
-                    "price": {"type": "half_float"},
-                    "product_id": {"type": "long"},
-                    "product_name": {
-                        "type": "text",
-                        "fields": {"keyword": {"type": "keyword"}},
-                        "analyzer": "english",
-                    },
-                    "quantity": {"type": "integer"},
-                    "sku": {"type": "keyword"},
-                    "tax_amount": {"type": "half_float"},
-                    "taxful_price": {"type": "half_float"},
-                    "taxless_price": {"type": "half_float"},
-                    "unit_discount_amount": {"type": "half_float"},
-                }
-            },
-            "sku": {"type": "keyword"},
-            "taxful_total_price": {"type": "float"},
-            "taxless_total_price": {"type": "float"},
-            "total_quantity": {"type": "integer"},
-            "total_unique_products": {"type": "integer"},
-            "type": {"type": "keyword"},
-            "user": {"type": "keyword"},
-        }
-    }
-}
 ECOMMERCE_FILE_NAME = ROOT_DIR + "/ecommerce.json.gz"
 ECOMMERCE_DF_FILE_NAME = ROOT_DIR + "/ecommerce_df.json.gz"
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -21,7 +21,7 @@ import pandas as pd
 from elasticsearch import Elasticsearch
 
 from eland.common import es_version
-from eland.dataload import (
+from eland.dataload import (  # noqa: F401
     ECOMMERCE_INDEX_NAME,
     ECOMMERCE_MAPPING,
     FLIGHTS_INDEX_NAME,


### PR DESCRIPTION
Adding an "Open in Colab" button was easy, but making the actual notebook runnable in Colab took way more effort. Ive followed the conventions used in https://github.com/elastic/elasticsearch-labs but:

 * I've used a hack to allow loading the test data from that notebook.
 * Making this nicer (including using the cloud id instead of host/port) will require changes in the tests.

I was not sure who to ask for review, feel free to change the reviewers list.