### PR TITLE
Release 8.18.2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog
 =========
 
+8.18.2 (2025-04-30)
+-------------------
+
+* Fix DeBERTa tokenization (`#778 <https://github.com/elastic/eland/pull/778>`_)
+* Upgrade PyTorch to 2.5.1 (`#791 <https://github.com/elastic/eland/pull/791>`_)
+
 8.18.1 (2025-04-16)
 -------------------
 

--- a/eland/_version.py
+++ b/eland/_version.py
@@ -18,7 +18,7 @@
 __title__ = "eland"
 __description__ = "Python Client and Toolkit for DataFrames, Big Data, Machine Learning and ETL in Elasticsearch"
 __url__ = "https://github.com/elastic/eland"
-__version__ = "8.18.1"
+__version__ = "8.18.2"
 __author__ = "Steve Dodson"
 __author_email__ = "steve.dodson@elastic.co"
 __maintainer__ = "Elastic Client Library Maintainers"


### PR DESCRIPTION
Closes https://github.com/elastic/eland/pull/789. I'm opening a new pull request because our release tooling does some preprocessing magic before opening the pull request.