### PR TITLE
Add expansion_type parameter to API call from eland_import_hub_model

### DIFF
--- a/eland/ml/pytorch/nlp_ml_model.py
+++ b/eland/ml/pytorch/nlp_ml_model.py
@@ -315,10 +315,12 @@ class TextExpansionInferenceOptions(InferenceConfig):
         *,
         tokenization: NlpTokenizationConfig,
         results_field: t.Optional[str] = None,
+        expansion_type: t.Optional[str] = "elser",
     ):
         super().__init__(configuration_type="text_expansion")
         self.tokenization = tokenization
         self.results_field = results_field
+        self.expansion_type = expansion_type
 
 
 class TrainedModelInput:

--- a/eland/ml/pytorch/transformers.py
+++ b/eland/ml/pytorch/transformers.py
@@ -552,6 +552,22 @@ class TransformerModel:
                     tokenization=tokenization_config,
                     embedding_size=embedding_size,
                 )
+        elif self._task_type == "text_expansion":
+            sample_embedding = self._traceable_model.sample_output()
+            if type(sample_embedding) is tuple:
+                text_embedding = sample_embedding[0]
+            else:
+                text_embedding = sample_embedding
+            shape = text_embedding.shape
+            token_window = shape[1]
+            if token_window > 1:
+                expansion_type = "splade"
+            else:
+                expansion_type = "elser" 
+            inference_config = TASK_TYPE_TO_INFERENCE_CONFIG[self._task_type](
+                tokenization=tokenization_config,
+                expansion_type=expansion_type,
+            )
         else:
             inference_config = TASK_TYPE_TO_INFERENCE_CONFIG[self._task_type](
                 tokenization=tokenization_config


### PR DESCRIPTION
## Overview

This PR is related to the Elasticsearch change: https://github.com/elastic/elasticsearch/pull/131679

In the above PR, Elasticsearch supports sparse embeddings including non-ELSER models. A significant example of a sparse vector model is the SPLADE model, which is a reference model for ELSER.
To inform Elasticsearch that the target model is for a SPLADE type one, this PR introduces a new `expansion_type` parameter when it calls the create trained model API.

## How Eland detects the SPLADE model

Eland identifies the model as a SPLADE model by checking the dimention of the output tensor. If the second dimension of the output tensor is over 1, it is considered a SPLADE model. This is because SPLADE models typically output embeddings per token, which is different from ELSER.