### PR TITLE
Reduce Docker image size from 4.8GB to 2.2GB

### DIFF
--- a/.buildkite/release-docker/run.sh
+++ b/.buildkite/release-docker/run.sh
@@ -22,11 +22,14 @@ pushd eland
 git checkout "v${RELEASE_VERSION}"
 git --no-pager show
 
-docker build -t "$docker_registry/eland/eland:$RELEASE_VERSION" "$PWD"
-docker push "$docker_registry/eland/eland:$RELEASE_VERSION"
-
-docker tag "$docker_registry/eland/eland:$RELEASE_VERSION" "$docker_registry/eland/eland:latest"
-docker push "$docker_registry/eland/eland:latest"
+# Create builder that supports QEMU emulation (needed for linux/arm64)
+docker buildx rm --force eland-multiarch-builder || true
+docker buildx create --name eland-multiarch-builder --bootstrap --use
+docker buildx build --push \
+  --tag "$docker_registry/eland/eland:$RELEASE_VERSION" \
+  --tag "$docker_registry/eland/eland:latest" \
+  --platform linux/amd64,linux/arm64 \
+  "$PWD"
 
 popd
 popd

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && \
 ADD . /eland
 WORKDIR /eland
 
-RUN python3 -m pip install --no-cache-dir --disable-pip-version-check .[all]
+RUN --mount=type=cache,target=/root/.cache python3 -m pip install torch==1.13.1+cpu --extra-index-url https://download.pytorch.org/whl/cpu
+RUN --mount=type=cache,target=/root/.cache python3 -m pip install --no-cache-dir --disable-pip-version-check .[all]
 
 CMD ["/bin/sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM python:3.10-slim-bookworm@sha256:d364435d339ad318ac4c533b9fbe709739f9ba006b0721fd25e8592d0bb857cb
+# syntax=docker/dockerfile:1
+FROM python:3.10-slim
 
 RUN apt-get update && \
     apt-get install -y build-essential pkg-config cmake \

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,16 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 ADD . /eland
 WORKDIR /eland
 
-RUN --mount=type=cache,target=/root/.cache python3 -m pip install torch==1.13.1+cpu --extra-index-url https://download.pytorch.org/whl/cpu
-RUN --mount=type=cache,target=/root/.cache python3 -m pip install --no-cache-dir --disable-pip-version-check .[all]
+ARG TARGETPLATFORM
+RUN --mount=type=cache,target=/root/.cache/pip \
+    if [ "$TARGETPLATFORM" = "linux/amd64" ]; then \
+      python3 -m pip install \
+        --no-cache-dir --disable-pip-version-check --extra-index-url https://download.pytorch.org/whl/cpu  \
+        torch==1.13.1+cpu .[all]; \
+    else \
+      python3 -m pip install \
+        --no-cache-dir --disable-pip-version-check \
+        .[all]; \
+    fi
 
 CMD ["/bin/sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,14 @@
 # syntax=docker/dockerfile:1
 FROM python:3.10-slim
 
-RUN apt-get update && \
-    apt-get install -y build-essential pkg-config cmake \
-                       libzip-dev libjpeg-dev && \
-    apt-get clean
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && apt-get install -y \
+      build-essential \
+      pkg-config \
+      cmake \
+      libzip-dev \
+      libjpeg-dev
 
 ADD . /eland
 WORKDIR /eland


### PR DESCRIPTION
Closes #600 

This was done by using the torchcpu PyPI package and not storing the PyPI cache in the Docker image.

Tested using `docker run -it --rm --network host -e ES_USERNAME=$ES_USERNAME -e ES_PASSWORD=$ES_PASSWORD eland eland_import_hub_model --cloud-id $CLOUD_ID  --hub-model-id elastic/distilbert-base-cased-finetuned-conll03-english --task-type ner`