### PR TITLE
Run PyTorch tests on 3.12 too

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -116,9 +116,6 @@ def test(session, pandas_version: str):
         "--nbval",
     )
 
-    # PyTorch 2.3.1 doesn't support Python 3.12
-    if session.python == "3.12":
-        pytest_args += ("--ignore=eland/ml/pytorch",)
     session.run(
         *pytest_args,
         *(session.posargs or ("eland/", "tests/")),


### PR DESCRIPTION
PyTorch 2.3.1 does support Python 3.12.