### PR TITLE
Upgrade Sentence Transformers and Transformers 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ extras = {
         "sentence-transformers>=5.0.0,<6.0.0",
         # sentencepiece is a required dependency for the slow tokenizers
         # https://huggingface.co/transformers/v4.4.2/migration.html#sentencepiece-is-removed-from-the-required-dependencies
-        "transformers[sentencepiece]>=4.53.2,<5.0.0",
+        "transformers[sentencepiece]>=4.47.0,<4.50.3",
     ],
 }
 extras["all"] = list({dep for deps in extras.values() for dep in deps})

--- a/setup.py
+++ b/setup.py
@@ -62,10 +62,10 @@ extras = {
         "requests<3",
         "torch==2.5.1",
         "tqdm",
-        "sentence-transformers>=2.1.0,<=2.7.0",
+        "sentence-transformers>=5.0.0,<6.0.0",
         # sentencepiece is a required dependency for the slow tokenizers
         # https://huggingface.co/transformers/v4.4.2/migration.html#sentencepiece-is-removed-from-the-required-dependencies
-        "transformers[sentencepiece]>=4.47.0",
+        "transformers[sentencepiece]>=4.53.2,<5.0.0",
     ],
 }
 extras["all"] = list({dep for deps in extras.values() for dep in deps})

--- a/tests/ml/pytorch/test_pytorch_model_upload_pytest.py
+++ b/tests/ml/pytorch/test_pytorch_model_upload_pytest.py
@@ -65,8 +65,6 @@ TEXT_EMBEDDING_MODELS = [
 
 TEXT_SIMILARITY_MODELS = ["mixedbread-ai/mxbai-rerank-xsmall-v1"]
 
-TEXT_EXPANSION_MODELS = ["naver/splade-v3-distilbert"]
-
 
 @pytest.fixture(scope="function", autouse=True)
 def setup_and_tear_down():
@@ -157,22 +155,3 @@ class TestPytorchModel:
 
             assert result.body["inference_results"][0]["predicted_value"] < 0
             assert result.body["inference_results"][1]["predicted_value"] > 0
-
-    @pytest.mark.skipif(ES_VERSION < (9, 0, 0), reason="requires current major version")
-    @pytest.mark.parametrize("model_id", TEXT_EXPANSION_MODELS)
-    def test_text_expansion(self, model_id):
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            ptm = download_model_and_start_deployment(
-                tmp_dir, False, model_id, "text_expansion"
-            )
-            result = ptm.infer(
-                docs=[
-                    {
-                        "text_field": "The Amazon rainforest covers most of the Amazon basin in South America"
-                    },
-                    {"text_field": "Paris is the capital of France"},
-                ]
-            )
-
-            assert len(result.body["inference_results"][0]["predicted_value"]) > 0
-            assert len(result.body["inference_results"][1]["predicted_value"]) > 0

--- a/tests/ml/pytorch/test_pytorch_model_upload_pytest.py
+++ b/tests/ml/pytorch/test_pytorch_model_upload_pytest.py
@@ -65,6 +65,8 @@ TEXT_EMBEDDING_MODELS = [
 
 TEXT_SIMILARITY_MODELS = ["mixedbread-ai/mxbai-rerank-xsmall-v1"]
 
+TEXT_EXPANSION_MODELS = ["naver/splade-v3-distilbert"]
+
 
 @pytest.fixture(scope="function", autouse=True)
 def setup_and_tear_down():
@@ -155,3 +157,22 @@ class TestPytorchModel:
 
             assert result.body["inference_results"][0]["predicted_value"] < 0
             assert result.body["inference_results"][1]["predicted_value"] > 0
+
+    @pytest.mark.skipif(ES_VERSION < (9, 0, 0), reason="requires current major version")
+    @pytest.mark.parametrize("model_id", TEXT_EXPANSION_MODELS)
+    def test_text_expansion(self, model_id):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            ptm = download_model_and_start_deployment(
+                tmp_dir, False, model_id, "text_expansion"
+            )
+            result = ptm.infer(
+                docs=[
+                    {
+                        "text_field": "The Amazon rainforest covers most of the Amazon basin in South America"
+                    },
+                    {"text_field": "Paris is the capital of France"},
+                ]
+            )
+
+            assert len(result.body["inference_results"][0]["predicted_value"]) > 0
+            assert len(result.body["inference_results"][1]["predicted_value"]) > 0


### PR DESCRIPTION
Sentence Transformers v5 adds support for sparse embedding models. v5 is now necessary for importing sparse models such as https://huggingface.co/naver/splade-v3-distilbert, without the upgrade the import fails with a `ModuleNotFoundError`

```
# Get the latest eland
docker pull docker.elastic.co/eland/eland:9.0.1

docker run -it --rm --network host docker.elastic.co/eland/eland:9.0.1 \
    eland_import_hub_model \
      --url 'http://host.docker.internal:9200/' \
      -u elastic-admin -p elastic-password \
      --hub-model-id 'naver/splade-v3-distilbert' \
      --task-type text_expansion --insecure

ModuleNotFoundError: No module named 'sentence_transformers.sparse_encoder'
```

A test has been added to cover this failure. 

The previous requirements for Sentence Transformers was `>=2.1.0,<=2.7.0` making the change to v5 a big leap but versions 3, 4, 5 have all been released in the last 12 months. 

The version of Transformers is also updated to the latest release. 

