### PR TITLE
[CVE-2023-4039] Updated bullseye docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye-20230522
+FROM debian:bullseye-20230904
 
 RUN apt-get update && \
     apt-get install -y build-essential pkg-config cmake \


### PR DESCRIPTION
This is a PR coming from [this snyk alert](https://app.snyk.io/org/clients-team/project/3125ecc2-6747-49be-86be-b47c7b05390d#issue-SNYK-DEBIAN11-GCC10-5901313) regarding [CVE-2023-4039](https://nvd.nist.gov/vuln/detail/CVE-2023-4039). It updates the Dockerfile using the latest image.