### PR TITLE
Default truncation to `second` for text similarity

### DIFF
--- a/eland/ml/pytorch/transformers.py
+++ b/eland/ml/pytorch/transformers.py
@@ -770,6 +770,10 @@ class TransformerModel:
             tokenization_config.span = 128
             tokenization_config.truncate = "none"
 
+        if self._task_type == "text_similarity":
+            print("is text sime")
+            tokenization_config.truncate = "second"
+
         if self._traceable_model.classification_labels():
             inference_config = TASK_TYPE_TO_INFERENCE_CONFIG[self._task_type](
                 tokenization=tokenization_config,

--- a/eland/ml/pytorch/transformers.py
+++ b/eland/ml/pytorch/transformers.py
@@ -771,7 +771,6 @@ class TransformerModel:
             tokenization_config.truncate = "none"
 
         if self._task_type == "text_similarity":
-            print("is text sime")
             tokenization_config.truncate = "second"
 
         if self._traceable_model.classification_labels():

--- a/tests/ml/pytorch/test_pytorch_model_config_pytest.py
+++ b/tests/ml/pytorch/test_pytorch_model_config_pytest.py
@@ -217,6 +217,9 @@ class TestModelConfguration:
                 assert isinstance(config.inference_config.classification_labels, list)
                 assert len(config.inference_config.classification_labels) > 0
 
+            if task_type == "text_similarity":
+                assert tokenization.truncate == "second"
+
             del tm
 
     def test_model_config_with_prefix_string(self):


### PR DESCRIPTION
 NLP models have 3 truncation settings: `FIRST`, `SECOND` and `NONE`

`FIRST` means truncate the first input. In most cases there is only 1 input (e.g for text embeddings) so this is a sensible default.
`SECOND` means truncate the second input. Task types with 2 inputs are extractive question answering where the question is one input and the context the other. Text Similarity takes has 2 inputs.
`NONE` means don't truncate and window the input.

For text similarity the first input is usually the shorter input, for example it might be the query text in a rerank operation. In this situation it is better to truncate the second input. This change makes that the default. 