### PR TITLE
[DOCS] Adds warning to model import docs about using models only from trusted sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ libraries to be serialized and used as an inference model in Elasticsearch.
 ### NLP with PyTorch
 
 > [!WARNING]  
-> Untrusted models can execute arbitrary code on your {{es}} server, exposing your cluster to remote code execution (RCE) vulnerabilities.
+> PyTorch models can execute code on your Elasticsearch server, exposing your cluster to potential security vulnerabilities.
 > **Only use models from trusted sources and never use models from unverified or unknown providers.**
 
 For NLP tasks, Eland allows importing PyTorch trained BERT models into Elasticsearch. Models can be either plain PyTorch

--- a/docs/reference/machine-learning.md
+++ b/docs/reference/machine-learning.md
@@ -67,7 +67,7 @@ eland_import_hub_model --help
 ### Import model with Docker [ml-nlp-pytorch-docker]
 
 ::::{warning}
-Untrusted models can execute arbitrary code on your {{es}} server, exposing your cluster to remote code execution (RCE) vulnerabilities.
+PyTorch models can execute code on your {{es}} server, exposing your cluster to potential security vulnerabilities.
 
 **Only use models from trusted sources and never use models from unverified or unknown providers.**
 ::::


### PR DESCRIPTION
## Overview

Related to https://github.com/elastic/developer-docs-team/issues/338

This PR adds a warning to pages that describe importing models, reminding users only to use models from trusted sources.