### PR TITLE
Fix pandas_to_eland append to an aliased index

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+* Fix ``pandas_to_eland`` failing to append to an aliased index (`#829 <https://github.com/elastic/eland/pull/829>`_)
+
 9.2.0 (2025-10-30)
 ------------------
 

--- a/eland/etl.py
+++ b/eland/etl.py
@@ -179,14 +179,18 @@ def pandas_to_eland(
             es_client.indices.create(index=es_dest_index, mappings=mapping["mappings"])
 
         elif es_if_exists == "append" and es_verify_mapping_compatibility:
-            dest_mapping = es_client.indices.get_mapping(index=es_dest_index)[
-                es_dest_index
-            ]
-            verify_mapping_compatibility(
-                ed_mapping=mapping,
-                es_mapping=dest_mapping,
-                es_type_overrides=es_type_overrides,
-            )
+            # get_mapping keys its response by concrete index name, which differs
+            # from es_dest_index when it is an alias. Verify against every index
+            # the name resolves to rather than assuming the response is keyed by
+            # es_dest_index (which raised KeyError for an alias, see #747).
+            for dest_mapping in es_client.indices.get_mapping(
+                index=es_dest_index
+            ).values():
+                verify_mapping_compatibility(
+                    ed_mapping=mapping,
+                    es_mapping=dest_mapping,
+                    es_type_overrides=es_type_overrides,
+                )
     else:
         es_client.indices.create(index=es_dest_index, mappings=mapping["mappings"])
 

--- a/tests/etl/test_pandas_to_eland.py
+++ b/tests/etl/test_pandas_to_eland.py
@@ -138,6 +138,34 @@ class TestPandasToEland:
         pd_df3 = pd_df._append(pd_df2)
         assert_pandas_eland_frame_equal(pd_df3, df2)
 
+    def test_es_if_exists_append_to_alias(self):
+        # Regression for #747: appending through an alias used to fail with
+        # KeyError, because get_mapping keys its response by the concrete index
+        # name rather than by the alias passed as es_dest_index.
+        pandas_to_eland(
+            pd_df,
+            es_client=ES_TEST_CLIENT,
+            es_dest_index="test-index",
+            es_refresh=True,
+        )
+        ES_TEST_CLIENT.indices.put_alias(index="test-index", name="test-alias")
+
+        try:
+            df = pandas_to_eland(
+                pd_df,
+                es_client=ES_TEST_CLIENT,
+                es_dest_index="test-alias",
+                es_if_exists="append",
+                es_refresh=True,
+            )
+
+            # Both writes landed in the aliased index.
+            assert df.shape == (6, 4)
+        finally:
+            ES_TEST_CLIENT.indices.delete_alias(
+                index="test-index", name="test-alias", ignore=404
+            )
+
     def test_es_if_exists_append_mapping_mismatch_schema_enforcement(self):
         df1 = pandas_to_eland(
             pd_df,


### PR DESCRIPTION
## What

`pandas_to_eland(..., es_if_exists="append")` raised `KeyError` when `es_dest_index` is an **alias** rather than a concrete index name.

The append path verifies mapping compatibility via:

```python
dest_mapping = es_client.indices.get_mapping(index=es_dest_index)[es_dest_index]
```

`indices.get_mapping` keys its response by the **concrete index name**, which differs from the alias passed in. So for an alias (e.g. an ILM rollover write alias) the subscript `[es_dest_index]` misses and raises `KeyError: '<alias>'`, exactly as reported in #747.

## Fix

Iterate the returned mappings instead of assuming the response is keyed by `es_dest_index`:

```python
for dest_mapping in es_client.indices.get_mapping(index=es_dest_index).values():
    verify_mapping_compatibility(...)
```

This keeps the existing behavior for a concrete index (a single entry whose key equals the index), fixes the alias case, and also handles an alias that resolves to more than one index (each resolved index is verified).

## Tests

Added `test_es_if_exists_append_to_alias` in `tests/etl/test_pandas_to_eland.py`: it creates an index, points an alias at it, and appends through the alias. The test fails on `main` with `KeyError` and passes with this change.

Closes #747
