### PR TITLE
Collapse double negation in NotFilter

### DIFF
--- a/eland/filter.py
+++ b/eland/filter.py
@@ -90,7 +90,15 @@ class OrFilter(BooleanFilter):
 class NotFilter(BooleanFilter):
     def __init__(self, x: BooleanFilter) -> None:
         super().__init__()
+        self._x = x
         self._filter = {"bool": {"must_not": x.build()}}
+
+    def __invert__(self) -> "BooleanFilter":
+        # Double negation cancels out: ``~~filter`` is equivalent to ``filter``,
+        # so return the wrapped filter instead of nesting another ``must_not``.
+        # This only applies to ``NotFilter`` itself; leaf filters that merely
+        # use ``must_not`` internally (e.g. ``IsNull``) are unaffected.
+        return self._x
 
 
 # LeafBooleanFilter

--- a/tests/operators/test_operators_pytest.py
+++ b/tests/operators/test_operators_pytest.py
@@ -129,10 +129,21 @@ class TestOperators:
         assert exp.build() == {"bool": {"must_not": {"range": {"a": {"gte": 2}}}}}
 
     def test_not_not_filter(self):
+        # Double negation cancels out: ~~filter is equivalent to filter.
         exp = ~~GreaterEqual("a", 2)
+        assert exp.build() == {"range": {"a": {"gte": 2}}}
 
+    def test_not_not_not_filter(self):
+        # An odd number of negations collapses to a single negation.
+        exp = ~~~GreaterEqual("a", 2)
+        assert exp.build() == {"bool": {"must_not": {"range": {"a": {"gte": 2}}}}}
+
+    def test_not_isnull_not_collapsed(self):
+        # IsNull uses must_not internally but is not a NotFilter, so inverting
+        # it must not be treated as a double negation.
+        exp = ~IsNull("a")
         assert exp.build() == {
-            "bool": {"must_not": {"bool": {"must_not": {"range": {"a": {"gte": 2}}}}}}
+            "bool": {"must_not": {"bool": {"must_not": {"exists": {"field": "a"}}}}}
         }
 
     def test_not_and_filter(self):


### PR DESCRIPTION
Closes #214

## What

`NotFilter` now collapses double negation: `~~filter` builds the same query as `filter`, instead of producing a nested `must_not` inside another `must_not`.

Before:

```python
(~~GreaterEqual("a", 2)).build()
# {"bool": {"must_not": {"bool": {"must_not": {"range": {"a": {"gte": 2}}}}}}}
```

After:

```python
(~~GreaterEqual("a", 2)).build()
# {"range": {"a": {"gte": 2}}}
```

## How

`NotFilter` keeps a reference to the filter it wraps and overrides `__invert__` to return that wrapped filter, so inverting a `NotFilter` unwraps the negation rather than nesting another `must_not`.

As called out in the issue, the decomposition only applies when the thing being inverted is itself a `NotFilter`. Leaf filters that use `must_not` internally but are not `NotFilter` instances (for example `IsNull`) are left untouched, so `~IsNull("a")` still produces the expected nested form.

An odd number of negations still collapses correctly to a single negation (`~~~x` == `~x`).

## Tests

Updated `test_not_not_filter` to expect the collapsed result, and added:
- `test_not_not_not_filter` — triple negation collapses to a single `must_not`
- `test_not_isnull_not_collapsed` — `IsNull` (which is not a `NotFilter`) is not collapsed

Happy to add a `CHANGELOG.rst` entry once this has a PR number if that's preferred.
