### PR TITLE
Fix missing value support for XGBRanker.

### DIFF
--- a/eland/ml/_model_serializer.py
+++ b/eland/ml/_model_serializer.py
@@ -96,6 +96,7 @@ class TreeNode:
             add_if_exists(d, "split_feature", self._split_feature)
             add_if_exists(d, "threshold", self._threshold)
             add_if_exists(d, "number_samples", self._number_samples)
+            add_if_exists(d, "default_left", self._default_left)
         else:
             if len(self._leaf_value) == 1:
                 # Support Elasticsearch 7.6 which only

--- a/eland/ml/transformers/xgboost.py
+++ b/eland/ml/transformers/xgboost.py
@@ -107,6 +107,7 @@ class XGBoostForestTransformer(ModelTransformer):
                 decision_type=self._node_decision_type,
                 left_child=self.extract_node_id(row["Yes"], curr_tree),
                 right_child=self.extract_node_id(row["No"], curr_tree),
+                default_left=row["Yes"] == row["Missing"],
                 threshold=float(row["Split"]),
                 split_feature=self.get_feature_id(row["Feature"]),
             )

--- a/tests/ml/test_ml_model_pytest.py
+++ b/tests/ml/test_ml_model_pytest.py
@@ -413,12 +413,15 @@ class TestMLModel:
         feature_logger = FeatureLogger(
             ES_TEST_CLIENT, NATIONAL_PARKS_INDEX_NAME, ltr_model_config
         )
-        expected_scores = sorted([
-            ranker.predict(np.asarray([doc_features]))[0]
-            for _, doc_features in feature_logger.extract_features(
-                {"query_string": "yosemite"}, ["park_yosemite", "park_everglades"]
-            ).items()
-        ], reverse=True)
+        expected_scores = sorted(
+            [
+                ranker.predict(np.asarray([doc_features]))[0]
+                for _, doc_features in feature_logger.extract_features(
+                    {"query_string": "yosemite"}, ["park_yosemite", "park_everglades"]
+                ).items()
+            ],
+            reverse=True,
+        )
         np.testing.assert_almost_equal(expected_scores, doc_scores, decimal=2)
 
         # Verify prediction is not supported for LTR

--- a/tests/ml/test_ml_model_pytest.py
+++ b/tests/ml/test_ml_model_pytest.py
@@ -413,12 +413,12 @@ class TestMLModel:
         feature_logger = FeatureLogger(
             ES_TEST_CLIENT, NATIONAL_PARKS_INDEX_NAME, ltr_model_config
         )
-        expected_scores = [
+        expected_scores = sorted([
             ranker.predict(np.asarray([doc_features]))[0]
             for _, doc_features in feature_logger.extract_features(
                 {"query_string": "yosemite"}, ["park_yosemite", "park_everglades"]
             ).items()
-        ]
+        ], reverse=True)
         np.testing.assert_almost_equal(expected_scores, doc_scores, decimal=2)
 
         # Verify prediction is not supported for LTR

--- a/tests/ml/test_ml_model_pytest.py
+++ b/tests/ml/test_ml_model_pytest.py
@@ -328,7 +328,9 @@ class TestMLModel:
         ["rank:ndcg", "rank:map", "rank:pairwise"],
     )
     def test_learning_to_rank(self, objective, compress_model_definition):
-        X, y = datasets.make_classification(n_features=3, n_informative=2, n_redundant=1)
+        X, y = datasets.make_classification(
+            n_features=3, n_informative=2, n_redundant=1
+        )
         rng = np.random.default_rng()
         qid = rng.integers(0, 3, size=X.shape[0])
 
@@ -401,17 +403,21 @@ class TestMLModel:
                     "model_id": model_id,
                     "params": {"query_string": "yosemite"},
                 },
-                "window_size": 2
+                "window_size": 2,
             },
         )
 
         # Assert that rescored search result match predition.
         doc_scores = [hit["_score"] for hit in search_result["hits"]["hits"]]
 
-        feature_logger = FeatureLogger(ES_TEST_CLIENT, NATIONAL_PARKS_INDEX_NAME, ltr_model_config)
+        feature_logger = FeatureLogger(
+            ES_TEST_CLIENT, NATIONAL_PARKS_INDEX_NAME, ltr_model_config
+        )
         expected_scores = [
             ranker.predict(np.asarray([doc_features]))[0]
-            for _, doc_features in feature_logger.extract_features({"query_string": "yosemite"}, ["park_yosemite", "park_everglades"]).items()
+            for _, doc_features in feature_logger.extract_features(
+                {"query_string": "yosemite"}, ["park_yosemite", "park_everglades"]
+            ).items()
         ]
         np.testing.assert_almost_equal(expected_scores, doc_scores, decimal=2)
 


### PR DESCRIPTION
When exporting XGBoost trees to ES, it was assumed are always using the left branch of the tree. 
In fact it is false and it is needed to configure it using a conditional on `default_left`.

Tests have been updated to check predicted score in _search match the one from the ranker model. It should allows us to catch any problem like this in the future.