### PR TITLE
LTR improvements

### DIFF
--- a/eland/ml/ltr/__init__.py
+++ b/eland/ml/ltr/__init__.py
@@ -15,11 +15,12 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
-from eland.ml.ltr.feature_logger import FeatureLogger
-from eland.ml.ltr.ltr_model_config import (
-    FeatureExtractor,
-    LTRModelConfig,
-    QueryFeatureExtractor,
-)
+from .feature_logger import FeatureLogger
+from .ltr_model_config import FeatureExtractor, LTRModelConfig, QueryFeatureExtractor
 
-__all__ = [LTRModelConfig, QueryFeatureExtractor, FeatureExtractor, FeatureLogger]
+__all__ = [
+    "LTRModelConfig",
+    "QueryFeatureExtractor",
+    "FeatureExtractor",
+    "FeatureLogger",
+]

--- a/eland/ml/ltr/ltr_model_config.py
+++ b/eland/ml/ltr/ltr_model_config.py
@@ -59,7 +59,7 @@ class QueryFeatureExtractor(FeatureExtractor):
         self,
         feature_name: str,
         query: Mapping[str, Any],
-        default_score: Optional[float] = float(0),
+        default_score: Optional[float] = None,
     ):
         """
         Parameters

--- a/eland/ml/ml_model.py
+++ b/eland/ml/ml_model.py
@@ -24,6 +24,7 @@ from eland.common import ensure_es_client, es_version
 from eland.utils import deprecated_api
 
 from .common import TYPE_CLASSIFICATION, TYPE_LEARNING_TO_RANK, TYPE_REGRESSION
+from .ltr import LTRModelConfig
 from .transformers import get_model_transformer
 
 if TYPE_CHECKING:
@@ -266,7 +267,6 @@ class MLModel:
         classification_weights: Optional[List[float]] = None,
         es_if_exists: Optional[str] = None,
         es_compress_model_definition: bool = True,
-        inference_config: Optional[Mapping[str, Mapping[str, Any]]] = None,
     ) -> "MLModel":
         """
         Transform and serialize a trained 3rd party model into Elasticsearch.
@@ -342,10 +342,6 @@ class MLModel:
             JSON instead of raw JSON to reduce the amount of data sent
             over the wire in HTTP requests. Defaults to 'True'.
 
-        inference_config: Mapping[str, Mapping[str, Any]]
-            Model inference configuration. Must contain a top-level property whose name is the same as the inference
-            task type.
-
         Examples
         --------
         >>> from sklearn import datasets
@@ -380,6 +376,120 @@ class MLModel:
         >>> # Delete model from Elasticsearch
         >>> es_model.delete_model()
         """
+
+        return cls._import_model(
+            es_client=es_client,
+            model_id=model_id,
+            model=model,
+            feature_names=feature_names,
+            classification_labels=classification_labels,
+            classification_weights=classification_weights,
+            es_if_exists=es_if_exists,
+        )
+
+    @classmethod
+    def import_ltr_model(
+        cls,
+        es_client: Union[str, List[str], Tuple[str, ...], "Elasticsearch"],
+        model_id: str,
+        model: Union[
+            "DecisionTreeRegressor",
+            "RandomForestRegressor",
+            "XGBRanker",
+            "XGBRegressor",
+            "LGBMRegressor",
+        ],
+        ltr_model_config: LTRModelConfig,
+        es_if_exists: Optional[str] = None,
+        es_compress_model_definition: bool = True,
+    ) -> "MLModel":
+        """
+        Transform and serialize a trained 3rd party model into Elasticsearch.
+        This model can then be used as an learning_to_rank rescorer in the Elastic Stack.
+
+        Parameters
+        ----------
+        es_client: Elasticsearch client argument(s)
+            - elasticsearch-py parameters or
+            - elasticsearch-py instance
+
+        model_id: str
+            The unique identifier of the trained inference model in Elasticsearch.
+
+        model: An instance of a supported python model. We support the following model types for LTR prediction:
+            - sklearn.tree.DecisionTreeRegressor
+            - sklearn.ensemble.RandomForestRegressor
+            - xgboost.XGBClassifier
+                - only the following objectives are supported:
+                    - "binary:logistic"
+                    - "multi:softmax"
+                    - "multi:softprob"
+            - xgboost.XGBRanker
+                - only the following objectives are supported:
+                    - "rank:map"
+                    - "rank:ndcg"
+                    - "rank:pairwise"
+            - xgboost.XGBRegressor
+                - only the following objectives are supported:
+                    - "reg:squarederror"
+                    - "reg:linear"
+                    - "reg:squaredlogerror"
+                    - "reg:logistic"
+                    - "reg:pseudohubererror"
+
+        ltr_model_config: LTRModelConfig
+            The LTR model configuration is used to configure features extractors for the LTR model.
+            Feature names are automatically inferred from the feature extractors.
+
+        es_if_exists: {'fail', 'replace'} default 'fail'
+            How to behave if model already exists
+
+            - fail: Raise a Value Error
+            - replace: Overwrite existing model
+
+        es_compress_model_definition: bool
+            If True will use 'compressed_definition' which uses gzipped
+            JSON instead of raw JSON to reduce the amount of data sent
+            over the wire in HTTP requests. Defaults to 'True'.
+        """
+
+        return cls._import_model(
+            es_client=es_client,
+            model_id=model_id,
+            model=model,
+            feature_names=ltr_model_config.feature_names,
+            inference_config=ltr_model_config.to_dict(),
+            es_if_exists=es_if_exists,
+            es_compress_model_definition=es_compress_model_definition,
+        )
+
+    @classmethod
+    def _import_model(
+        cls,
+        es_client: Union[str, List[str], Tuple[str, ...], "Elasticsearch"],
+        model_id: str,
+        model: Union[
+            "DecisionTreeClassifier",
+            "DecisionTreeRegressor",
+            "RandomForestRegressor",
+            "RandomForestClassifier",
+            "XGBClassifier",
+            "XGBRanker",
+            "XGBRegressor",
+            "LGBMRegressor",
+            "LGBMClassifier",
+        ],
+        feature_names: List[str],
+        classification_labels: Optional[List[str]] = None,
+        classification_weights: Optional[List[float]] = None,
+        es_if_exists: Optional[str] = None,
+        es_compress_model_definition: bool = True,
+        inference_config: Optional[Mapping[str, Mapping[str, Any]]] = None,
+    ) -> "MLModel":
+        """
+        Actual implementation of model import used by public API methods.
+        """
+
         es_client = ensure_es_client(es_client)
         transformer = get_model_transformer(
             model,

--- a/eland/ml/ml_model.py
+++ b/eland/ml/ml_model.py
@@ -405,7 +405,7 @@ class MLModel:
     ) -> "MLModel":
         """
         Transform and serialize a trained 3rd party model into Elasticsearch.
