### PR TITLE
Accept LTR inference config when creating model

### DIFF
--- a/eland/ml/common.py
+++ b/eland/ml/common.py
@@ -16,4 +16,5 @@
 #  under the License.
 
 TYPE_CLASSIFICATION = "classification"
+TYPE_LEARNING_TO_RANK = "learning_to_rank"
 TYPE_REGRESSION = "regression"

--- a/eland/ml/ml_model.py
+++ b/eland/ml/ml_model.py
@@ -23,7 +23,7 @@ import numpy as np
 from eland.common import ensure_es_client, es_version
 from eland.utils import deprecated_api
 
-from .common import TYPE_CLASSIFICATION, TYPE_REGRESSION
+from .common import TYPE_CLASSIFICATION, TYPE_LEARNING_TO_RANK, TYPE_REGRESSION
 from .transformers import get_model_transformer
 
 if TYPE_CHECKING:
@@ -130,6 +130,11 @@ class MLModel:
         >>> # Delete model from Elasticsearch
         >>> es_model.delete_model()
         """
+        if self.model_type not in (TYPE_CLASSIFICATION, TYPE_REGRESSION):
+            raise NotImplementedError(
+                f"Prediction for type {self.model_type} is not supported."
+            )
+
         docs: List[Mapping[str, Any]] = []
         if isinstance(X, np.ndarray):
 
@@ -215,7 +220,9 @@ class MLModel:
         inference_config = self._trained_model_config["inference_config"]
         if "classification" in inference_config:
             return TYPE_CLASSIFICATION
-        elif "regression" in inference_config or "learning_to_rank" in inference_config:
+        elif "learning_to_rank" in inference_config:
+            return TYPE_LEARNING_TO_RANK
+        elif "regression" in inference_config:
             return TYPE_REGRESSION
         raise ValueError("Unable to determine 'model_type' for MLModel")
 

--- a/eland/ml/ml_model.py
+++ b/eland/ml/ml_model.py
@@ -174,6 +174,7 @@ class MLModel:
                         "inference": {
                             "model_id": self._model_id,
                             "inference_config": {self.model_type: {}},
+                            # "inference_config": self.inference_config,
                             field_map_name: {},
                         }
                     }
@@ -215,7 +216,7 @@ class MLModel:
         inference_config = self._trained_model_config["inference_config"]
         if "classification" in inference_config:
             return TYPE_CLASSIFICATION
-        elif "regression" in inference_config:
+        elif "regression" in inference_config or "learning_to_rank" in inference_config:
             return TYPE_REGRESSION
         raise ValueError("Unable to determine 'model_type' for MLModel")
 
@@ -254,7 +255,7 @@ class MLModel:
         classification_weights: Optional[List[float]] = None,
         es_if_exists: Optional[str] = None,
         es_compress_model_definition: bool = True,
-        inference_config: Optional[Dict[str, Dict[str, Any]]] = None
+        inference_config: Optional[Dict[str, Dict[str, Any]]] = None,
     ) -> "MLModel":
         """
         Transform and serialize a trained 3rd party model into Elasticsearch.
@@ -372,7 +373,7 @@ class MLModel:
         )
         serializer = transformer.transform()
         model_type = transformer.model_type
-        default_inference_config = {model_type: {}}
+        default_inference_config: Dict[str, Any] = {model_type: {}}
 
         if es_if_exists is None:
             es_if_exists = "fail"

--- a/eland/ml/ml_model.py
+++ b/eland/ml/ml_model.py
@@ -261,7 +261,7 @@ class MLModel:
         classification_weights: Optional[List[float]] = None,
         es_if_exists: Optional[str] = None,
         es_compress_model_definition: bool = True,
