### PR TITLE
Add deprecation warning for ESGradientBoostingModel subclasses

### DIFF
--- a/eland/__init__.py
+++ b/eland/__init__.py
@@ -15,6 +15,8 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
+import warnings
+
 from ._version import (  # noqa: F401
     __author__,
     __author_email__,
@@ -25,12 +27,15 @@ from ._version import (  # noqa: F401
     __url__,
     __version__,
 )
-from .common import SortOrder
+from .common import ElandDeprecationWarning, SortOrder
 from .dataframe import DataFrame
 from .etl import csv_to_eland, eland_to_pandas, pandas_to_eland
 from .index import Index
 from .ndframe import NDFrame
 from .series import Series
+
+# Display Eland deprecation warnings by default
+warnings.simplefilter("default", category=ElandDeprecationWarning)
 
 __all__ = [
     "DataFrame",

--- a/eland/common.py
+++ b/eland/common.py
@@ -52,6 +52,10 @@ PANDAS_VERSION: Tuple[int, ...] = tuple(
 _ELAND_MAJOR_VERSION = int(_eland_version.split(".")[0])
 
 
+class ElandDeprecationWarning(DeprecationWarning):
+    """Warning for deprecation functionality in Eland"""
+
+
 with warnings.catch_warnings():
     warnings.simplefilter("ignore")
     EMPTY_SERIES_DTYPE = pd.Series().dtype

--- a/eland/ml/exporters/es_gb_models.py
+++ b/eland/ml/exporters/es_gb_models.py
@@ -15,9 +15,9 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
+import warnings
 from abc import ABC
 from typing import Any, List, Literal, Mapping, Optional, Set, Tuple, Union
-import warnings
 
 import numpy as np
 from elasticsearch import Elasticsearch
@@ -63,6 +63,10 @@ class ESGradientBoostingModel(ABC):
         model_id : str
             The unique identifier of the trained inference model in Elasticsearch.
 
+        Deprecation Warning:
+        ------
+        Exporting data frame analytics models as ESGradientBoostingModel subclasses is deprecated and will be removed in version 9.0.0.
+
         Raises
         ------
         RuntimeError
@@ -72,9 +76,10 @@ class ESGradientBoostingModel(ABC):
             from xgboost, lgbm, or sklearn are not supported.
         """
         warnings.warn(
-            "Exporting data frame analytics models as ESGradientBoostingModel subclasses is deprecated and will be removed in version 9.0.0."
+            "Exporting data frame analytics models as ESGradientBoostingModel subclasses is deprecated and will be removed in version 9.0.0.",
             PendingDeprecationWarning,
-            stacklevel=3)
+            stacklevel=3,
+        )
         self.es_client: Elasticsearch = ensure_es_client(es_client)
         self.model_id = model_id
 

--- a/eland/ml/exporters/es_gb_models.py
+++ b/eland/ml/exporters/es_gb_models.py
@@ -17,6 +17,7 @@
 
 from abc import ABC
 from typing import Any, List, Literal, Mapping, Optional, Set, Tuple, Union
+import warnings
 
 import numpy as np
 from elasticsearch import Elasticsearch
@@ -70,6 +71,10 @@ class ESGradientBoostingModel(ABC):
             The model is expected to be trained in Elastic Stack. Models initially imported
             from xgboost, lgbm, or sklearn are not supported.
         """
+        warnings.warn(
+            "Exporting data frame analytics models as ESGradientBoostingModel subclasses is deprecated and will be removed in version 9.0.0."
+            PendingDeprecationWarning,
+            stacklevel=3)
         self.es_client: Elasticsearch = ensure_es_client(es_client)
         self.model_id = model_id
 

--- a/eland/ml/exporters/es_gb_models.py
+++ b/eland/ml/exporters/es_gb_models.py
@@ -37,7 +37,7 @@ from sklearn.ensemble._gb_losses import (
 from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
 from sklearn.utils.validation import check_array
 
-from eland.common import ensure_es_client
+from eland.common import ElandDeprecationWarning, ensure_es_client
 from eland.ml.common import TYPE_CLASSIFICATION, TYPE_REGRESSION
 
 from ._sklearn_deserializers import Tree
@@ -77,8 +77,8 @@ class ESGradientBoostingModel(ABC):
         """
         warnings.warn(
             "Exporting data frame analytics models as ESGradientBoostingModel subclasses is deprecated and will be removed in version 9.0.0.",
-            PendingDeprecationWarning,
-            stacklevel=3,
+            ElandDeprecationWarning,
+            stacklevel=2,
         )
         self.es_client: Elasticsearch = ensure_es_client(es_client)
         self.model_id = model_id


### PR DESCRIPTION
Introduce a warning indicating that exporting data frame analytics models as ESGradientBoostingModel subclasses is deprecated and will be removed in version 9.0.0.

The implementation of ESGradientBoostingModel relies on importing undocumented private classes that were changed in 1.4 to https://github.com/scikit-learn/scikit-learn/pull/26278. This dependency makes the code difficult to maintain, while the functionality is not widely used by users. Therefore, we will deprecate this functionality in 8.16 and remove it completely in 9.0.0. 