### PR TITLE
Drop Python 3.8 support and introduce Python 3.12 CI/CD

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -35,10 +35,10 @@ steps:
     matrix:
       setup:
         python:
+          - '3.12'
           - '3.11'
           - '3.10'
           - '3.9'
-          - '3.8'
         stack:          
           - '8.16.0-SNAPSHOT'
           - '8.15.2'

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,3 +9,6 @@ python:
   install:
     - path: .
     - requirements: docs/requirements-docs.txt
+
+sphinx:
+  configuration: docs/sphinx/conf.py

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -203,7 +203,7 @@ currently using a minimum version of PyCharm 2019.2.4.
 * To test specific versions of Python run
 
     ``` bash
-    > nox -s test-3.8
+    > nox -s test-3.12
     ```
 
 ### Documentation

--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ $ conda install -c conda-forge eland
 
 ### Compatibility
 
-- Supports Python 3.8, 3.9, 3.10, 3.11 and Pandas 1.5
-- Supports Elasticsearch clusters that are 7.11+, recommended 8.13 or later for all features to work.
+- Supports Python 3.9, 3.10, 3.11, 3.12 and Pandas 1.5
+- Supports Elasticsearch 8+ clusters, recommended 8.16 or later for all features to work.
   If you are using the NLP with PyTorch feature make sure your Eland minor version matches the minor 
   version of your Elasticsearch cluster. For all other features it is sufficient for the major versions
   to match.

--- a/docs/guide/overview.asciidoc
+++ b/docs/guide/overview.asciidoc
@@ -8,8 +8,8 @@ Source code is available on https://github.com/elastic/eland[GitHub].
 [discrete]
 === Compatibility
 
-- Supports Python 3.8+ and Pandas 1.5
-- Supports {es} clusters that are 7.11+, recommended 7.14 or later for all features to work.
+- Supports Python 3.9+ and Pandas 1.5
+- Supports {es} 8+ clusters, recommended 8.16 or later for all features to work.
   Make sure your Eland major version matches the major version of your Elasticsearch cluster.
 
 The recommended way to set your requirements in your `setup.py` or

--- a/docs/sphinx/development/contributing.rst
+++ b/docs/sphinx/development/contributing.rst
@@ -200,7 +200,7 @@ Configuring PyCharm And Running Tests
 - To test specific versions of Python run
    .. code-block:: bash
 
-      nox -s test-3.8
+      nox -s test-3.12
 
 
 Documentation

--- a/eland/ml/pytorch/transformers.py
+++ b/eland/ml/pytorch/transformers.py
@@ -1090,9 +1090,5 @@ def elasticsearch_model_id(model_id: str) -> str:
     """
 
     id = re.sub(r"[\s\\/]", "__", model_id).lower()[-64:]
-    if id.startswith("__"):
-        # This check is only needed as long as Eland supports Python 3.8
-        # str.removeprefix was introduced in Python 3.9 and can be used
-        # once 3.8 support is dropped
-        id = id[2:]
+    id = id.removeprefix("__")
     return id

--- a/noxfile.py
+++ b/noxfile.py
@@ -61,7 +61,7 @@ def format(session):
     session.install("black", "isort", "flynt")
     session.run("python", "utils/license-headers.py", "fix", *SOURCE_FILES)
     session.run("flynt", *SOURCE_FILES)
-    session.run("black", "--target-version=py38", *SOURCE_FILES)
+    session.run("black", "--target-version=py39", *SOURCE_FILES)
     session.run("isort", "--profile=black", *SOURCE_FILES)
     lint(session)
 
@@ -73,7 +73,7 @@ def lint(session):
     session.install("black", "flake8", "mypy", "isort", "numpy")
     session.install(".")
     session.run("python", "utils/license-headers.py", "check", *SOURCE_FILES)
-    session.run("black", "--check", "--target-version=py38", *SOURCE_FILES)
+    session.run("black", "--check", "--target-version=py39", *SOURCE_FILES)
     session.run("isort", "--check", "--profile=black", *SOURCE_FILES)
     session.run("flake8", "--extend-ignore=E203,E402,E501,E704,E712", *SOURCE_FILES)
 
@@ -100,7 +100,7 @@ def lint(session):
             session.error("\n" + "\n".join(sorted(set(errors))))
 
 
-@nox.session(python=["3.8", "3.9", "3.10", "3.11"])
+@nox.session(python=["3.9", "3.10", "3.11", "3.12"])
 @nox.parametrize("pandas_version", ["1.5.0"])
 def test(session, pandas_version: str):
     session.install("-r", "requirements-dev.txt")

--- a/setup.py
+++ b/setup.py
@@ -38,10 +38,10 @@ CLASSIFIERS = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering",
 ]
 
@@ -95,7 +95,7 @@ setup(
     entry_points={
         "console_scripts": "eland_import_hub_model=eland.cli.eland_import_hub_model:main"
     },
-    python_requires=">=3.8,<3.12",
+    python_requires=">=3.9,<3.13",
     package_data={"eland": ["py.typed"]},
     include_package_data=True,
     zip_safe=False,


### PR DESCRIPTION
This PR is somewhat related to #742 . It's also part of my bigger effort of getting eland and its dependencies more up to date. Currently introducing eland as a dependency in a project means you're stuck at Pandas<2 and therefore also Python<3.13 (pandas 1.5.0 doesn't build on Python 3.13).

It updates the package so it supports newer Python versions.