-        inference_config: Optional[Dict[str, Dict[str, Any]]] = None,
+        inference_config: Optional[Mapping[str, Mapping[str, Any]]] = None,
     ) -> "MLModel":
         """
         Transform and serialize a trained 3rd party model into Elasticsearch.
@@ -332,7 +332,7 @@ class MLModel:
             JSON instead of raw JSON to reduce the amount of data sent
             over the wire in HTTP requests. Defaults to 'True'.
 
-        inference_config: Dict[str, Dict]
+        inference_config: Mapping[str, Mapping[str, Any]]
             Model inference configuration. Must contain a top-level property whose name is the same as the inference
             task type.
 
@@ -379,7 +379,7 @@ class MLModel:
         )
         serializer = transformer.transform()
         model_type = transformer.model_type
-        default_inference_config: Dict[str, Any] = {model_type: {}}
+        default_inference_config: Mapping[str, Mapping[str, Any]] = {model_type: {}}
 
         if es_if_exists is None:
             es_if_exists = "fail"

--- a/eland/ml/ml_model.py
+++ b/eland/ml/ml_model.py
@@ -254,6 +254,7 @@ class MLModel:
         classification_weights: Optional[List[float]] = None,
         es_if_exists: Optional[str] = None,
         es_compress_model_definition: bool = True,
+        inference_config: Optional[Dict[str, Dict[str, Any]]] = None
     ) -> "MLModel":
         """
         Transform and serialize a trained 3rd party model into Elasticsearch.
@@ -324,6 +325,10 @@ class MLModel:
             JSON instead of raw JSON to reduce the amount of data sent
             over the wire in HTTP requests. Defaults to 'True'.
 
+        inference_config: Dict[str, Dict]
+            Model inference configuration. Must contain a top-level property whose name is the same as the inference
+            task type.
+
         Examples
         --------
         >>> from sklearn import datasets
@@ -367,6 +372,7 @@ class MLModel:
         )
         serializer = transformer.transform()
         model_type = transformer.model_type
+        default_inference_config = {model_type: {}}
 
         if es_if_exists is None:
             es_if_exists = "fail"
@@ -389,14 +395,14 @@ class MLModel:
             ml_model._client.ml.put_trained_model(
                 model_id=model_id,
                 input={"field_names": feature_names},
-                inference_config={model_type: {}},
+                inference_config=inference_config or default_inference_config,
                 compressed_definition=serializer.serialize_and_compress_model(),
             )
         else:
             ml_model._client.ml.put_trained_model(
                 model_id=model_id,
                 input={"field_names": feature_names},
-                inference_config={model_type: {}},
+                inference_config=inference_config or default_inference_config,
                 definition=serializer.serialize_model(),
             )
 

--- a/eland/ml/ml_model.py
+++ b/eland/ml/ml_model.py
@@ -174,7 +174,6 @@ class MLModel:
                         "inference": {
                             "model_id": self._model_id,
                             "inference_config": {self.model_type: {}},
-                            # "inference_config": self.inference_config,
                             field_map_name: {},
                         }
                     }

--- a/tests/ml/test_ml_model_pytest.py
+++ b/tests/ml/test_ml_model_pytest.py
@@ -384,7 +384,7 @@ class TestMLModel:
         # Execute search with rescoring
         search_result = ES_TEST_CLIENT.search(
             index=MOVIES_INDEX_NAME,
-            query={"terms": {"_id": ["tt1318514", "tt0071562"] } },
+            query={"terms": {"_id": ["tt1318514", "tt0071562"]}},
             rescore={
                 "learning_to_rank": {
                     "model_id": model_id,
@@ -397,8 +397,8 @@ class TestMLModel:
         # - all documents from the query are present
         # - all documents have been rescored (score != 1.0)
         # - document scores are unique
-        doc_scores = [hit['_score'] for hit in search_result['hits']['hits']]
-        assert len(search_result['hits']['hits']) == 2
+        doc_scores = [hit["_score"] for hit in search_result["hits"]["hits"]]
+        assert len(search_result["hits"]["hits"]) == 2
         assert all(score != float(1) for score in doc_scores)
         assert all(doc_scores.count(score) == 1 for score in doc_scores)
 

--- a/tests/ml/test_ml_model_pytest.py
+++ b/tests/ml/test_ml_model_pytest.py
@@ -396,11 +396,9 @@ class TestMLModel:
         # Assert that:
         # - all documents from the query are present
         # - all documents have been rescored (score != 1.0)
-        # - document scores are unique
         doc_scores = [hit["_score"] for hit in search_result["hits"]["hits"]]
         assert len(search_result["hits"]["hits"]) == 2
         assert all(score != float(1) for score in doc_scores)
-        assert all(doc_scores.count(score) == 1 for score in doc_scores)
 
         # Verify prediction is not supported for LTR
         try:

--- a/tests/ml/test_ml_model_pytest.py
+++ b/tests/ml/test_ml_model_pytest.py
@@ -23,7 +23,12 @@ import pytest
 
 import eland as ed
 from eland.ml import MLModel
-from tests import ES_TEST_CLIENT, ES_VERSION, FLIGHTS_SMALL_INDEX_NAME, MOVIES_INDEX_NAME
+from tests import (
+    ES_TEST_CLIENT,
+    ES_VERSION,
+    FLIGHTS_SMALL_INDEX_NAME,
+    MOVIES_INDEX_NAME,
+)
 
 try:
     from sklearn import datasets
@@ -329,7 +334,7 @@ class TestMLModel:
             {
                 "query_extractor": {
                     "feature_name": "title_bm25",
-                    "query": {"match": { "title": "{{query_string}}" } }
+                    "query": {"match": {"title": "{{query_string}}"}},
                 }
             },
             {
@@ -337,18 +342,19 @@ class TestMLModel:
                     "feature_name": "imdb_rating",
                     "query": {
                         "script_score": {
-                            "query": {"exists": { "field": "imdbRating" }},
+                            "query": {"exists": {"field": "imdbRating"}},
                             "script": {"source": 'return doc["imdbRating"].value;'},
                         }
-                    }
+                    },
                 }
-            }
+            },
         ]
