### PR TITLE
Add support for DeBERTa-V2 tokenizer

### DIFF
--- a/eland/ml/pytorch/nlp_ml_model.py
+++ b/eland/ml/pytorch/nlp_ml_model.py
@@ -86,6 +86,27 @@ class NlpXLMRobertaTokenizationConfig(NlpTokenizationConfig):
         )
 
 
+class DebertaV2Config(NlpTokenizationConfig):
+    def __init__(
+        self,
+        *,
+        do_lower_case: t.Optional[bool] = None,
+        with_special_tokens: t.Optional[bool] = None,
+        max_sequence_length: t.Optional[int] = None,
+        truncate: t.Optional[
+            t.Union["t.Literal['first', 'none', 'second']", str]
+        ] = None,
+        span: t.Optional[int] = None,
+    ):
+        super().__init__(
+            configuration_type="deberta_v2",
+            with_special_tokens=with_special_tokens,
+            max_sequence_length=max_sequence_length,
+            truncate=truncate,
+            span=span,
+        )
+
+
 class NlpBertTokenizationConfig(NlpTokenizationConfig):
     def __init__(
         self,

--- a/eland/ml/pytorch/transformers.py
+++ b/eland/ml/pytorch/transformers.py
@@ -43,6 +43,7 @@ from transformers import (
 )
 
 from eland.ml.pytorch.nlp_ml_model import (
+    DebertaV2Config,
     FillMaskInferenceOptions,
     NerInferenceOptions,
     NlpBertJapaneseTokenizationConfig,
@@ -115,6 +116,7 @@ SUPPORTED_TOKENIZERS = (
     transformers.BartTokenizer,
     transformers.SqueezeBertTokenizer,
     transformers.XLMRobertaTokenizer,
+    transformers.DebertaV2Tokenizer,
 )
 SUPPORTED_TOKENIZERS_NAMES = ", ".join(sorted([str(x) for x in SUPPORTED_TOKENIZERS]))
 
@@ -318,6 +320,7 @@ class _SentenceTransformerWrapperModule(nn.Module):  # type: ignore
                 transformers.MPNetTokenizer,
                 transformers.RobertaTokenizer,
                 transformers.XLMRobertaTokenizer,
+                transformers.DebertaV2Tokenizer,
             ),
         ):
             return _TwoParameterSentenceTransformerWrapper(model, output_key)
@@ -485,6 +488,7 @@ class _TransformerTraceableModel(TraceableModel):
                 transformers.MPNetTokenizer,
                 transformers.RobertaTokenizer,
                 transformers.XLMRobertaTokenizer,
+                transformers.DebertaV2Tokenizer,
             ),
         ):
             del inputs["token_type_ids"]
@@ -717,6 +721,11 @@ class TransformerModel:
         elif isinstance(self._tokenizer, transformers.XLMRobertaTokenizer):
             return NlpXLMRobertaTokenizationConfig(
                 max_sequence_length=_max_sequence_length
+            )
+        elif isinstance(self._tokenizer, transformers.DebertaV2Tokenizer):
+            return DebertaV2Config(
+                max_sequence_length=_max_sequence_length,
+                do_lower_case=getattr(self._tokenizer, "do_lower_case", None),
             )
         else:
             japanese_morphological_tokenizers = ["mecab"]


### PR DESCRIPTION
This PR adds support for uploading models based on DeBERTa-V2 and V3.

Unfortunately there's currently no way test test this, due to an incompatibility between the Huggingface DeBERTa model and our pytorch implementation https://github.com/huggingface/transformers/issues/20815