### PR TITLE
Upgrade PyTorch to 2.5.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     if [ "$TARGETPLATFORM" = "linux/amd64" ]; then \
       python3 -m pip install \
         --no-cache-dir --disable-pip-version-check --extra-index-url https://download.pytorch.org/whl/cpu  \
-        torch==2.3.1+cpu .[all]; \
+        torch==2.5.1+cpu .[all]; \
     else \
       python3 -m pip install \
         --no-cache-dir --disable-pip-version-check \

--- a/Dockerfile.wolfi
+++ b/Dockerfile.wolfi
@@ -13,7 +13,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     if [ "$TARGETPLATFORM" = "linux/amd64" ]; then \
       python3 -m pip install \
         --no-cache-dir --disable-pip-version-check --extra-index-url https://download.pytorch.org/whl/cpu  \
-        torch==2.3.1+cpu .[all]; \
+        torch==2.5.1+cpu .[all]; \
     else \
       python3 -m pip install \
         --no-cache-dir --disable-pip-version-check \

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ extras = {
     "lightgbm": ["lightgbm>=2,<4"],
     "pytorch": [
         "requests<3",
-        "torch==2.3.1",
+        "torch==2.5.1",
         "tqdm",
         "sentence-transformers>=2.1.0,<=2.7.0",
         # sentencepiece is a required dependency for the slow tokenizers


### PR DESCRIPTION
PyTorch was upgraded to 2.5.1 in ml-cpp on the 8.18 and 9.0 branches in https://github.com/elastic/ml-cpp/pull/2800

The backport of this will require this version check to be updated https://github.com/elastic/eland/blob/main/eland/cli/eland_import_hub_model.py#L242