### PR TITLE
Deal with the possibility of lists in multi-fields

### DIFF
--- a/eland/operations.py
+++ b/eland/operations.py
@@ -1543,14 +1543,22 @@ def quantile_to_percentile(quantile: Union[int, float]) -> float:
     return float(min(100, max(0, quantile * 100)))
 
 
-def is_field_already_present(key: str, dictionary: Dict[str, Any]) -> bool:
+def is_field_already_present(
+    key: str, data: Union[Dict[str, Any], List[Dict[str, Any]]]
+) -> bool:
     if "." in key:
         splitted = key.split(".")
-        return is_field_already_present(
-            ".".join(splitted[1:]), dictionary.get(splitted[0], {})
-        )
+        if isinstance(data, dict):
+            return is_field_already_present(
+                ".".join(splitted[1:]), data.get(splitted[0], {})
+            )
+        if isinstance(data, list):
+            return any(
+                is_field_already_present(".".join(splitted[1:]), x.get(splitted[0], {}))
+                for x in data
+            )
     else:
-        return key in dictionary
+        return key in data
 
 
 def _search_yield_hits(


### PR DESCRIPTION
While running the new release, it looks like my previous pull request #693 didn't deal with an edge case while checking whether a field was present. It is possible for a field to be a list of dicts as well.

On top of that it feels a bit like painting myself into a corner fixing the missing fields #692. The example indices eland uses for testing aren't as complex (and nested) as the mappings I'm dealing with in our internal data warehouse.