### PR TITLE
fix: add explicit permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -5,6 +5,10 @@ on:
       - closed
       - labeled
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   backport:
     name: Backport


### PR DESCRIPTION
InfoSec is changing GITHUB_TOKEN default permissions from read/write to read-only on July 15th. Adding explicit `permissions` blocks to all workflows that require write access.

## Changes
- `.github/workflows/backport.yml`: Added `permissions: contents: write, pull-requests: write`