### PR TITLE
Remove input fields from exported LTR models

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -32,6 +32,7 @@ steps:
           - '3.9'
           - '3.8'
         stack:
-          - '8.13.0-SNAPSHOT'
+          - '8.15.0-SNAPSHOT'
+          - '8.14.1'
           - '8.12.2'
     command: ./.buildkite/run-tests

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -34,5 +34,4 @@ steps:
         stack:
           - '8.15.0-SNAPSHOT'
           - '8.14.1'
-          - '8.12.2'
     command: ./.buildkite/run-tests

--- a/eland/cli/eland_import_hub_model.py
+++ b/eland/cli/eland_import_hub_model.py
@@ -33,7 +33,7 @@ from elastic_transport.client_utils import DEFAULT
 from elasticsearch import AuthenticationException, Elasticsearch
 
 from eland._version import __version__
-from eland.common import parse_es_version
+from eland.common import is_serverless_es, parse_es_version
 
 MODEL_HUB_URL = "https://huggingface.co"
 
@@ -197,10 +197,7 @@ def get_es_client(cli_args, logger):
 def check_cluster_version(es_client, logger):
     es_info = es_client.info()
 
-    if (
-        "build_flavor" in es_info["version"]
-        and es_info["version"]["build_flavor"] == "serverless"
-    ):
+    if is_serverless_es(es_client):
         logger.info(f"Connected to serverless cluster '{es_info['cluster_name']}'")
         # Serverless is compatible
         # Return the latest known semantic version, i.e. this version

--- a/eland/common.py
+++ b/eland/common.py
@@ -344,6 +344,17 @@ def es_version(es_client: Elasticsearch) -> Tuple[int, int, int]:
     return eland_es_version
 
 
