### PR TITLE
Fix docs build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3"
+    python: "3.10"
 
 python:
   install:


### PR DESCRIPTION
Some dependencies like numpy are pinned to versions that do not support Python 3.12. Python 3.10 is the latest version supported by Eland.