### PR TITLE
Allow nox 2025.02.09

### DIFF
--- a/.buildkite/Dockerfile
+++ b/.buildkite/Dockerfile
@@ -4,7 +4,6 @@ FROM python:${PYTHON_VERSION}
 ENV FORCE_COLOR=1
 
 WORKDIR /code/eland
-# https://github.com/wntrblm/nox/issues/930
-RUN python -m pip install nox==2024.10.09
+RUN python -m pip install nox
 
 COPY . .


### PR DESCRIPTION
See the linked nox issues for more details.

Turns out `subprocess` was not needed, and giving all files to mypy is much faster than running mypy once per file.