+def is_serverless_es(es_client: Elasticsearch) -> bool:
+    """
+    Returns true if the client is connected to a serverless instance of Elasticsearch.
+    """
+    es_info = es_client.info()
+    return (
+        "build_flavor" in es_info["version"]
+        and es_info["version"]["build_flavor"] == "serverless"
+    )
+
+
 def parse_es_version(version: str) -> Tuple[int, int, int]:
     """
     Parse the semantic version from a string e.g. '8.8.0'

--- a/eland/ml/ml_model.py
+++ b/eland/ml/ml_model.py
@@ -533,20 +533,20 @@ class MLModel:
             ),
         )
 
-        put_trained_model_kwargs = {
-            "model_id": model_id,
-            "inference_config": inference_config or default_inference_config,
-            "input": trained_model_input,
-        }
-
         if es_compress_model_definition:
-            put_trained_model_kwargs["compressed_definition"] = (
-                serializer.serialize_and_compress_model()
+            ml_model._client.ml.put_trained_model(
+                model_id=model_id,
+                inference_config=inference_config or default_inference_config,
+                input=trained_model_input,
+                compressed_definition=serializer.serialize_and_compress_model(),
             )
         else:
-            put_trained_model_kwargs["definition"] = serializer.serialize_model()
-
-        ml_model._client.ml.put_trained_model(**put_trained_model_kwargs)
+            ml_model._client.ml.put_trained_model(
+                model_id=model_id,
+                inference_config=inference_config or default_inference_config,
+                input=trained_model_input,
+                definition=serializer.serialize_model(),
+            )
 
         return ml_model
 
@@ -557,6 +557,7 @@ class MLModel:
         feature_names: List[str],
         model_type: str,
     ) -> Optional[Mapping[str, Any]]:
+        es_client = ensure_es_client(es_client)
         if es_version(es_client) < (8, 15) or model_type is not TYPE_LEARNING_TO_RANK:
             return {"field_names": feature_names}
 

--- a/eland/ml/ml_model.py
+++ b/eland/ml/ml_model.py
@@ -526,7 +526,11 @@ class MLModel:
         trained_model_input = cls._trained_model_input(
             es_client,
             feature_names,
-            next(iter(inference_config)) if inference_config is not None else model_type
+            (
+                next(iter(inference_config))
+                if inference_config is not None
+                else model_type
+            ),
         )
 
         put_trained_model_kwargs = {
@@ -536,9 +540,11 @@ class MLModel:
         }
 
         if es_compress_model_definition:
-            put_trained_model_kwargs['compressed_definition'] = serializer.serialize_and_compress_model()
+            put_trained_model_kwargs["compressed_definition"] = (
+                serializer.serialize_and_compress_model()
+            )
         else:
-            put_trained_model_kwargs['definition'] = serializer.serialize_model()
+            put_trained_model_kwargs["definition"] = serializer.serialize_model()
 
         ml_model._client.ml.put_trained_model(**put_trained_model_kwargs)
 
@@ -552,7 +558,7 @@ class MLModel:
         model_type: str,
     ) -> Optional[Mapping[str, Any]]:
         if es_version(es_client) < (8, 15) or model_type is not TYPE_LEARNING_TO_RANK:
-            return { "field_names": feature_names }
+            return {"field_names": feature_names}
 
         return None
 

--- a/eland/ml/ml_model.py
+++ b/eland/ml/ml_model.py
@@ -20,7 +20,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional, Tuple, Uni
 import elasticsearch
 import numpy as np
 
-from eland.common import ensure_es_client, es_version
+from eland.common import ensure_es_client, es_version, is_serverless_es
 from eland.utils import deprecated_api
 
 from .common import TYPE_CLASSIFICATION, TYPE_LEARNING_TO_RANK, TYPE_REGRESSION
@@ -527,7 +527,9 @@ class MLModel:
 
         trained_model_input = None
         is_ltr = next(iter(inference_config)) is TYPE_LEARNING_TO_RANK
-        if not is_ltr or es_version(es_client) < (8, 15):
+        if not is_ltr or (
+            es_version(es_client) < (8, 15) and not is_serverless_es(es_client)
+        ):
             trained_model_input = {"field_names": feature_names}
 
         if es_compress_model_definition:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -20,7 +20,7 @@ import os
 import pandas as pd
 from elasticsearch import Elasticsearch
 
-from eland.common import es_version
+from eland.common import es_version, is_serverless_es
 
 ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
 
@@ -33,6 +33,7 @@ ELASTICSEARCH_HOST = os.environ.get(
 ES_TEST_CLIENT = Elasticsearch(ELASTICSEARCH_HOST)
 
 ES_VERSION = es_version(ES_TEST_CLIENT)
+ES_IS_SERVERLESS = is_serverless_es(ES_TEST_CLIENT)
 
 FLIGHTS_INDEX_NAME = "flights"
 FLIGHTS_MAPPING = {

--- a/tests/ml/test_ml_model_pytest.py
+++ b/tests/ml/test_ml_model_pytest.py
@@ -25,9 +25,9 @@ import eland as ed
 from eland.ml import MLModel
 from eland.ml.ltr import FeatureLogger, LTRModelConfig, QueryFeatureExtractor
 from tests import (
+    ES_IS_SERVERLESS,
     ES_TEST_CLIENT,
     ES_VERSION,
-    ES_IS_SERVERLESS,
     FLIGHTS_SMALL_INDEX_NAME,
     NATIONAL_PARKS_INDEX_NAME,
 )

--- a/tests/ml/test_ml_model_pytest.py
+++ b/tests/ml/test_ml_model_pytest.py
@@ -449,7 +449,9 @@ class TestMLModel:
             pass
 
         # Clean up
-        ES_TEST_CLIENT.cluster.health(index=".ml-*", wait_for_active_shards="all")
+        ES_TEST_CLIENT.cluster.health(
+            index=".ml-*", wait_for_active_shards="all"
+        )  # Added to prevent flakiness in the test
         es_model.delete_model()
 
     @requires_sklearn

--- a/tests/ml/test_ml_model_pytest.py
+++ b/tests/ml/test_ml_model_pytest.py
@@ -27,6 +27,7 @@ from eland.ml.ltr import FeatureLogger, LTRModelConfig, QueryFeatureExtractor
 from tests import (
     ES_TEST_CLIENT,
     ES_VERSION,
+    ES_IS_SERVERLESS,
     FLIGHTS_SMALL_INDEX_NAME,
     NATIONAL_PARKS_INDEX_NAME,
 )
@@ -393,7 +394,7 @@ class TestMLModel:
         assert "input" in saved_trained_model_config
         assert "field_names" in saved_trained_model_config["input"]
 
-        if ES_VERSION < (8, 15):
+        if not ES_IS_SERVERLESS and ES_VERSION < (8, 15):
             assert len(saved_trained_model_config["input"]["field_names"]) == 3
         else:
             assert not len(saved_trained_model_config["input"]["field_names"])
@@ -448,7 +449,7 @@ class TestMLModel:
             pass
 
         # Clean up
-        ES_TEST_CLIENT.cluster.health(index='.ml-*', wait_for_active_shards='all')
+        ES_TEST_CLIENT.cluster.health(index=".ml-*", wait_for_active_shards="all")
         es_model.delete_model()
 
     @requires_sklearn

--- a/tests/ml/test_ml_model_pytest.py
+++ b/tests/ml/test_ml_model_pytest.py
@@ -394,9 +394,9 @@ class TestMLModel:
         assert "field_names" in saved_trained_model_config["input"]
 
         if ES_VERSION < (8, 15):
-            assert not len(saved_trained_model_config["input"]["field_names"])
-        else:
             assert len(saved_trained_model_config["input"]["field_names"]) == 3
+        else:
+            assert not len(saved_trained_model_config["input"]["field_names"])
 
         saved_inference_config = saved_trained_model_config["inference_config"]
 

--- a/tests/ml/test_ml_model_pytest.py
+++ b/tests/ml/test_ml_model_pytest.py
@@ -448,6 +448,7 @@ class TestMLModel:
             pass
 
         # Clean up
+        ES_TEST_CLIENT.cluster.health(index='.ml-*', wait_for_active_shards='all')
         es_model.delete_model()
 
     @requires_sklearn
@@ -476,6 +477,7 @@ class TestMLModel:
         )
 
         # Clean up
+
         es_model.delete_model()
 
     @requires_sklearn

--- a/tests/ml/test_ml_model_pytest.py
+++ b/tests/ml/test_ml_model_pytest.py
@@ -387,9 +387,19 @@ class TestMLModel:
         response = ES_TEST_CLIENT.ml.get_trained_models(model_id=model_id)
         assert response.meta.status == 200
         assert response.body["count"] == 1
-        saved_inference_config = response.body["trained_model_configs"][0][
-            "inference_config"
-        ]
+
+        saved_trained_model_config = response.body["trained_model_configs"][0]
+
+        assert "input" in saved_trained_model_config
+        assert "field_names" in saved_trained_model_config["input"]
+
+        if ES_VERSION < (8, 15):
+            assert not len(saved_trained_model_config["input"]["field_names"])
+        else:
+            assert len(saved_trained_model_config["input"]["field_names"]) == 3
+
+        saved_inference_config = saved_trained_model_config["inference_config"]
+
         assert "learning_to_rank" in saved_inference_config
         assert "feature_extractors" in saved_inference_config["learning_to_rank"]
         saved_feature_extractors = saved_inference_config["learning_to_rank"][

--- a/tests/ml/test_ml_model_pytest.py
+++ b/tests/ml/test_ml_model_pytest.py
@@ -380,7 +380,6 @@ class TestMLModel:
             model_id,
             ranker,
             ltr_model_config,
-            es_if_exists="replace",
             es_compress_model_definition=compress_model_definition,
         )
 


### PR DESCRIPTION
## Context:

In Elasticsearch >= 8.15.0, we update the `PUT _ml/trained_models/<model_id>` API for LTR models and specifying `input.field_names` is not supported anymore. 

Previously, the field was required and eland was putting feature names into it as a hack.

The Elasticsearch PR: https://github.com/elastic/elasticsearch/pull/109437

## PR content:

The behavior now depends of the es version and the `input.field_names` is set only for ES < 8.15.0