### PR TITLE
Revert "Release 8.18.0"

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,13 +2,6 @@
 Changelog
 =========
 
-8.18.0 (2025-04-15)
--------------------
-
-* Drop Python 3.8, Support Python 3.12 (`#743 <https://github.com/elastic/eland/pull/743>`_)
-* Support Pandas 2 (`#742 <https://github.com/elastic/eland/pull/742>`_)
-* Upgrade transformers to 4.47 (`#752 <https://github.com/elastic/eland/pull/752>`_)
-
 8.17.0 (2025-01-07)
 -------------------
 

--- a/eland/_version.py
+++ b/eland/_version.py
@@ -18,7 +18,7 @@
 __title__ = "eland"
 __description__ = "Python Client and Toolkit for DataFrames, Big Data, Machine Learning and ETL in Elasticsearch"
 __url__ = "https://github.com/elastic/eland"
-__version__ = "8.18.0"
+__version__ = "8.17.0"
 __author__ = "Steve Dodson"
 __author_email__ = "steve.dodson@elastic.co"
 __maintainer__ = "Elastic Client Library Maintainers"


### PR DESCRIPTION
Reverts elastic/eland#771. The pull request was against main, not 8.18. The main branch is for the 9.x releases.

Regarding 8.18.0 itself, I yanked the release from PyPI and deleted the tag from git a few minutes after releasing. This will avoid anyone using the `main` branch and thinking it's 8.18.0.