### PR TITLE
Forbid Elasticsearch 8 client or server

### DIFF
--- a/eland/cli/eland_import_hub_model.py
+++ b/eland/cli/eland_import_hub_model.py
@@ -236,7 +236,7 @@ def check_cluster_version(es_client, logger):
             f"Elasticsearch version {major_version} does not support NLP models. Please upgrade Elasticsearch to the latest version"
         )
         exit(1)
-   elif major_version < 9:
+    elif major_version < 9:
         logger.error(
             "Eland 9.x does not support Elasticsearch 8.x. Please upgrade Elasticsearch first."
         )

--- a/eland/cli/eland_import_hub_model.py
+++ b/eland/cli/eland_import_hub_model.py
@@ -236,14 +236,9 @@ def check_cluster_version(es_client, logger):
             f"Elasticsearch version {major_version} does not support NLP models. Please upgrade Elasticsearch to the latest version"
         )
         exit(1)
-
-    # PyTorch was upgraded to version 2.3.1 in 8.15.2
-    # and is incompatible with earlier versions
-    if sem_ver < (8, 15, 2):
-        import torch
-
+   elif major_version < 9:
         logger.error(
-            f"Eland uses PyTorch version {torch.__version__} which is incompatible with Elasticsearch versions prior to 8.15.2. Please upgrade Elasticsearch to at least version 8.15.2"
+            "Eland 9.x does not support Elasticsearch 8.x. Please upgrade Elasticsearch first."
         )
         exit(1)
 

--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ setup(
     keywords="elastic eland pandas python",
     packages=find_packages(include=["eland", "eland.*"]),
     install_requires=[
-        "elasticsearch>=8.3,<9",
+        "elasticsearch>=9,<10",
         "pandas>=1.5,<3",
         "matplotlib>=3.6",
         "numpy>=1.2.0,<2",


### PR DESCRIPTION
Today, Eland 9.0 works fine on an Elasticsearch 8.15.2 server, but since we're no longer testing for it, should we disable it?