### PR TITLE
Fix missing method str.removeprefix in Python 3.8

### DIFF
--- a/eland/ml/pytorch/transformers.py
+++ b/eland/ml/pytorch/transformers.py
@@ -1061,7 +1061,7 @@ def elasticsearch_model_id(model_id: str) -> str:
     id = re.sub(r"[\s\\/]", "__", model_id).lower()[-64:]
     if id.startswith("__"):
         # This check is only needed as long as Eland supports Python 3.8
-        # str.removeprefix was introduced in Python 3.9 and can be used 
+        # str.removeprefix was introduced in Python 3.9 and can be used
         # once 3.8 support is dropped
         id = id[2:]
     return id

--- a/eland/ml/pytorch/transformers.py
+++ b/eland/ml/pytorch/transformers.py
@@ -24,6 +24,7 @@ import json
 import os.path
 import random
 import re
+import sys
 from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Optional, Set, Tuple, Union
 

--- a/eland/ml/pytorch/transformers.py
+++ b/eland/ml/pytorch/transformers.py
@@ -1061,9 +1061,7 @@ def elasticsearch_model_id(model_id: str) -> str:
     id = re.sub(r"[\s\\/]", "__", model_id).lower()[-64:]
     if id.startswith("__"):
         # This check is only needed as long as Eland supports Python 3.8
-        # str.removeprefix was introduced in Python 3.9
-        if sys.version_info >= (3, 9, 0):
-            id = id.removeprefix("__")
-        else:
-            id = id[2:]
+        # str.removeprefix was introduced in Python 3.9 and can be used 
+        # once 3.8 support is dropped
+        id = id[2:]
     return id

--- a/eland/ml/pytorch/transformers.py
+++ b/eland/ml/pytorch/transformers.py
@@ -1061,7 +1061,7 @@ def elasticsearch_model_id(model_id: str) -> str:
     if id.startswith("__"):
         # This check is only needed as long as Eland supports Python 3.8
         # str.removeprefix was introduced in Python 3.9
-        if sys.version_info > (3, 9, 0):
+        if sys.version_info >= (3, 9, 0):
             id = id.removeprefix("__")
         else:
             id = id[2:]

--- a/eland/ml/pytorch/transformers.py
+++ b/eland/ml/pytorch/transformers.py
@@ -1059,5 +1059,10 @@ def elasticsearch_model_id(model_id: str) -> str:
 
     id = re.sub(r"[\s\\/]", "__", model_id).lower()[-64:]
     if id.startswith("__"):
-        id = id.removeprefix("__")
+        # This check is only needed as long as Eland supports Python 3.8
+        # str.removeprefix was introduced in Python 3.9
+        if sys.version_info > (3, 9, 0):
+            id = id.removeprefix("__")
+        else:
+            id = id[2:]
     return id

--- a/eland/ml/pytorch/transformers.py
+++ b/eland/ml/pytorch/transformers.py
@@ -24,7 +24,6 @@ import json
 import os.path
 import random
 import re
-import sys
 from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Optional, Set, Tuple, Union
 


### PR DESCRIPTION
Eland still supports Python 3.8, so str.removeprefix can be called and raise an `AttributeError`.

Once Eland drops Python 3.8 support this if/else can be removed (only keeping the code in the if).