### PR TITLE
Fix error finding the model's max input size and add override option

### DIFF
--- a/eland/cli/eland_import_hub_model.py
+++ b/eland/cli/eland_import_hub_model.py
@@ -152,6 +152,7 @@ def get_arg_parser():
                 Face configuration. Max input length should never exceed the
                 model's true max length, setting a smaller max length is valid.
                 """,
+        type=int,
     )
 
     return parser

--- a/eland/ml/pytorch/__init__.py
+++ b/eland/ml/pytorch/__init__.py
@@ -31,7 +31,10 @@ from eland.ml.pytorch.nlp_ml_model import (
     ZeroShotClassificationInferenceOptions,
 )
 from eland.ml.pytorch.traceable_model import TraceableModel  # noqa: F401
-from eland.ml.pytorch.transformers import task_type_from_model_config
+from eland.ml.pytorch.transformers import (
+    UnknownModelInputSizeError,
+    task_type_from_model_config,
+)
 
 __all__ = [
     "PyTorchModel",
@@ -49,4 +52,5 @@ __all__ = [
     "TextSimilarityInferenceOptions",
     "ZeroShotClassificationInferenceOptions",
     "task_type_from_model_config",
+    "UnknownModelInputSizeError",
 ]

--- a/tests/ml/pytorch/test_pytorch_model_config_pytest.py
+++ b/tests/ml/pytorch/test_pytorch_model_config_pytest.py
@@ -156,7 +156,7 @@ if HAS_PYTORCH and HAS_SKLEARN and HAS_TRANSFORMERS:
             NlpRobertaTokenizationConfig,
             512,
             None,
-        ),        
+        ),
     ]
 else:
     MODEL_CONFIGURATIONS = []
@@ -242,3 +242,16 @@ class TestModelConfguration:
                 ingest_prefix="INGEST:",
                 search_prefix="SEARCH:",
             )
+
+    def test_model_config_with_user_specified_input_length(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tm = TransformerModel(
+                model_id="sentence-transformers/all-distilroberta-v1",
+                task_type="text_embedding",
+                es_version=(8, 13, 0),
+                quantize=False,
+                max_model_input_size=213,
+            )
+            _, config, _ = tm.save(tmp_dir)
+            tokenization = config.inference_config.tokenization
+            assert tokenization.max_sequence_length == 213

--- a/tests/ml/pytorch/test_pytorch_model_config_pytest.py
+++ b/tests/ml/pytorch/test_pytorch_model_config_pytest.py
@@ -163,6 +163,7 @@ else:
 
 
 class TestModelConfguration:
+    @pytest.mark.skip(reason="https://github.com/elastic/eland/issues/633")
     @pytest.mark.parametrize(
         "model_id,task_type,config_type,tokenizer_type,max_sequence_len,embedding_size",
         MODEL_CONFIGURATIONS,

--- a/tests/ml/pytorch/test_pytorch_model_config_pytest.py
+++ b/tests/ml/pytorch/test_pytorch_model_config_pytest.py
@@ -149,13 +149,20 @@ if HAS_PYTORCH and HAS_SKLEARN and HAS_TRANSFORMERS:
             1024,
             None,
         ),
+        (
+            "cardiffnlp/twitter-roberta-base-sentiment",
+            "text_classification",
+            TextClassificationInferenceOptions,
+            NlpRobertaTokenizationConfig,
+            512,
+            None,
+        ),        
     ]
 else:
     MODEL_CONFIGURATIONS = []
 
 
 class TestModelConfguration:
-    @pytest.mark.skip(reason="https://github.com/elastic/eland/issues/633")
     @pytest.mark.parametrize(
         "model_id,task_type,config_type,tokenizer_type,max_sequence_len,embedding_size",
         MODEL_CONFIGURATIONS,


### PR DESCRIPTION
The error in #668 is due to the model's max input length being incorrectly set to a value that is larger than the true max input length. The problem is due to falling back to the `max_position_embeddings` setting if `model_max_length` is not found in the config. `max_position_embeddings` cannot be reliably used to set the max input size as it may be greater than the true max input. 

For the situations where the max input length cannot be found in the model's configuration a new `--max-model-input-length` setting is added to the `eland/cli/eland_import_hub_model`  script allowing the user to manually specify the value. This is an advanced setting and requires the user to knowingly set an accurate value. It is valid to set a smaller value and input will be truncated to that smaller value.

```
    eland_import_hub_model \
      --cloud-id $ELASTIC_CLOUD_ID \
      --hub-model-id 'sentence-transformers/msmarco-MiniLM-L-12-v3' \
      --task-type text_embedding \
      --max-model-input-length=256 
```

Closes #668