### PR TITLE
Fix classification predictions with non-numeric class labels

### DIFF
--- a/eland/ml/ml_model.py
+++ b/eland/ml/ml_model.py
@@ -30,7 +30,7 @@ from .transformers import get_model_transformer
 
 if TYPE_CHECKING:
     from elasticsearch import Elasticsearch
-    from numpy.typing import ArrayLike, DTypeLike
+    from numpy.typing import ArrayLike
 
     # Try importing each ML lib separately so mypy users don't have to
     # have both installed to use type-checking.
@@ -105,7 +105,8 @@ class MLModel:
 
         Returns
         -------
-        y: np.ndarray of dtype float for regressors or int for classifiers
+        y: np.ndarray of dtype float32 for regressors, or int for classifiers with
+           numeric class labels, or str for classifiers with string class labels
 
         Examples
         --------
@@ -204,12 +205,20 @@ class MLModel:
 
             y.append(res["doc"]["_source"]["ml"]["inference"][self.results_field])
 
-        # Return results as np.ndarray of float32 or int (consistent with sklearn/xgboost)
+        # Return results as np.ndarray of float32 or int (consistent with sklearn/xgboost).
+        # Elasticsearch's inference results are always JSON values, and a classifier trained
+        # on numeric class labels can come back as either numbers or numeric-looking strings
+        # depending on how the model was serialized, so `np.int_` is still the right dtype to
+        # try first. But a classifier trained on non-numeric class labels (e.g. the standard
+        # iris dataset's species names) returns predictions that can't be cast to `np.int_` at
+        # all; in that case, fall back to letting numpy infer the dtype from the values
+        # themselves instead of raising.
         if self.model_type == TYPE_CLASSIFICATION:
-            dt: "DTypeLike" = np.int_
-        else:
-            dt = np.float32
-        return np.asarray(y, dtype=dt)
+            try:
+                return np.asarray(y, dtype=np.int_)
+            except ValueError:
+                return np.asarray(y)
+        return np.asarray(y, dtype=np.float32)
 
     @property
     def model_type(self) -> str:

--- a/tests/ml/test_ml_model_pytest.py
+++ b/tests/ml/test_ml_model_pytest.py
@@ -192,6 +192,38 @@ class TestMLModel:
         es_model.delete_model()
 
     @requires_sklearn
+    def test_decision_tree_classifier_string_class_labels(self):
+        # A classifier trained on non-numeric class labels (e.g. the standard iris
+        # dataset's species names) used to raise a `ValueError` from `predict()`, since
+        # results were always forced into an `np.int_` array. See #434.
+        iris = datasets.load_iris()
+        string_labels = np.asarray(iris.target_names)[iris.target]
+
+        classifier = DecisionTreeClassifier()
+        classifier.fit(iris.data, string_labels)
+
+        feature_names = ["f0", "f1", "f2", "f3"]
+        model_id = "test_decision_tree_classifier_string_class_labels"
+
+        es_model = MLModel.import_model(
+            ES_TEST_CLIENT,
+            model_id,
+            classifier,
+            feature_names,
+            es_if_exists="replace",
+        )
+
+        test_data = random_rows(iris.data, 20)
+        es_results = es_model.predict(test_data)
+        py_results = classifier.predict(test_data)
+
+        assert es_results.dtype.kind in ("U", "S")
+        np.testing.assert_array_equal(es_results, py_results)
+
+        # Clean up
+        es_model.delete_model()
+
+    @requires_sklearn
     @pytest.mark.parametrize("compress_model_definition", [True, False])
     def test_decision_tree_regressor(self, compress_model_definition):
         # Train model


### PR DESCRIPTION
Closes #434.

`predict()` always casts classification results to `np.int_`, which blows up for any classifier trained on non-numeric class labels. The iris dataset's species names are the obvious example:

```
ValueError: invalid literal for int() with base 10: 'setosa'
```

Fix tries the `np.int_` cast first, then falls back to letting numpy infer the dtype if that cast raises. Kept the try-first order on purpose: turns out Elasticsearch can return numeric class labels as numeric-looking strings (depending on how the model got serialized), so a plain "is this a string" check would have broken the existing int-labeled classifier tests. Found that out the hard way while testing this against a real cluster.

Verified against a real Elasticsearch 9.2.0 instance, not mocked:
- Trained a `RandomForestClassifier` on iris with the actual string species names, imported it, watched `predict()` throw the ValueError above pre-fix, then confirmed it returns string predictions matching sklearn's own output post-fix.
- Ran the existing `test_decision_tree_classifier` cases (all 4 parametrizations) to make sure numeric-labeled classifiers still come back as `np.int_`. No regression there.
- Added `test_decision_tree_classifier_string_class_labels` next to them, same pattern, covering the case from the issue.

Also fixed the `predict()` docstring, it still claimed results are always float or int.
