### PR TITLE
Restore public Dockerfile

### DIFF
--- a/.buildkite/release-docker/run.sh
+++ b/.buildkite/release-docker/run.sh
@@ -26,6 +26,7 @@ git --no-pager show
 docker buildx rm --force eland-multiarch-builder || true
 docker buildx create --name eland-multiarch-builder --bootstrap --use
 docker buildx build --push \
+  --file Dockerfile.wolfi \
   --tag "$docker_registry/eland/eland:$RELEASE_VERSION" \
   --tag "$docker_registry/eland/eland:latest" \
   --platform linux/amd64,linux/arm64 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,17 @@
 # syntax=docker/dockerfile:1
-FROM docker.elastic.co/wolfi/python:3.10-dev AS builder
+FROM python:3.10-slim
 
-WORKDIR /eland
-ENV VIRTUAL_ENV=/eland/venv
-RUN python3 -m venv $VIRTUAL_ENV
-ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && apt-get install -y \
+      build-essential \
+      pkg-config \
+      cmake \
+      libzip-dev \
+      libjpeg-dev
 
 ADD . /eland
+WORKDIR /eland
 
 ARG TARGETPLATFORM
 RUN --mount=type=cache,target=/root/.cache/pip \
@@ -20,23 +25,4 @@ RUN --mount=type=cache,target=/root/.cache/pip \
         .[all]; \
     fi
 
-FROM docker.elastic.co/wolfi/python:3.10
-
-WORKDIR /eland
-ENV VIRTUAL_ENV=/eland/venv
-ENV PATH="$VIRTUAL_ENV/bin:$PATH"
-
-COPY --from=builder /eland /eland
-
-# The eland_import_hub_model script is intended to be executed by a shell,
-# which will see its shebang line and then execute it with the Python
-# interpreter of the virtual environment. We want to keep this behavior even
-# with Wolfi so that users can use the image as before. To do that, we use two
-# tricks:
-#
-#  * copy /bin/sh (that is, busybox's ash) from the builder image
-#  * revert to Docker's the default entrypoint, which is the only way to pass
-#    parameters to `eland_import_hub_model` without needing quotes.
-#
-COPY --from=builder /bin/sh /bin/sh
-ENTRYPOINT []
+CMD ["/bin/sh"]

--- a/Dockerfile.wolfi
+++ b/Dockerfile.wolfi
@@ -1,0 +1,42 @@
+# syntax=docker/dockerfile:1
+FROM docker.elastic.co/wolfi/python:3.10-dev AS builder
+
+WORKDIR /eland
+ENV VIRTUAL_ENV=/eland/venv
+RUN python3 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+ADD . /eland
+
+ARG TARGETPLATFORM
+RUN --mount=type=cache,target=/root/.cache/pip \
+    if [ "$TARGETPLATFORM" = "linux/amd64" ]; then \
+      python3 -m pip install \
+        --no-cache-dir --disable-pip-version-check --extra-index-url https://download.pytorch.org/whl/cpu  \
+        torch==2.1.2+cpu .[all]; \
+    else \
+      python3 -m pip install \
+        --no-cache-dir --disable-pip-version-check \
+        .[all]; \
+    fi
+
+FROM docker.elastic.co/wolfi/python:3.10
+
+WORKDIR /eland
+ENV VIRTUAL_ENV=/eland/venv
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+COPY --from=builder /eland /eland
+
+# The eland_import_hub_model script is intended to be executed by a shell,
+# which will see its shebang line and then execute it with the Python
+# interpreter of the virtual environment. We want to keep this behavior even
+# with Wolfi so that users can use the image as before. To do that, we use two
+# tricks:
+#
+#  * copy /bin/sh (that is, busybox's ash) from the builder image
+#  * revert to Docker's the default entrypoint, which is the only way to pass
+#    parameters to `eland_import_hub_model` without needing quotes.
+#
+COPY --from=builder /bin/sh /bin/sh
+ENTRYPOINT []


### PR DESCRIPTION
Since non-latest Wolfi images are not public, we allow users to continue building with Dockerfile being Debian-based.