### PR TITLE
Allow reading Elasticsearch certs in Wolfi image

### DIFF
--- a/Dockerfile.wolfi
+++ b/Dockerfile.wolfi
@@ -26,6 +26,10 @@ WORKDIR /eland
 ENV VIRTUAL_ENV=/eland/venv
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
+# Use the same `USER` instruction as Elasticsearch to make sure Eland can read
+# a volume with Elasticsearch data in it. This is useful for --ca-cert.
+USER 1000:0
+
 COPY --from=builder /eland /eland
 
 # The eland_import_hub_model script is intended to be executed by a shell,


### PR DESCRIPTION
The config/certs directory of Elasticsearch is not readable by other users and groups. This work in the public image, which uses the root user, but the Wolfi image does not. Using the same user id fixes the problem.

Thanks @legacyworld for the report.