### PR TITLE
[NLP] Add prefix_string config option to the import model hub script

### DIFF
--- a/eland/cli/eland_import_hub_model.py
+++ b/eland/cli/eland_import_hub_model.py
@@ -128,6 +128,19 @@ def get_arg_parser():
         "--ca-certs", required=False, default=DEFAULT, help="Path to CA bundle"
     )
 
+    parser.add_argument(
+        "--ingest-prefix",
+        required=False,
+        default=None,
+        help="String to prepend to model input at ingest",
+    )
+    parser.add_argument(
+        "--search-prefix",
+        required=False,
+        default=None,
+        help="String to prepend to model input at search",
+    )
+
     return parser
 
 
@@ -244,6 +257,8 @@ def main():
                 task_type=args.task_type,
                 es_version=cluster_version,
                 quantize=args.quantize,
+                ingest_prefix=args.ingest_prefix,
+                search_prefix=args.search_prefix,
             )
             model_path, config, vocab_path = tm.save(tmp_dir)
         except TaskTypeError as err:

--- a/eland/ml/pytorch/nlp_ml_model.py
+++ b/eland/ml/pytorch/nlp_ml_model.py
@@ -308,6 +308,23 @@ class TrainedModelInput:
         return self.__dict__
 
 
+class PrefixStrings:
+    def __init__(
+        self, *, ingest_prefix: t.Optional[str], search_prefix: t.Optional[str]
+    ):
+        self.ingest_prefix = ingest_prefix
+        self.search_prefix = search_prefix
+
+    def to_dict(self) -> t.Dict[str, t.Any]:
+        config = {}
+        if self.ingest_prefix is not None:
+            config["ingest"] = self.ingest_prefix
+        if self.search_prefix is not None:
+            config["search"] = self.search_prefix
+
+        return config
+
+
 class NlpTrainedModelConfig:
     def __init__(
         self,
@@ -318,6 +335,7 @@ class NlpTrainedModelConfig:
         metadata: t.Optional[dict] = None,
         model_type: t.Union["t.Literal['pytorch']", str] = "pytorch",
         tags: t.Optional[t.Union[t.List[str], t.Tuple[str, ...]]] = None,
+        prefix_strings: t.Optional[PrefixStrings],
     ):
         self.tags = tags
         self.description = description
@@ -325,6 +343,7 @@ class NlpTrainedModelConfig:
         self.input = input
         self.metadata = metadata
         self.model_type = model_type
+        self.prefix_strings = prefix_strings
 
     def to_dict(self) -> t.Dict[str, t.Any]:
         return {


### PR DESCRIPTION
The prefix_strings option was added in https://github.com/elastic/elasticsearch/pull/102089 to support the E5 model.

The new params to `eland_import_hub_model` are `--search-prefix` and `--ingest-prefix`

### Example usage
```
eland_import_hub_model       
  --url 'http://localhost:9200'
  --hub-model-id intfloat/multilingual-e5-small       
  --task-type text_embedding 
  --search-prefix "query: " 
  --ingest-prefix "passage: "
```

This option is only available in Elasticsearch 8.12 and depends on https://github.com/elastic/elasticsearch-specification/pull/2363