### PR TITLE
Allow es-doc members to trigger CI

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -56,6 +56,7 @@ spec:
       teams:
         ml-core: {}
         clients-team: {}
+        es-docs: {}
         everyone:
           access_level: READ_ONLY
 


### PR DESCRIPTION
@leemthompo had to include an useless commit to trigger CI here: https://github.com/elastic/eland/pull/630. For the record, in cases like that I tend to use `git commit --allow-empty -m "Trigger CI"` which does not change the content of the pull request.