### PR TITLE
Add 8.19.0 Snapshot to Build and Fix test_ml_model Tests to Normalized Expected Scores if Min Score is Less Than Zero

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -48,4 +48,5 @@ steps:
           - '8.18.0'
           - '8.16.6'
           - '8.14.1'
+          - '8.19.0-SNAPSHOT'
     command: ./.buildkite/run-tests

--- a/eland/ml/_model_serializer.py
+++ b/eland/ml/_model_serializer.py
@@ -19,7 +19,7 @@ import base64
 import gzip
 import json
 from abc import ABC
-from typing import Any, Dict, List, Optional, Sequence
+from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 
 def add_if_exists(d: Dict[str, Any], k: str, v: Any) -> None:
@@ -57,6 +57,9 @@ class ModelSerializer(ABC):
         return base64.b64encode(gzip.compress(json_string.encode("utf-8"))).decode(
             "ascii"
         )
+
+    def bounds(self) -> Tuple[float, float]:
+        raise NotImplementedError
 
 
 class TreeNode:
@@ -128,6 +131,14 @@ class Tree(ModelSerializer):
         d = super().to_dict()
         add_if_exists(d, "tree_structure", [t.to_dict() for t in self._tree_structure])
         return {"tree": d}
+
+    def bounds(self) -> Tuple[float, float]:
+        leaf_values = [
+            tree_node._leaf_value[0]
+            for tree_node in self._tree_structure
+            if tree_node._leaf_value is not None
+        ]
+        return min(leaf_values), max(leaf_values)
 
 
 class Ensemble(ModelSerializer):

--- a/eland/ml/_model_serializer.py
+++ b/eland/ml/_model_serializer.py
@@ -169,3 +169,9 @@ class Ensemble(ModelSerializer):
         add_if_exists(d, "classification_weights", self._classification_weights)
         add_if_exists(d, "aggregate_output", self._output_aggregator)
         return {"ensemble": d}
+
+    def bounds(self) -> Tuple[float, float]:
+        min_bound, max_bound = tuple(
+            map(sum, zip(*[model.bounds() for model in self._trained_models]))
+        )
+        return min_bound, max_bound


### PR DESCRIPTION
Backport to `8.x` from #777 

Adds the 8.19.0-SNAPSHOT to the build.

Fixes a bug in the tests:

The LTR rescoring in Elasticsearch 8.19+ has the ability to normalize the scores for LTR if any score is negative (as Lucene cannot handle negative scores). This updates the model tests to ensure scores are normalized as well.

The normalization process essentially adds the negative score to all scores, sliding the scoring window upwards, so that all scores are >= 0.0