### PR TITLE
Fix Docker image build on Linux

### DIFF
--- a/.buildkite/build-docker-images.sh
+++ b/.buildkite/build-docker-images.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+export LC_ALL=en_US.UTF-8
+
+docker buildx rm --force eland-multiarch-builder || true
+docker buildx create --name eland-multiarch-builder --bootstrap --use
+
+for platform in linux/amd64 linux/arm64; do
+  echo "--- Building $platform"
+  # Create builder that supports QEMU emulation (needed for linux/arm64)
+  docker buildx build --push \
+    --file Dockerfile.wolfi \
+    --load --platform $platform \
+    .

--- a/.buildkite/build-docker-images.sh
+++ b/.buildkite/build-docker-images.sh
@@ -6,8 +6,4 @@ export LC_ALL=en_US.UTF-8
 # Create builder that supports QEMU emulation (needed for linux/arm64)
 docker buildx rm --force eland-multiarch-builder || true
 docker buildx create --name eland-multiarch-builder --bootstrap --use
-
-for platform in linux/amd64 linux/arm64; do
-  echo "--- Building $platform"
-  docker buildx build --file Dockerfile.wolfi --load --platform $platform .
-done
+docker buildx build --file Dockerfile.wolfi --load --platform $PLATFORM .

--- a/.buildkite/build-docker-images.sh
+++ b/.buildkite/build-docker-images.sh
@@ -3,13 +3,14 @@
 set -eo pipefail
 export LC_ALL=en_US.UTF-8
 
+# Create builder that supports QEMU emulation (needed for linux/arm64)
 docker buildx rm --force eland-multiarch-builder || true
 docker buildx create --name eland-multiarch-builder --bootstrap --use
 
 for platform in linux/amd64 linux/arm64; do
   echo "--- Building $platform"
-  # Create builder that supports QEMU emulation (needed for linux/arm64)
   docker buildx build --push \
     --file Dockerfile.wolfi \
     --load --platform $platform \
     .
+done

--- a/.buildkite/build-docker-images.sh
+++ b/.buildkite/build-docker-images.sh
@@ -9,8 +9,5 @@ docker buildx create --name eland-multiarch-builder --bootstrap --use
 
 for platform in linux/amd64 linux/arm64; do
   echo "--- Building $platform"
-  docker buildx build --push \
-    --file Dockerfile.wolfi \
-    --load --platform $platform \
-    .
+  docker buildx build --file Dockerfile.wolfi --load --platform $platform .
 done

--- a/.buildkite/build-docker-images.sh
+++ b/.buildkite/build-docker-images.sh
@@ -3,7 +3,9 @@
 set -eo pipefail
 export LC_ALL=en_US.UTF-8
 
-# Create builder that supports QEMU emulation (needed for linux/arm64)
-docker buildx rm --force eland-multiarch-builder || true
-docker buildx create --name eland-multiarch-builder --bootstrap --use
-docker buildx build --file Dockerfile.wolfi --load --platform $PLATFORM .
+echo "--- Building the Wolfi image"
+# Building the linux/arm64 image takes about one hour on Buildkite, which is too slow
+docker build --file Dockerfile.wolfi .
+
+echo "--- Building the public image"
+docker build .

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -15,6 +15,14 @@ steps:
       machineType: "n2-standard-2"
     commands:
       - ./.buildkite/build-documentation.sh
+  - label: ":docker: Build docker images"
+    env:
+      PYTHON_VERSION: 3.11-bookworm
+    agents:
+      provider: "gcp"
+      machineType: "n2-standard-2"
+    commands:
+      - ./.buildkite/build-docker-images.sh
   - label: "Eland :python: {{ matrix.python }} :elasticsearch: {{ matrix.stack }}"
     agents:
       provider: "gcp"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -20,14 +20,7 @@ steps:
       PYTHON_VERSION: 3.11-bookworm
     agents:
       provider: "gcp"
-      machineType: "n2-standard-4"
-    env:
-      PLATFORM: "{{ matrix.platform }}"
-    matrix:
-      setup:
-        platform:
-          - 'linux/arm64'
-          - 'linux/amd64'
+      machineType: "n2-standard-2"
     commands:
       - ./.buildkite/build-docker-images.sh
   - label: "Eland :python: {{ matrix.python }} :elasticsearch: {{ matrix.stack }}"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -15,12 +15,19 @@ steps:
       machineType: "n2-standard-2"
     commands:
       - ./.buildkite/build-documentation.sh
-  - label: ":docker: Build docker images"
+  - label: ":docker: Build docker image {{ matrix.platform }}"
     env:
       PYTHON_VERSION: 3.11-bookworm
     agents:
       provider: "gcp"
-      machineType: "n2-standard-2"
+      machineType: "n2-standard-4"
+    env:
+      PLATFORM: "{{ matrix.platform }}"
+    matrix:
+      setup:
+        platform:
+          - 'linux/arm64'
+          - 'linux/amd64'
     commands:
       - ./.buildkite/build-docker-images.sh
   - label: "Eland :python: {{ matrix.python }} :elasticsearch: {{ matrix.stack }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     if [ "$TARGETPLATFORM" = "linux/amd64" ]; then \
       python3 -m pip install \
         --no-cache-dir --disable-pip-version-check --extra-index-url https://download.pytorch.org/whl/cpu  \
-        torch==2.1.2+cpu .[all]; \
+        torch==2.3.1+cpu .[all]; \
     else \
       python3 -m pip install \
         --no-cache-dir --disable-pip-version-check \

--- a/Dockerfile.wolfi
+++ b/Dockerfile.wolfi
@@ -13,7 +13,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     if [ "$TARGETPLATFORM" = "linux/amd64" ]; then \
       python3 -m pip install \
         --no-cache-dir --disable-pip-version-check --extra-index-url https://download.pytorch.org/whl/cpu  \
-        torch==2.1.2+cpu .[all]; \
+        torch==2.3.1+cpu .[all]; \
     else \
       python3 -m pip install \
         --no-cache-dir --disable-pip-version-check \


### PR DESCRIPTION
I tested the Docker image buid on macOS, which does not need a version. And I failed to test a staging build + push on Buildkite before releasing, sorry.

This will require a new release, Eland 8.15.2.