-        This model can then be used as an learning_to_rank rescorer in the Elastic Stack.
+        This model can then be used as a learning_to_rank rescorer in the Elastic Stack.
 
         Parameters
         ----------
@@ -438,7 +438,7 @@ class MLModel:
                     - "reg:pseudohubererror"
 
         ltr_model_config: LTRModelConfig
-            The LTR model configuration is used to configure features extractors for the LTR model.
+            The LTR model configuration is used to configure feature extractors for the LTR model.
             Feature names are automatically inferred from the feature extractors.
 
         es_if_exists: {'fail', 'replace'} default 'fail'

--- a/eland/ml/ml_model.py
+++ b/eland/ml/ml_model.py
@@ -385,6 +385,7 @@ class MLModel:
             classification_labels=classification_labels,
             classification_weights=classification_weights,
             es_if_exists=es_if_exists,
+            es_compress_model_definition=es_compress_model_definition,
         )
 
     @classmethod
@@ -419,11 +420,6 @@ class MLModel:
         model: An instance of a supported python model. We support the following model types for LTR prediction:
             - sklearn.tree.DecisionTreeRegressor
             - sklearn.ensemble.RandomForestRegressor
-            - xgboost.XGBClassifier
-                - only the following objectives are supported:
-                    - "binary:logistic"
-                    - "multi:softmax"
-                    - "multi:softprob"
             - xgboost.XGBRanker
                 - only the following objectives are supported:
                     - "rank:map"
@@ -436,6 +432,15 @@ class MLModel:
                     - "reg:squaredlogerror"
                     - "reg:logistic"
                     - "reg:pseudohubererror"
+            - lightgbm.LGBMRegressor
+                - Categorical fields are expected to already be processed
+                - Only the following objectives are supported
+                    - "regression"
+                    - "regression_l1"
+                    - "huber"
+                    - "fair"
+                    - "quantile"
+                    - "mape"
 
         ltr_model_config: LTRModelConfig
             The LTR model configuration is used to configure feature extractors for the LTR model.

--- a/tests/ml/ltr/test_feature_logger_pytest.py
+++ b/tests/ml/ltr/test_feature_logger_pytest.py
@@ -15,6 +15,8 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
+import math
+
 from eland.ml.ltr import FeatureLogger, LTRModelConfig, QueryFeatureExtractor
 from tests import ES_TEST_CLIENT, NATIONAL_PARKS_INDEX_NAME
 
@@ -53,12 +55,12 @@ class TestFeatureLogger:
 
         # "park_hawaii-volcanoes" document does not matches for title but is a world heritage site
         assert (
-            doc_features["park_hawaii-volcanoes"][0] == 0
+            math.isnan(doc_features["park_hawaii-volcanoes"][0])
             and doc_features["park_hawaii-volcanoes"][1] > 1
         )
 
         # "park_hawaii-volcanoes" document does not matches for title and is not a world heritage site
-        assert doc_features["park_death-valley"] == [0, 0]
+        assert all(math.isnan(feature) for feature in doc_features["park_death-valley"])
 
     def _ltr_model_config(self):
         # Returns an LTR config with 2 query feature extractors:


### PR DESCRIPTION
This PR contains two improvements for the LTR feature in Eland.

- Feature logger now extract `NaN` when a query does not match a query. It is consistent with what is done in Elasticsearch.

- A specific method (`import_ltr_model`) has been added to import LTR model with support for a `ltr_model_config` object of class `LTRModelConfig`. The `inference_model` params is removed from the `import_model` method

**Example:**

```python
ed.ml.MLModel.import_ltr_model(
  es_client=es_client,
  model=ranker,
  model_id='ltr-model-xgb',
  ltr_model_config=ltr_model_config,
  es_if_exists = 'replace'
)
```

The previous version was more difficult to use (and could lead to inconsistencies):

```python
ed.ml.MLModel.import_model(
  es_client=es_client,
  model=ranker,
  model_id='ltr-model-xgb',
  feature_names=ltr_model_config.feature_names,
  inference_config=ltr_model_config.to_dict(),
  es_if_exists = 'replace'
)
```