-        feature_names = [extractor['query_extractor']['feature_name'] for extractor in feature_extractors]
+        feature_names = [
+            extractor["query_extractor"]["feature_name"]
+            for extractor in feature_extractors
+        ]
         inference_config = {
-            "learning_to_rank": {
-                "feature_extractors": feature_extractors
-            }
+            "learning_to_rank": {"feature_extractors": feature_extractors}
         }
 
         es_model = MLModel.import_model(
@@ -377,24 +383,24 @@ class TestMLModel:
 
         # Execute search with rescoring and verify document order
         search_result = ES_TEST_CLIENT.search(
-            index = MOVIES_INDEX_NAME,
-            query = {
-                "multi_match": { 
+            index=MOVIES_INDEX_NAME,
+            query={
+                "multi_match": {
                     "fields": ["title", "actors", "directors", "plot"],
-                    "query": "planet of the apes"
+                    "query": "planet of the apes",
                 }
             },
-            rescore = {
+            rescore={
                 "learning_to_rank": {
                     "model_id": model_id,
-                    "params": {"query_string": "planet of the apes"}
+                    "params": {"query_string": "planet of the apes"},
                 }
             },
         )
-        assert search_result['hits']['hits'][0]['_id'] == 'tt1318514'
-        assert search_result['hits']['hits'][1]['_id'] == 'tt0063442'
-        assert search_result['hits']['hits'][2]['_id'] == 'tt0214341'
-        
+        assert search_result["hits"]["hits"][0]["_id"] == "tt1318514"
+        assert search_result["hits"]["hits"][1]["_id"] == "tt0063442"
+        assert search_result["hits"]["hits"][2]["_id"] == "tt0214341"
+
         # Verify prediction is not supported for LTR
         try:
             es_model.predict([0])


### PR DESCRIPTION
This PR adds support for importing a model with a specific `inference_config`. This allows us to use regression models with the `learning_to_rank` inference type that come with externally supplied configuration.

Example:
```python
MLModel.import_model(
    es_client,
    model_id,
    regressor,
    feature_names,
    es_if_exists="replace",
    es_compress_model_definition=compress_model_definition,
    inference_config={
        "learning_to_rank": {
            "feature_extractors": [
                {
                    "query_extractor": {
                        "feature_name": "title_bm25",
                        "query": {"match": {"title": "{{query_string}}"}},
                    }
                },
                {
                    "query_extractor": {
                        "feature_name": "imdb_rating",
                        "query": {
                            "script_score": {
                                "query": {"exists": {"field": "imdbRating"}},
                                "script": {"source": 'return doc["imdbRating"].value;'},
                            }
                        },
                    }
                },
            ]
        }
    },
)
```

The change is backward compatible - if `inference_config` is not passed, it will be set to the default `{<model_type>: {}}`.