### PR TITLE
Stop duplicating requirements

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,5 +7,5 @@ build:
 
 python:
   install:
-    - requirements: docs/requirements-docs.txt
     - path: .
+    - requirements: docs/requirements-docs.txt

--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -1,13 +1,5 @@
-elasticsearch>=7.7
-pandas>=1.5
-matplotlib>=3.6
+matplotlib
 nbval
-scikit-learn>=0.22.1
-xgboost>=1
-lightgbm
 sphinx==5.3.0
 nbsphinx
 furo
-
-# traitlets has been having all sorts of release problems lately.
-traitlets<5.1

--- a/noxfile.py
+++ b/noxfile.py
@@ -56,7 +56,7 @@ TYPED_FILES = (
 )
 
 
-@nox.session(reuse_venv=True)
+@nox.session(reuse_venv=True, python="3.11")
 def format(session):
     session.install("black", "isort", "flynt")
     session.run("python", "utils/license-headers.py", "fix", *SOURCE_FILES)
@@ -66,12 +66,12 @@ def format(session):
     lint(session)
 
 
-@nox.session(reuse_venv=True)
+@nox.session(reuse_venv=True, python="3.11")
 def lint(session):
     # Install numpy to use its mypy plugin
     # https://numpy.org/devdocs/reference/typing.html#mypy-plugin
     session.install("black", "flake8", "mypy", "isort", "numpy")
-    session.install("--pre", "elasticsearch>=8.3,<9")
+    session.install(".")
     session.run("python", "utils/license-headers.py", "check", *SOURCE_FILES)
     session.run("black", "--check", "--target-version=py38", *SOURCE_FILES)
     session.run("isort", "--check", "--profile=black", *SOURCE_FILES)
@@ -150,8 +150,8 @@ def docs(session):
     # Run this so users get an error if they don't have Pandoc installed.
     session.run("pandoc", "--version", external=True)
 
-    session.install("-r", "docs/requirements-docs.txt")
     session.install(".")
+    session.install("-r", "docs/requirements-docs.txt")
 
     # See if we have an Elasticsearch cluster active
     # to rebuild the Jupyter notebooks with.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,25 +1,8 @@
 #
-# Basic requirements
+# Basic requirements with extras
 #
-elasticsearch>=8.3,<9
-pandas>=1.5,<2
-matplotlib>=3.6
-numpy>=1.2.0,<2
-tqdm<5
+.[all]
 
-#
-# Extras
-#
-scikit-learn>=1.3,<1.4
-xgboost>=0.90,<2
-lightgbm>=2,<4
-
-# Elasticsearch uses PyTorch 2.1.2
-# Python 3.12 is not supported by PyTorch 2.1.2
-torch==2.1.2; python_version<'3.12'
-# Versions known to be compatible with PyTorch 2.1.2
-sentence-transformers>=2.1.0,<=2.3.1
-transformers[torch]>=4.31.0,<4.36.0
 #
 # Testing
 #

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,0 @@
-#
-# Basic requirements
-#
-elasticsearch>=8.3,<9
-pandas>=1.5,<2
-matplotlib>=3.6
-numpy>=1.2.0,<2

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ extras = {
     "scikit-learn": ["scikit-learn>=1.3,<1.4"],
     "lightgbm": ["lightgbm>=2,<4"],
     "pytorch": [
+        "requests<3",
         "torch==2.1.2",
         "tqdm",
         "sentence-transformers>=2.1.0,<=2.3.1",

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ extras = {
     "lightgbm": ["lightgbm>=2,<4"],
     "pytorch": [
         "torch==2.1.2",
+        "tqdm",
         "sentence-transformers>=2.1.0,<=2.3.1",
         "transformers[torch]>=4.31.0,<4.36.0",
     ],


### PR DESCRIPTION
Today we specify `elasticsearch>=8.3,<9` in four places. In setup.py, as expected for the package metadata to be correct, but also:

 * in requirements.txt, which was unused, so I removed it
 * in requirements-dev.txt, which can simply refer to `.[extras]` to install all packages with its extras
 * in noxfile.py, where installing `.` is enough to make lint pass (also we don't need pre-releases anymore)
 * in docs/requirements-docs.txt which was out of date anyway