### PR TITLE
Build documentation using Docker again

### DIFF
--- a/.buildkite/Dockerfile
+++ b/.buildkite/Dockerfile
@@ -1,6 +1,8 @@
 ARG PYTHON_VERSION=3.9
 FROM python:${PYTHON_VERSION}
 
+ENV FORCE_COLOR=1
+
 WORKDIR /code/eland
 RUN python -m pip install nox
 

--- a/.buildkite/build-documentation.sh
+++ b/.buildkite/build-documentation.sh
@@ -1,15 +1,8 @@
 #!/usr/bin/env bash
-sudo apt-get update
-sudo apt-get install -y pandoc python3 python3-pip
-python3 -m pip install nox
-/opt/buildkite-agent/.local/bin/nox -s docs
 
-# I couldn't make this work, for some reason pandoc is not found in the docker container repository:
-# docker build --file .buildkite/Dockerfile --tag elastic/eland --build-arg PYTHON_VERSION=${PYTHON_VERSION} .
-# docker run \
-#        --name doc_build \
-#        --rm \
-#        elastic/eland \
-#        apt-get update && \
-#        sudo apt-get install --yes pandoc && \
-#        nox -s docs
+docker build --file .buildkite/Dockerfile --tag elastic/eland --build-arg PYTHON_VERSION=${PYTHON_VERSION} .
+docker run \
+  --name doc_build \
+  --rm \
+  elastic/eland \
+  bash -c "apt-get update && apt-get install --yes pandoc && nox -s docs"

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,4 @@
 # docs and example
-docs/*
 example/*
 
 # Git
@@ -17,9 +16,6 @@ dist/
 
 # Build folder
 build/
-
-# docs
-docs/*
 
 # pytest results
 tests/dataframe/results/*csv

--- a/docs/sphinx/reference/api/eland.DataFrame.to_json.rst
+++ b/docs/sphinx/reference/api/eland.DataFrame.to_json.rst
@@ -1,5 +1,5 @@
 ﻿eland.DataFrame.to\_json
-=======================
+========================
 
 .. currentmodule:: eland
 

--- a/docs/sphinx/reference/api/eland.ml.MLModel.rst
+++ b/docs/sphinx/reference/api/eland.ml.MLModel.rst
@@ -17,6 +17,7 @@
       ~MLModel.delete_model
       ~MLModel.exists_model
       ~MLModel.export_model
+      ~MLModel.import_ltr_model
       ~MLModel.import_model
       ~MLModel.predict
    


### PR DESCRIPTION
This will respect the PYTHON_VERSION setting, allowing us to remove support for Python 3.8.

This was noticed by @bartbroere when working on #742. Thank you!