### PR TITLE
Support HTTP proxies in eland_import_hub_model

### DIFF
--- a/docs/guide/machine-learning.asciidoc
+++ b/docs/guide/machine-learning.asciidoc
@@ -154,6 +154,20 @@ underscores `__`.
 
 --
 
+[discrete]
+[[ml-nlp-pytorch-proxy]]
+==== Connect to Elasticsearch through a proxy
+
+Behind the scenes, Eland uses the `requests` Python library, which
+https://requests.readthedocs.io/en/latest/user/advanced/#proxies[allows configuring
+proxies through an environment variable]. For example, to use an HTTP proxy to connect to
+an HTTPS Elasticsearch cluster, you would need to set the `HTTPS_PROXY` environment
+variable when invoking Eland:
+
+[source,bash]
+--------------------------------------------------
+HTTPS_PROXY=http://proxy-host:proxy-port eland_import_hub_model ...
+--------------------------------------------------
 
 [discrete]
 [[ml-nlp-pytorch-auth]]

--- a/docs/guide/machine-learning.asciidoc
+++ b/docs/guide/machine-learning.asciidoc
@@ -192,3 +192,28 @@ eland_import_hub_model --es-api-key <api-key> --url https://<hostname>:<port> ..
 eland_import_hub_model --hub-access-token <access-token> ...
 --------------------------------------------------
 --
+
+[discrete]
+[[ml-nlp-pytorch-tls]]
+==== TLS/SSL
+
+The following TLS/SSL options for Elasticsearch are available when using the import script:
+
+
+* Specify alternate CA bundle to verify the cluster certificate:
++
+--
+[source,bash]
+--------------------------------------------------
+eland_import_hub_model --ca-certs CA_CERTS ...
+--------------------------------------------------
+--
+
+* Disable TLS/SSL verification altogether (strongly discouraged):
++
+--
+[source,bash]
+--------------------------------------------------
+eland_import_hub_model --insecure ...
+--------------------------------------------------
+--

--- a/docs/guide/machine-learning.asciidoc
+++ b/docs/guide/machine-learning.asciidoc
@@ -161,13 +161,16 @@ underscores `__`.
 Behind the scenes, Eland uses the `requests` Python library, which
 https://requests.readthedocs.io/en/latest/user/advanced/#proxies[allows configuring
 proxies through an environment variable]. For example, to use an HTTP proxy to connect to
-an HTTPS Elasticsearch cluster, you would need to set the `HTTPS_PROXY` environment
-variable when invoking Eland:
+an HTTPS Elasticsearch cluster, you need to set the `HTTPS_PROXY` environment variable
+when invoking Eland:
 
 [source,bash]
 --------------------------------------------------
 HTTPS_PROXY=http://proxy-host:proxy-port eland_import_hub_model ...
 --------------------------------------------------
+
+If you disabled security on your Elasticsearch cluster, you should use `HTTP_PROXY`
+instead.
 
 [discrete]
 [[ml-nlp-pytorch-auth]]

--- a/docs/guide/machine-learning.asciidoc
+++ b/docs/guide/machine-learning.asciidoc
@@ -60,6 +60,12 @@ $ eland_import_hub_model <authentication> \ <1>
 <4> Specify the type of NLP task. Supported values are `fill_mask`, `ner`,
 `question_answering`, `text_classification`, `text_embedding`, and `zero_shot_classification`.
 
+For more information about the available options, run `eland_import_hub_model` with the `--help` option.
+
+[source,bash]
+------------------------
+$ eland_import_hub_model --help
+------------------------
 
 [discrete]
 [[ml-nlp-pytorch-docker]]

--- a/eland/cli/eland_import_hub_model.py
+++ b/eland/cli/eland_import_hub_model.py
@@ -164,6 +164,7 @@ def get_es_client(cli_args, logger):
             "request_timeout": 300,
             "verify_certs": cli_args.insecure,
             "ca_certs": cli_args.ca_certs,
+            "node_class": "requests",
         }
 
         # Deployment location


### PR DESCRIPTION
Depends on #667 

Tested by running `python -m dummyserver.proxy` using tag 2.1.0 of urllib3 (I broke the command-line proxy in later commits of urllib3) and using `export HTTPS_PROXY=http://localhost:8888/` to upload a model with Eland. Without the proxy running, the upload fails.