### PR TITLE
Fix tracing baai/bge-m3

### DIFF
--- a/eland/ml/pytorch/transformers.py
+++ b/eland/ml/pytorch/transformers.py
@@ -570,7 +570,7 @@ class _TraceableTextEmbeddingModel(_TransformerTraceableModel):
     def _prepare_inputs(self) -> transformers.BatchEncoding:
         return self._tokenizer(
             "This is an example sentence.",
-            padding="max_length",
+            padding="longest",
             return_tensors="pt",
         )
 
@@ -759,7 +759,7 @@ class TransformerModel:
         # a random or very large value.
         REASONABLE_MAX_LENGTH = 8192
         max_len = getattr(self._tokenizer, "model_max_length", None)
-        if max_len is not None and max_len < REASONABLE_MAX_LENGTH:
+        if max_len is not None and max_len <= REASONABLE_MAX_LENGTH:
             return int(max_len)
 
         max_sizes = getattr(self._tokenizer, "max_model_input_sizes", dict())

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ extras = {
         "sentence-transformers>=2.1.0,<=2.7.0",
         # sentencepiece is a required dependency for the slow tokenizers
         # https://huggingface.co/transformers/v4.4.2/migration.html#sentencepiece-is-removed-from-the-required-dependencies
-        "transformers[sentencepiece]>=4.31.0,<4.44.0",
+        "transformers[sentencepiece]>=4.47.0",
     ],
 }
 extras["all"] = list({dep for deps in extras.values() for dep in deps})


### PR DESCRIPTION
Fixes a kernel crash importing https://huggingface.co/BAAI/bge-m3 as described in #737

The required change is upgrading the version of transformers.

```
eland_import_hub_model \
  --url 'http://localhost:9200' \
  -u elastic-admin -p elastic-password \
  --hub-model-id 'baai/bge-m3' \
  --task-type text_embedding --insecure --max-model-input-length=8192
```