### PR TITLE
Fix failed import of Sentence Transformer RoBERTa models

### DIFF
--- a/eland/ml/pytorch/transformers.py
+++ b/eland/ml/pytorch/transformers.py
@@ -311,7 +311,7 @@ class _SentenceTransformerWrapperModule(nn.Module):  # type: ignore
             (
                 transformers.BartTokenizer,
                 transformers.MPNetTokenizer,
-                transformers.RobertaConfig,
+                transformers.RobertaTokenizer,
                 transformers.XLMRobertaTokenizer,
             ),
         ):

--- a/tests/ml/pytorch/test_pytorch_model_config_pytest.py
+++ b/tests/ml/pytorch/test_pytorch_model_config_pytest.py
@@ -78,6 +78,14 @@ pytestmark = [
 if HAS_PYTORCH and HAS_SKLEARN and HAS_TRANSFORMERS:
     MODEL_CONFIGURATIONS = [
         (
+            "sentence-transformers/all-distilroberta-v1",
+            "text_embedding",
+            TextEmbeddingInferenceOptions,
+            NlpRobertaTokenizationConfig,
+            512,
+            768,
+        ),
+        (
             "intfloat/multilingual-e5-small",
             "text_embedding",
             TextEmbeddingInferenceOptions,


### PR DESCRIPTION
Uploading the `sentence-transformers/all-distilroberta-v1 ` model to Elasticsearch failed with the following

```
TypeError: _SentenceTransformerWrapper.forward() missing 2 required positional arguments: 'token_type_ids' and 'position_ids'
```

The error occurs when the `eland_import_hub_model` script evaluates the model to measure the size of the output embedding. It can be reproduced with the following command:
```
eland_import_hub_model --url <elastic> --hub-model-id sentence-transformers/all-distilroberta-v1 --task-type text_embedding
```


The problem is due to the model's tokenizer type not being recognised due to a simple typo. A test has been added to cover this case. 