### PR TITLE
Adding support for xgboost 2.x

### DIFF
--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -3,7 +3,7 @@ pandas>=1.5
 matplotlib>=3.6
 nbval
 scikit-learn>=0.22.1
-xgboost>=1
+xgboost>=2
 lightgbm
 sphinx==5.3.0
 nbsphinx

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,7 +11,7 @@ tqdm<5
 # Extras
 #
 scikit-learn>=1.3,<1.4
-xgboost>=0.90,<2
+xgboost>=0.90,<=2
 lightgbm>=2,<4
 
 # PyTorch doesn't support Python 3.11 yet (pytorch/pytorch#86566)

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ with open(path.join(here, "README.md"), "r", "utf-8") as f:
     long_description = "\n".join(lines[last_html_index:])
 
 extras = {
-    "xgboost": ["xgboost>=0.90,<2"],
+    "xgboost": ["xgboost>=0.90,<=2"],
     "scikit-learn": ["scikit-learn>=1.3,<1.4"],
     "lightgbm": ["lightgbm>=2,<4"],
     "pytorch": [


### PR DESCRIPTION
XGBoost is the latest and provides some improvements for LTR.

Currently installing xgboost without using eland extras deploy the v2 version of xgboost and everything works well. 

It would be great if the v2 version of xgboost can be installed by default when using eland extras too:

```
pip install eland[xgboost]
```