### PR TITLE
Revert "Allow reading Elasticsearch certs in Wolfi image"

### DIFF
--- a/Dockerfile.wolfi
+++ b/Dockerfile.wolfi
@@ -26,10 +26,6 @@ WORKDIR /eland
 ENV VIRTUAL_ENV=/eland/venv
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-# Use the same `USER` instruction as Elasticsearch to make sure Eland can read
-# a volume with Elasticsearch data in it. This is useful for --ca-cert.
-USER 1000:0
-
 COPY --from=builder /eland /eland
 
 # The eland_import_hub_model script is intended to be executed by a shell,


### PR DESCRIPTION
Reverts elastic/eland#732. Setting a different user actually breaks model upload, as Hugging Face writes to a cache folder unconditionally (even with caching disabled: https://huggingface.co/docs/datasets/v2.17.1/en/package_reference/main_classes#datasets.disable_caching). In my tests with `--ca-certs` I only checked that we could read the cert, unfortunately.